### PR TITLE
Proposal to alias `Serializer.Record`/`Deserializer.Record` as `RecordSerializer`/`RecordDeserializer`

### DIFF
--- a/docs/src/main/mdoc/modules.md
+++ b/docs/src/main/mdoc/modules.md
@@ -48,10 +48,10 @@ We can then create a `Serializer` and `Deserializer` instance for `Person`.
 import fs2.kafka.{Deserializer, Serializer}
 import fs2.kafka.vulcan.{avroDeserializer, avroSerializer}
 
-implicit val personSerializer: Serializer.Record[IO, Person] =
+implicit val personSerializer: RecordSerializer[IO, Person] =
   avroSerializer[Person].using(avroSettings)
 
-implicit val personDeserializer: Deserializer.Record[IO, Person] =
+implicit val personDeserializer: RecordDeserializer[IO, Person] =
   avroDeserializer[Person].using(avroSettings)
 ```
 
@@ -107,10 +107,10 @@ We can then create multiple `Serializer`s and `Deserializer`s using the `AvroSet
 
 ```scala mdoc:silent
 avroSettingsSharedClient.map { avroSettings =>
-  val personSerializer: Serializer.Record[IO, Person] =
+  val personSerializer: RecordSerializer[IO, Person] =
     avroSerializer[Person].using(avroSettings)
 
-  val personDeserializer: Deserializer.Record[IO, Person] =
+  val personDeserializer: RecordDeserializer[IO, Person] =
     avroDeserializer[Person].using(avroSettings)
 
   val consumerSettings =

--- a/docs/src/main/mdoc/modules.md
+++ b/docs/src/main/mdoc/modules.md
@@ -45,7 +45,7 @@ val avroSettings =
 We can then create a `Serializer` and `Deserializer` instance for `Person`.
 
 ```scala mdoc:silent
