### PR TITLE
Added KafkaAdminClient methods alterConsumerGroupOffsets and deleteConsumerGroupOffsets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val embeddedKafkaVersion = "2.6.0"
 
 val fs2Version = "2.4.4"
 
-val kafkaVersion = "2.5.0"
+val kafkaVersion = "2.6.0"
 
 val vulcanVersion = "1.2.0"
 
@@ -200,7 +200,8 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[Problem]("fs2.kafka.internal.*"),
       ProblemFilters.exclude[IncompatibleSignatureProblem]("*"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaProducer.resource"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.partitionsMapStream")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.partitionsMapStream"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.*")
     )
     // format: on
   }

--- a/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
@@ -186,6 +186,21 @@ sealed abstract class KafkaAdminClient[F[_]] {
     * }}}
     */
   def listTopics: ListTopics[F]
+
+  /**
+    * Alters offsets for the specified group. In order to succeed, the group must be empty.
+    */
+  def alterConsumerGroupOffsets(
+    groupId: String,
+    offsets: Map[TopicPartition, OffsetAndMetadata]
+  ): F[Unit]
+
+  /**
+    * Delete committed offsets for a set of partitions in a consumer group. This will
+    * succeed at the partition level only if the group is not actively subscribed
+    * to the corresponding topic.
+    */
+  def deleteConsumerGroupOffsets(groupId: String, partitions: Set[TopicPartition]): F[Unit]
 }
 
 object KafkaAdminClient {
@@ -445,6 +460,20 @@ object KafkaAdminClient {
         "ListTopics$" + System.identityHashCode(this)
     }
 
+  private[this] def alterConsumerGroupOffsetsWith[F[_]](
+    withAdminClient: WithAdminClient[F],
+    groupId: String,
+    offsets: Map[TopicPartition, OffsetAndMetadata]
+  ): F[Unit] =
+    withAdminClient(_.alterConsumerGroupOffsets(groupId, offsets.asJava).all().void)
+
+  private[this] def deleteConsumerGroupOffsetsWith[F[_]](
+    withAdminClient: WithAdminClient[F],
+    groupId: String,
+    partitions: Set[TopicPartition]
+  ): F[Unit] =
+    withAdminClient(_.deleteConsumerGroupOffsets(groupId, partitions.asJava).all().void)
+
   private[kafka] def resource[F[_]](
     settings: AdminClientSettings[F]
   )(
@@ -515,6 +544,18 @@ object KafkaAdminClient {
 
         override def describeAcls(filter: AclBindingFilter): F[List[AclBinding]] =
           describeAclsWith(client, filter)
+
+        override def alterConsumerGroupOffsets(
+          groupId: String,
+          offsets: Map[TopicPartition, OffsetAndMetadata]
+        ): F[Unit] =
+          alterConsumerGroupOffsetsWith(client, groupId, offsets)
+
+        override def deleteConsumerGroupOffsets(
+          groupId: String,
+          partitions: Set[TopicPartition]
+        ): F[Unit] =
+          deleteConsumerGroupOffsetsWith(client, groupId, partitions)
 
         override def toString: String =
           "KafkaAdminClient$" + System.identityHashCode(this)


### PR DESCRIPTION
I added new methods to the KafkaAdminClient: `alterConsumerGroupOffsets` and `deleteConsumerGroupOffsets`. Also, I updated kafka version to 2.6.0.