### PR TITLE
Update vulcan to 0.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val fs2Version = "2.0.1"
 
 val kafkaVersion = "2.3.0"
 
-val vulcanVersion = "0.3.0"
+val vulcanVersion = "0.3.1"
 
 val scala212 = "2.12.10"
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val fs2Version = "2.0.1"
 
 val kafkaVersion = "2.3.0"
 
-val vulcanVersion = "0.2.2"
+val vulcanVersion = "0.3.0"
 
 val scala212 = "2.12.10"
 

--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -2,7 +2,4 @@ latestVersion in ThisBuild := "0.20.1"
 
 unreleasedModuleNames in ThisBuild := Set()
 
-binaryCompatibleVersions in ThisBuild := Set(
-  "0.20.0",
-  "0.20.1"
-)
+binaryCompatibleVersions in ThisBuild := Set()

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.20.2-SNAPSHOT"
+version in ThisBuild := "0.21.0-SNAPSHOT"


### PR DESCRIPTION
Vulcan 0.3.x is not binary-compatible with 0.2.x, so this will have to wait for fs2-kafka 0.21.0. However, the parts of Vulcan which fs2-kafka makes use of remain binary-compatible, and as such, you can safely upgrade to Vulcan 0.3.x in your own projects.