### PR TITLE
Convert Headers to use Map as underlying data structure

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -21,6 +21,7 @@ import cats.effect.{CancelToken, Concurrent, Sync}
 import cats.effect.concurrent.Ref
 import cats.implicits._
 import fs2.kafka.{Header, Headers, KafkaHeaders}
+import fs2.kafka.internal.converters.collection
 import fs2.kafka.internal.converters.collection._
 import java.time.Duration
 import java.time.temporal.ChronoUnit
@@ -32,7 +33,6 @@ import org.apache.kafka.common.KafkaFuture.{BaseFunction, BiConsumer}
 
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.FiniteDuration
-import scala.jdk.javaapi.CollectionConverters
 
 private[kafka] object syntax {
   implicit final class LoggingSyntax[F[_], A](
@@ -241,8 +241,8 @@ private[kafka] object syntax {
   ) extends AnyVal {
     def asScala: Headers = {
       Headers.fromIterable(
-        CollectionConverters
-          .asScala(headers)
+        collection
+          .iterableAsScalaIterable(headers)
           .map(header => Header(header.key, header.value))
       )
     }

--- a/modules/core/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -20,8 +20,7 @@ import cats.{FlatMap, Foldable, Show}
 import cats.effect.{CancelToken, Concurrent, Sync}
 import cats.effect.concurrent.Ref
 import cats.implicits._
-import fs2.kafka.{Header, Headers, KafkaHeaders}
-import fs2.kafka.internal.converters.collection
+import fs2.kafka.{Header, Headers, KafkaHeader, KafkaHeaders}
 import fs2.kafka.internal.converters.collection._
 import java.time.Duration
 import java.time.temporal.ChronoUnit
@@ -241,8 +240,8 @@ private[kafka] object syntax {
   ) extends AnyVal {
     def asScala: Headers = {
       Headers.fromIterable(
-        collection
-          .iterableAsScalaIterable(headers)
+        (headers: java.lang.Iterable[KafkaHeader])
+          .asScala
           .map(header => Header(header.key, header.value))
       )
     }


### PR DESCRIPTION
Currently `Headers` is based of a `Chain`. This we need to traverse the whole `Chain` to find values in it (`O(n)`). At a large scale, this becomes an expensive operation, especially in our case where we need to extract two headers which may or may not be there. The operation is clearly visible in the profiler.

This PR changes `Headers` to be based of `Map` instead, making lookups `O(1)`.

If you guys think this is useless, let me know! Perhaps `Headers` used to be based on `Map` but it was inefficient or wrong in some other way?

**Not addressed in this PR**:
The underlying Kafka `Headers` class actually allows to have multiple values for the same key. The current `fs2-kafka` `Headers` class doesn't really allow it because the main function is:
```scala
final def apply(key: String): Option[Header]
```
I believe this should be changed into either:
```scala
final def apply(key: String): List[Header]
```
or
```scala
final def apply(key: String): Option[NonEmptyList[Header]]
```
However this PR does not address that.