### PR TITLE
Fix build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val kafkaVersion = "2.5.0"
 
 val vulcanVersion = "1.2.0"
 
-val scala212 = "2.12.12"
+val scala212 = "2.12.10"
 
 val scala213 = "2.13.3"
 

--- a/project/PackagingTypePlugin.scala
+++ b/project/PackagingTypePlugin.scala
@@ -1,0 +1,9 @@
+import sbt._
+
+// workaround from https://github.com/sbt/sbt/issues/3618#issuecomment-424924293
+object PackagingTypePlugin extends AutoPlugin {
+  override val buildSettings = {
+    sys.props += "packaging.type" -> "jar"
+    Nil
+  }
+}


### PR DESCRIPTION
The latest update of scala 2.12.10 to 2.12.12 makes all build red because of this error:
```
[error] Test suite fs2.kafka.KafkaConsumerSpec failed with java.lang.NoClassDefFoundError: scala/math/Ordering$$anon$7.
[error] This may be due to the ClassLoaderLayeringStrategy (ScalaLibrary) used by your task.
[error] To improve performance and reduce memory, sbt attempts to cache the class loaders used to load the project dependencies.
[error] The project class files are loaded in a separate class loader that is created for each test run.
[error] The test class loader accesses the project dependency classes using the cached project dependency classloader.
[error] With this approach, class loading may fail under the following conditions:
[error] 
[error]  * Dependencies use reflection to access classes in your project's classpath.
[error]    Java serialization/deserialization may cause this.
[error]  * An open package is accessed across layers. If the project's classes access or extend
[error]    jvm package private classes defined in a project dependency, it may cause an IllegalAccessError
[error]    because the jvm enforces package private at the classloader level.
[error] 
[error] These issues, along with others that were not enumerated above, may be resolved by changing the class loader layering strategy.
[error] The Flat and ScalaLibrary strategies bundle the full project classpath in the same class loader.
[error] To use one of these strategies, set the  ClassLoaderLayeringStrategy key
[error] in your configuration, for example:
[error] 
[error] set core / Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.ScalaLibrary
[error] set core / Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
[error] 
[error] See ClassLoaderLayeringStrategy.scala for the full list of options.
```
I tried to investigate a bit and found [this](https://github.com/sbt/sbt/issues/4525) and [this](https://github.com/lucidsoftware/neo-sbt-scalafmt/issues/78). It looks like some sbt plugins manipulate scala version and cause this class loader issue. I'm not 100% sure that this is the root cause, but it looks pretty similar. 

I didn't find any valuable solution in a decent time, so I decided to just revert scala 2.12 update. Looks like this update is not necessary for the library and making all current builds green is very important for the pending pull requests.

Also, looks like [updating kafka-avro-serializer to the 6.0.0](https://github.com/fd4s/fs2-kafka/pull/402) cause [this](https://github.com/sbt/sbt/issues/3618) issue. Fortunately, there is a [workaround](https://github.com/sbt/sbt/issues/3618#issuecomment-424924293) for it. I added this workaround in a second commit.