### PR TITLE
Change to ensure revoked partition records are removed

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
@@ -124,6 +124,15 @@ private[kafka] object LogEntry {
       s"Revoked fetches without records for partitions [${partitions.mkString(", ")}]. Current state [$state]."
   }
 
+  final case class RemovedRevokedRecords[F[_], K, V](
+    records: Records[F, K, V],
+    state: State[F, K, V]
+  ) extends LogEntry {
+    override def level: LogLevel = Debug
+    override def message: String =
+      s"Removed revoked records for partitions [${recordsString(records)}]. Current state [$state]."
+  }
+
   final case class StoredRecords[F[_], K, V](
     records: Records[F, K, V],
     state: State[F, K, V]


### PR DESCRIPTION
When rebalance revokes partitions for which there are no fetch requests, we should remove any buffered records for the partition. This should help with duplicate records being processed due to rebalances (the next consumer for the partition will refetch these records).