### PR TITLE
Update Kafka to 2.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,15 @@ val catsEffectVersion = "2.0.0"
 
 val catsVersion = "2.0.0"
 
-val confluentVersion = "5.3.2"
+val confluentVersion = "5.4.0"
 
-val embeddedKafkaVersion = "2.3.1"
+val embeddedKafkaVersion = "2.4.0"
 
 val fs2Version = "2.1.0"
 
-val kafkaVersion = "2.3.1"
+val kafkaVersion = "2.4.0"
 
-val vulcanVersion = "0.2.2"
+val vulcanVersion = "0.3.1"
 
 val scala212 = "2.12.10"
 
@@ -83,14 +83,10 @@ lazy val dependencySettings = Seq(
     "org.typelevel" %% "cats-effect-laws" % catsEffectVersion,
     "ch.qos.logback" % "logback-classic" % "1.2.3"
   ).map(_ % Test),
-  libraryDependencies ++= {
-    if (!scalaVersion.value.startsWith("2.13"))
-      Seq(
-        "io.github.embeddedkafka" %% "embedded-kafka" % embeddedKafkaVersion,
-        "org.apache.kafka" %% "kafka" % kafkaVersion
-      ).map(_ % Test)
-    else Seq.empty
-  },
+  libraryDependencies ++= Seq(
+    "io.github.embeddedkafka" %% "embedded-kafka" % embeddedKafkaVersion,
+    "org.apache.kafka" %% "kafka" % kafkaVersion
+  ).map(_ % Test),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
   addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full)
 )
@@ -187,7 +183,8 @@ lazy val publishSettings =
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts := {
     if (publishArtifact.value) {
-      Set(organization.value %% moduleName.value % (previousStableVersion in ThisBuild).value.get)
+      // Set(organization.value %% moduleName.value % (previousStableVersion in ThisBuild).value.get)
+      Set()
     } else Set()
   },
   mimaBinaryIssueFilters ++= {
@@ -195,15 +192,7 @@ lazy val mimaSettings = Seq(
     // format: off
     Seq(
       ProblemFilters.exclude[Problem]("fs2.kafka.internal.*"),
-      ProblemFilters.exclude[IncompatibleSignatureProblem]("*"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.Timestamp.unknownTime"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.createAcls"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.deleteAcls"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.describeAcls"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.unsubscribe"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.assign"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.partitionsFor"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.metrics")
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("*")
     )
     // format: on
   }
@@ -246,19 +235,7 @@ lazy val scalaSettings = Seq(
 lazy val testSettings = Seq(
   logBuffered in Test := false,
   parallelExecution in Test := false,
-  testOptions in Test += Tests.Argument("-oDF"),
-  excludeFilter.in(Test, unmanagedSources) := {
-    if (scalaVersion.value.startsWith("2.13"))
-      HiddenFileFilter ||
-      "BaseKafkaSpec.scala" ||
-      "HeaderDeserializerSpec.scala" ||
-      "KafkaAdminClientSpec.scala" ||
-      "KafkaConsumerSpec.scala" ||
-      "KafkaProducerSpec.scala" ||
-      "TransactionalKafkaProducerSpec.scala"
-    else
-      (excludeFilter.in(Test, unmanagedSources)).value
-  }
+  testOptions in Test += Tests.Argument("-oDF")
 )
 
 def minorVersion(version: String): String = {

--- a/docs/src/main/mdoc/admin.md
+++ b/docs/src/main/mdoc/admin.md
@@ -66,8 +66,8 @@ def topicOperations[F[_]: Concurrent: ContextShift]: F[Unit] =
     for {
       topicNames <- client.listTopics.names
       _ <- client.describeTopics(topicNames.toList)
-      _ <- client.createTopic(new NewTopic("new-topic", 1, 1)) // numPartitions and replicationFactor
-      _ <- client.createTopics(new NewTopic("newer-topic", 1, 1) :: Nil)
+      _ <- client.createTopic(new NewTopic("new-topic", 1, 1.toShort))
+      _ <- client.createTopics(new NewTopic("newer-topic", 1, 1.toShort) :: Nil)
       _ <- client.createPartitions(Map("new-topic" -> NewPartitions.increaseTo(4)))
       _ <- client.deleteTopic("new-topic")
       _ <- client.deleteTopics("newer-topic" :: Nil)
@@ -141,7 +141,7 @@ There are ACL management functions to describe, create and delete ACL entries.
 import org.apache.kafka.common.acl._
 import org.apache.kafka.common.resource.{
   PatternType,
-  ResourcePattern, 
+  ResourcePattern,
   ResourceType
 }
 
@@ -160,10 +160,10 @@ def aclOperations[F[_]: Concurrent: ContextShift]: F[Unit] =
       acl = new AclBinding(pattern, aclEntry)
       _ <- client.createAcls(List(acl))
 
-      _ <- client.deleteAcls(List(AclBindingFilter.ANY))   
+      _ <- client.deleteAcls(List(AclBindingFilter.ANY))
     } yield ()
   }
-``` 
+```
 
 [kafkaadminclient]: @API_BASE_URL@/KafkaAdminClient.html
 [adminclientsettings]: @API_BASE_URL@/AdminClientSettings.html

--- a/modules/core/src/test/scala/fs2/kafka/BaseCatsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/BaseCatsSpec.scala
@@ -62,4 +62,7 @@ trait BaseCatsSpec extends CatsSuite with BaseGenerators {
         }
       }.isSuccess
     }
+
+  implicit val headerDeserializerUnitArbitrary: Arbitrary[HeaderDeserializer[Unit]] =
+    Arbitrary(Gen.const(HeaderDeserializer.unit))
 }

--- a/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -140,7 +140,7 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
               }
               describedTopics <- adminClient.describeTopics(topicNames.toList)
               _ <- IO(assert(describedTopics.size == 1))
-              newTopic = new NewTopic("new-test-topic", 1, 1)
+              newTopic = new NewTopic("new-test-topic", 1, 1.toShort)
               preCreateNames <- adminClient.listTopics.names
               _ <- IO(assert(!preCreateNames.contains(newTopic.name)))
               _ <- adminClient.createTopic(newTopic)


### PR DESCRIPTION
This pull request updates:
- Confluent serializer to 5.4.0,
- Kafka to 2.4.0,
- Embedded Kafka to 2.4.0,
- Vulcan to 0.3.1,

and re-enables all tests on Scala 2.13. Mima reporting is disabled in preparation of the 1.0 release.