-import fs2.kafka.{Deserializer, Serializer}
+import fs2.kafka.{Deserializer, RecordDeserializer, RecordSerializer, Serializer}
 import fs2.kafka.vulcan.{avroDeserializer, avroSerializer}
 
 implicit val personSerializer: RecordSerializer[IO, Person] =

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -589,7 +589,7 @@ object ConsumerSettings {
     )
 
   def apply[F[_], K, V](
-    keyDeserializer: Deserializer.Record[F, K],
+    keyDeserializer: RecordDeserializer[F, K],
     valueDeserializer: Deserializer[F, V]
   )(implicit F: Sync[F]): ConsumerSettings[F, K, V] =
     create(
@@ -599,7 +599,7 @@ object ConsumerSettings {
 
   def apply[F[_], K, V](
     keyDeserializer: Deserializer[F, K],
-    valueDeserializer: Deserializer.Record[F, V]
+    valueDeserializer: RecordDeserializer[F, V]
   )(implicit F: Sync[F]): ConsumerSettings[F, K, V] =
     create(
       keyDeserializer = F.pure(keyDeserializer),
@@ -607,8 +607,8 @@ object ConsumerSettings {
     )
 
   def apply[F[_], K, V](
-    keyDeserializer: Deserializer.Record[F, K],
-    valueDeserializer: Deserializer.Record[F, V]
+    keyDeserializer: RecordDeserializer[F, K],
+    valueDeserializer: RecordDeserializer[F, V]
   )(implicit F: Sync[F]): ConsumerSettings[F, K, V] =
     create(
       keyDeserializer = keyDeserializer.forKey,
@@ -617,8 +617,8 @@ object ConsumerSettings {
 
   def apply[F[_], K, V](
     implicit F: Sync[F],
-    keyDeserializer: Deserializer.Record[F, K],
-    valueDeserializer: Deserializer.Record[F, V]
+    keyDeserializer: RecordDeserializer[F, K],
+    valueDeserializer: RecordDeserializer[F, V]
   ): ConsumerSettings[F, K, V] =
     create(
       keyDeserializer = keyDeserializer.forKey,

--- a/modules/core/src/main/scala/fs2/kafka/Deserializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Deserializer.scala
@@ -343,14 +343,14 @@ object Deserializer {
 
   object Record {
     def apply[F[_], A](
-      implicit deserializer: Deserializer.Record[F, A]
-    ): Deserializer.Record[F, A] =
+      implicit deserializer: RecordDeserializer[F, A]
+    ): RecordDeserializer[F, A] =
       deserializer
 
     def const[F[_], A](
       deserializer: => F[Deserializer[F, A]]
-    ): Deserializer.Record[F, A] =
-      Deserializer.Record.instance(
+    ): RecordDeserializer[F, A] =
+      RecordDeserializer.instance(
         forKey = deserializer,
         forValue = deserializer
       )
@@ -358,11 +358,11 @@ object Deserializer {
     def instance[F[_], A](
       forKey: => F[Deserializer[F, A]],
       forValue: => F[Deserializer[F, A]]
-    ): Deserializer.Record[F, A] = {
+    ): RecordDeserializer[F, A] = {
       def _forKey = forKey
       def _forValue = forValue
 
-      new Deserializer.Record[F, A] {
+      new RecordDeserializer[F, A] {
         override def forKey: F[Deserializer[F, A]] =
           _forKey
 
@@ -376,13 +376,13 @@ object Deserializer {
 
     def lift[F[_], A](deserializer: => Deserializer[F, A])(
       implicit F: Applicative[F]
-    ): Deserializer.Record[F, A] =
-      Deserializer.Record.const(F.pure(deserializer))
+    ): RecordDeserializer[F, A] =
+      RecordDeserializer.const(F.pure(deserializer))
 
     implicit def lift[F[_], A](
       implicit F: Applicative[F],
       deserializer: Deserializer[F, A]
-    ): Deserializer.Record[F, A] =
-      Deserializer.Record.lift(deserializer)
+    ): RecordDeserializer[F, A] =
+      RecordDeserializer.lift(deserializer)
   }
 }

--- a/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -364,7 +364,7 @@ object ProducerSettings {
     )
 
   def apply[F[_], K, V](
-    keySerializer: Serializer.Record[F, K],
+    keySerializer: RecordSerializer[F, K],
     valueSerializer: Serializer[F, V]
   )(implicit F: Sync[F]): ProducerSettings[F, K, V] =
     create(
@@ -374,7 +374,7 @@ object ProducerSettings {
 
   def apply[F[_], K, V](
     keySerializer: Serializer[F, K],
-    valueSerializer: Serializer.Record[F, V]
+    valueSerializer: RecordSerializer[F, V]
   )(implicit F: Sync[F]): ProducerSettings[F, K, V] =
     create(
       keySerializer = F.pure(keySerializer),
@@ -382,8 +382,8 @@ object ProducerSettings {
     )
 
   def apply[F[_], K, V](
-    keySerializer: Serializer.Record[F, K],
-    valueSerializer: Serializer.Record[F, V]
+    keySerializer: RecordSerializer[F, K],
+    valueSerializer: RecordSerializer[F, V]
   )(implicit F: Sync[F]): ProducerSettings[F, K, V] =
     create(
       keySerializer = keySerializer.forKey,
@@ -392,8 +392,8 @@ object ProducerSettings {
 
   def apply[F[_], K, V](
     implicit F: Sync[F],
-    keySerializer: Serializer.Record[F, K],
-    valueSerializer: Serializer.Record[F, V]
+    keySerializer: RecordSerializer[F, K],
+    valueSerializer: RecordSerializer[F, V]
   ): ProducerSettings[F, K, V] =
     create(
       keySerializer = keySerializer.forKey,

--- a/modules/core/src/main/scala/fs2/kafka/Serializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Serializer.scala
@@ -281,14 +281,14 @@ object Serializer {
 
   object Record {
     def apply[F[_], A](
-      implicit serializer: Serializer.Record[F, A]
-    ): Serializer.Record[F, A] =
+      implicit serializer: RecordSerializer[F, A]
+    ): RecordSerializer[F, A] =
       serializer
 
     def const[F[_], A](
       serializer: => F[Serializer[F, A]]
-    ): Serializer.Record[F, A] =
-      Serializer.Record.instance(
+    ): RecordSerializer[F, A] =
+      RecordSerializer.instance(
         forKey = serializer,
         forValue = serializer
       )
@@ -296,11 +296,11 @@ object Serializer {
     def instance[F[_], A](
       forKey: => F[Serializer[F, A]],
       forValue: => F[Serializer[F, A]]
-    ): Serializer.Record[F, A] = {
+    ): RecordSerializer[F, A] = {
       def _forKey = forKey
       def _forValue = forValue
 
-      new Serializer.Record[F, A] {
+      new RecordSerializer[F, A] {
         override def forKey: F[Serializer[F, A]] =
           _forKey
 
@@ -314,13 +314,13 @@ object Serializer {
 
     def lift[F[_], A](serializer: => Serializer[F, A])(
       implicit F: Applicative[F]
-    ): Serializer.Record[F, A] =
-      Serializer.Record.const(F.pure(serializer))
+    ): RecordSerializer[F, A] =
+      RecordSerializer.const(F.pure(serializer))
 
     implicit def lift[F[_], A](
       implicit F: Applicative[F],
       serializer: Serializer[F, A]
-    ): Serializer.Record[F, A] =
-      Serializer.Record.lift(serializer)
+    ): RecordSerializer[F, A] =
+      RecordSerializer.lift(serializer)
   }
 }

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -58,6 +58,14 @@ package object kafka {
   type KafkaByteProducerRecord =
     org.apache.kafka.clients.producer.ProducerRecord[Array[Byte], Array[Byte]]
 
+  /** Type and value aliases for `fs2.vulcan.Deserializer.Record`. */
+  type RecordDeserializer[F[_], A] = Deserializer.Record[F, A]
+  val RecordDeserializer: Deserializer.Record.type = Deserializer.Record
+
+  /** Type and value aliases for `fs2.vulcan.Serializer.record`. */
+  type RecordSerializer[F[_], A] = Serializer.Record[F, A]
+  val RecordSerializer: Serializer.Record.type = Serializer.Record
+
   /**
     * Commits offsets in batches of every `n` offsets or time window
     * of length `d`, whichever happens first. If there are no offsets

--- a/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -275,7 +275,7 @@ final class ConsumerSettingsSpec extends BaseSpec {
 
     it("should be able to create with and without deserializer creation effects") {
       val deserializer = Deserializer[IO, String]
-      val recordDeserializer = Deserializer.Record.lift(deserializer)
+      val recordDeserializer = RecordDeserializer.lift(deserializer)
 
       ConsumerSettings(deserializer, deserializer)
       ConsumerSettings(recordDeserializer, deserializer)
@@ -288,8 +288,8 @@ final class ConsumerSettingsSpec extends BaseSpec {
         Deserializer[IO, String]
           .map(identity)
 
-      implicit val deserializer: Deserializer.Record[IO, String] =
-        Deserializer.Record.lift(deserializerInstance)
+      implicit val deserializer: RecordDeserializer[IO, String] =
+        RecordDeserializer.lift(deserializerInstance)
 
       ConsumerSettings[IO, Int, Int]
       ConsumerSettings[IO, String, Int].keyDeserializer.unsafeRunSync shouldBe deserializerInstance

--- a/modules/core/src/test/scala/fs2/kafka/DeserializerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/DeserializerSpec.scala
@@ -184,6 +184,6 @@ final class DeserializerSpec extends BaseCatsSpec with TestInstances {
   }
 
   test("Deserializer.Record#toString") {
-    assert(Deserializer.Record[IO, String].toString startsWith "Deserializer.Record$")
+    assert(RecordDeserializer[IO, String].toString startsWith "Deserializer.Record$")
   }
 }

--- a/modules/core/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
@@ -148,7 +148,7 @@ final class ProducerSettingsSpec extends BaseSpec {
 
     it("should be able to create with and without serializer creation effects") {
       val serializer = Serializer[IO, String]
-      val recordSerializer = Serializer.Record.lift(serializer)
+      val recordSerializer = RecordSerializer.lift(serializer)
 
       ProducerSettings(serializer, serializer)
       ProducerSettings(recordSerializer, serializer)
@@ -161,8 +161,8 @@ final class ProducerSettingsSpec extends BaseSpec {
         Serializer[IO, String]
           .mapBytes(identity)
 
-      implicit val serializer: Serializer.Record[IO, String] =
-        Serializer.Record.lift(serializerInstance)
+      implicit val serializer: RecordSerializer[IO, String] =
+        RecordSerializer.lift(serializerInstance)
 
       ProducerSettings[IO, Int, Int]
       ProducerSettings[IO, String, Int].keySerializer.unsafeRunSync shouldBe serializerInstance

--- a/modules/core/src/test/scala/fs2/kafka/SerializerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/SerializerSpec.scala
@@ -241,7 +241,7 @@ final class SerializerSpec extends BaseCatsSpec with TestInstances {
   }
 
   test("Serializer.Record#toString") {
-    assert(Serializer.Record[IO, Int].toString startsWith "Serializer.Record$")
+    assert(RecordSerializer[IO, Int].toString startsWith "Serializer.Record$")
   }
 
   def roundtrip[A: Arbitrary: Eq](

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroDeserializer.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroDeserializer.scala
@@ -19,14 +19,14 @@ package fs2.kafka.vulcan
 import _root_.vulcan.Codec
 import cats.effect.Sync
 import cats.implicits._
-import fs2.kafka.Deserializer
+import fs2.kafka.{Deserializer, RecordDeserializer}
 
 final class AvroDeserializer[A] private[vulcan] (
   private val codec: Codec[A]
 ) extends AnyVal {
   def using[F[_]](
     settings: AvroSettings[F]
-  )(implicit F: Sync[F]): Deserializer.Record[F, A] =
+  )(implicit F: Sync[F]): RecordDeserializer[F, A] =
     codec.schema match {
       case Right(schema) =>
         val createDeserializer: Boolean => F[Deserializer[F, A]] =
@@ -41,13 +41,13 @@ final class AvroDeserializer[A] private[vulcan] (
             }
           }
 
-        Deserializer.Record.instance(
+        RecordDeserializer.instance(
           forKey = createDeserializer(true),
           forValue = createDeserializer(false)
         )
 
       case Left(error) =>
-        Deserializer.Record.const {
+        RecordDeserializer.const {
           F.raiseError(error.throwable)
         }
     }

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSerializer.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSerializer.scala
@@ -19,14 +19,14 @@ package fs2.kafka.vulcan
 import _root_.vulcan.Codec
 import cats.effect.Sync
 import cats.implicits._
-import fs2.kafka.Serializer
+import fs2.kafka.{RecordSerializer, Serializer}
 
 final class AvroSerializer[A] private[vulcan] (
   private val codec: Codec[A]
 ) extends AnyVal {
   def using[F[_]](
     settings: AvroSettings[F]
-  )(implicit F: Sync[F]): Serializer.Record[F, A] =
+  )(implicit F: Sync[F]): RecordSerializer[F, A] =
     codec.schema match {
       case Right(schema) =>
         val createSerializer: Boolean => F[Serializer[F, A]] =
@@ -41,13 +41,13 @@ final class AvroSerializer[A] private[vulcan] (
             }
           }
 
-        Serializer.Record.instance(
+        RecordSerializer.instance(
           forKey = createSerializer(true),
           forValue = createSerializer(false)
         )
 
       case Left(error) =>
-        Serializer.Record.const {
+        RecordSerializer.const {
           F.raiseError(error.throwable)
         }
     }


### PR DESCRIPTION
I've found the current naming confusing, both when learning the API and when explaining it to others: the default assumption for a newcomer is that `Deserializer.Record` is either a subtype of `Deserializer`, or a kind of record that is used in combination with one. It's also awkward to say "deserializer dot record" out loud.

I think this change improves the situation by presenting these types as first-class elements of the API.