### PR TITLE
Add `apply` methods for `AvroSerializer`/`AvroDeserializer`

### DIFF
--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroDeserializer.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroDeserializer.scala
@@ -55,3 +55,8 @@ final class AvroDeserializer[A] private[vulcan] (
   override def toString: String =
     "AvroDeserializer$" + System.identityHashCode(this)
 }
+
+object AvroDeserializer {
+  def apply[A](implicit codec: Codec[A]): AvroDeserializer[A] =
+    new AvroDeserializer(codec)
+}

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSerializer.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSerializer.scala
@@ -55,3 +55,8 @@ final class AvroSerializer[A] private[vulcan] (
   override def toString: String =
     "AvroSerializer$" + System.identityHashCode(this)
 }
+
+object AvroSerializer {
+  def apply[A](implicit codec: Codec[A]): AvroSerializer[A] =
+    new AvroSerializer(codec)
+}

--- a/modules/vulcan/src/test/scala/fs2/kafka/vulcan/AvroDeserializerSpec.scala
+++ b/modules/vulcan/src/test/scala/fs2/kafka/vulcan/AvroDeserializerSpec.scala
@@ -9,7 +9,7 @@ final class AvroDeserializerSpec extends AnyFunSpec {
   describe("AvroDeserializer") {
     it("can create a deserializer") {
       val deserializer =
-        avroDeserializer[Int].using(avroSettings)
+        AvroDeserializer[Int].using(avroSettings)
 
       assert(deserializer.forKey.attempt.unsafeRunSync().isRight)
       assert(deserializer.forValue.attempt.unsafeRunSync().isRight)

--- a/modules/vulcan/src/test/scala/fs2/kafka/vulcan/AvroSerializerSpec.scala
+++ b/modules/vulcan/src/test/scala/fs2/kafka/vulcan/AvroSerializerSpec.scala
@@ -9,7 +9,7 @@ final class AvroSerializerSpec extends AnyFunSpec {
   describe("AvroSerializer") {
     it("can create a serializer") {
       val serializer =
-        avroSerializer[Int].using(avroSettings)
+        AvroSerializer[Int].using(avroSettings)
 
       assert(serializer.forKey.attempt.unsafeRunSync().isRight)
       assert(serializer.forValue.attempt.unsafeRunSync().isRight)


### PR DESCRIPTION
Particularly useful in IntelliJ, which will not auto-import the factory methods from the `fs2.kafka.vulcan` package object, creating temptation to import that object, which in turn breaks auto-import of anything from the root `vulcan` namespace.