### PR TITLE
Update documentation: Add port to bootstrap server url.

### DIFF
--- a/docs/src/main/mdoc/consumers.md
+++ b/docs/src/main/mdoc/consumers.md
@@ -107,7 +107,7 @@ In order to create a [`KafkaConsumer`][kafkaconsumer], we first need to create [
 val consumerSettings =
   ConsumerSettings[IO, String, String]
     .withAutoOffsetReset(AutoOffsetReset.Earliest)
-    .withBootstrapServers("localhost")
+    .withBootstrapServers("localhost:9092")
     .withGroupId("group")
 ```
 
@@ -118,7 +118,7 @@ ConsumerSettings(
   keyDeserializer = Deserializer[IO, String],
   valueDeserializer = Deserializer[IO, String]
 ).withAutoOffsetReset(AutoOffsetReset.Earliest)
- .withBootstrapServers("localhost")
+ .withBootstrapServers("localhost:9092")
  .withGroupId("group")
 ```
 

--- a/docs/src/main/mdoc/modules.md
+++ b/docs/src/main/mdoc/modules.md
@@ -63,12 +63,12 @@ import fs2.kafka.{AutoOffsetReset, ConsumerSettings, ProducerSettings}
 val consumerSettings =
   ConsumerSettings[IO, String, Person]
     .withAutoOffsetReset(AutoOffsetReset.Earliest)
-    .withBootstrapServers("localhost")
+    .withBootstrapServers("localhost:9092")
     .withGroupId("group")
 
 val producerSettings =
   ProducerSettings[IO, String, Person]
-    .withBootstrapServers("localhost")
+    .withBootstrapServers("localhost:9092")
 ```
 
 If we prefer, we can instead specificy the `Serializer`s and `Deserializer`s explicitly.
@@ -80,13 +80,13 @@ ConsumerSettings(
   keyDeserializer = Deserializer[IO, String],
   valueDeserializer = personDeserializer
 ).withAutoOffsetReset(AutoOffsetReset.Earliest)
- .withBootstrapServers("localhost")
+ .withBootstrapServers("localhost:9092")
  .withGroupId("group")
 
 ProducerSettings(
   keySerializer = Serializer[IO, String],
   valueSerializer = personSerializer
-).withBootstrapServers("localhost")
+).withBootstrapServers("localhost:9092")
 ```
 
 ### Sharing Client
@@ -118,14 +118,14 @@ avroSettingsSharedClient.map { avroSettings =>
       keyDeserializer = Deserializer[IO, String],
       valueDeserializer = personDeserializer
     ).withAutoOffsetReset(AutoOffsetReset.Earliest)
-    .withBootstrapServers("localhost")
+    .withBootstrapServers("localhost:9092")
     .withGroupId("group")
 
  val producerSettings =
   ProducerSettings(
     keySerializer = Serializer[IO, String],
     valueSerializer = personSerializer
-  ).withBootstrapServers("localhost")
+  ).withBootstrapServers("localhost:9092")
 
   (consumerSettings, producerSettings)
 }

--- a/docs/src/main/mdoc/producers.md
+++ b/docs/src/main/mdoc/producers.md
@@ -106,7 +106,7 @@ In order to create a [`KafkaProducer`][kafkaproducer], we first need to create [
 ```scala mdoc:silent
 val producerSettings =
   ProducerSettings[IO, String, String]
-    .withBootstrapServers("localhost")
+    .withBootstrapServers("localhost:9092")
 ```
 
 We can also specify the serializers explicitly when necessary.
@@ -115,7 +115,7 @@ We can also specify the serializers explicitly when necessary.
 ProducerSettings(
   keySerializer = Serializer[IO, String],
   valueSerializer = Serializer[IO, String]
-).withBootstrapServers("localhost")
+).withBootstrapServers("localhost:9092")
 ```
 
 [`ProducerSettings`][producersettings] provides functions for configuring both the Java Kafka producer and options specific to the library. If functions for configuring certain properties of the Java Kafka producer is missing, we can instead use `withProperty` or `withProperties` together with constants from [`ProducerConfig`][producerconfig]. Available properties for the Java Kafka producer are described in the [documentation](http://kafka.apache.org/documentation/#producerconfigs).
@@ -163,7 +163,7 @@ If we're only producing records in one part of our stream, using `produce` is co
 val consumerSettings =
   ConsumerSettings[IO, String, String]
     .withAutoOffsetReset(AutoOffsetReset.Earliest)
-    .withBootstrapServers("localhost")
+    .withBootstrapServers("localhost:9092")
     .withGroupId("group")
 
 object ProduceExample extends IOApp {

--- a/docs/src/main/mdoc/quick-example.md
+++ b/docs/src/main/mdoc/quick-example.md
@@ -23,12 +23,12 @@ object Main extends IOApp {
     val consumerSettings =
       ConsumerSettings[IO, String, String]
         .withAutoOffsetReset(AutoOffsetReset.Earliest)
-        .withBootstrapServers("localhost")
+        .withBootstrapServers("localhost:9092")
         .withGroupId("group")
 
     val producerSettings =
       ProducerSettings[IO, String, String]
-        .withBootstrapServers("localhost")
+        .withBootstrapServers("localhost:9092")
 
     val stream =
       consumerStream[IO]

--- a/docs/src/main/mdoc/transactions.md
+++ b/docs/src/main/mdoc/transactions.md
@@ -30,14 +30,14 @@ object Main extends IOApp {
       ConsumerSettings[IO, String, String]
         .withIsolationLevel(IsolationLevel.ReadCommitted)
         .withAutoOffsetReset(AutoOffsetReset.Earliest)
-        .withBootstrapServers("localhost")
+        .withBootstrapServers("localhost:9092")
         .withGroupId("group")
 
     val producerSettings =
       TransactionalProducerSettings(
         "transactional-id",
         ProducerSettings[IO, String, String]
-          .withBootstrapServers("localhost")
+          .withBootstrapServers("localhost:9092")
       )
 
     val stream =


### PR DESCRIPTION
The `KafkaConsumer` and `KafkaProducer` classes require a url with a port.
If the port is not provided then an exception will be thrown - example stacktrace is below

```
org.apache.kafka.common.KafkaException: Failed to construct kafka consumer
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:820)
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:631)
	at fs2.kafka.ConsumerSettings$.$anonfun$create$3(ConsumerSettings.scala:567)
	at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:87)
	at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:355)
	at cats.effect.internals.IORunLoop$RestartCallback.run(IORunLoop.scala:366)
	at cats.effect.internals.Trampoline.cats$effect$internals$Trampoline$$immediateLoop(Trampoline.scala:70)
	at cats.effect.internals.Trampoline.startLoop(Trampoline.scala:36)
	at cats.effect.internals.TrampolineEC$JVMTrampoline.super$startLoop(TrampolineEC.scala:93)
	at cats.effect.internals.TrampolineEC$JVMTrampoline.$anonfun$startLoop$1(TrampolineEC.scala:93)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
	at cats.effect.internals.TrampolineEC$JVMTrampoline.startLoop(TrampolineEC.scala:93)
	at cats.effect.internals.Trampoline.execute(Trampoline.scala:43)
	at cats.effect.internals.TrampolineEC.execute(TrampolineEC.scala:44)
	at cats.effect.internals.ForwardCancelable.loop$1(ForwardCancelable.scala:46)
	at cats.effect.internals.ForwardCancelable.$anonfun$cancel$1(ForwardCancelable.scala:52)
	at cats.effect.internals.ForwardCancelable.$anonfun$cancel$1$adapted(ForwardCancelable.scala:52)
	at cats.effect.internals.IORunLoop$RestartCallback.start(IORunLoop.scala:341)
	at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:119)
	at cats.effect.internals.IORunLoop$.start(IORunLoop.scala:34)
	at cats.effect.IO.unsafeRunAsync(IO.scala:257)
	at cats.effect.internals.IORace$.onSuccess$1(IORace.scala:40)
	at cats.effect.internals.IORace$.$anonfun$simple$5(IORace.scala:87)
	at cats.effect.internals.IORace$.$anonfun$simple$5$adapted(IORace.scala:85)
	at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:136)
	at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:355)
	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:376)
	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:316)
	at cats.effect.internals.IOShift$Tick.run(IOShift.scala:36)
	at cats.effect.internals.PoolUtils$$anon$2$$anon$3.run(PoolUtils.scala:51)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.kafka.common.config.ConfigException: Invalid url in bootstrap.servers: localhost
	at org.apache.kafka.clients.ClientUtils.parseAndValidateAddresses(ClientUtils.java:58)
	at org.apache.kafka.clients.ClientUtils.parseAndValidateAddresses(ClientUtils.java:47)
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:735)
	... 33 more```