### PR TITLE
Added commitSync and commitAsync methods to the KafkaConsumer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,6 +208,8 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.kafka.KafkaProducer.resource"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.kafka.TransactionalKafkaProducer.resource"),
       ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.kafka.KafkaConsumer.partitionsMapStream"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.kafka.KafkaConsumer.commitAsync"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.kafka.KafkaConsumer.commitSync"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.*")
     )
     // format: on

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaCommit.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaCommit.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018-2020 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.consumer
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+
+trait KafkaCommit[F[_]] {
+
+  /**
+    * Commit the specified offsets for the specified list of topics and partitions to Kafka.<br>
+    * <br>
+    * This commits offsets to Kafka. The offsets committed using this API will be used on the first fetch after every
+    * rebalance and also on startup. As such, if you need to store offsets in anything other than Kafka, this API
+    * should not be used. The committed offset should be the next message your application will consume,
+    * i.e. lastProcessedMessageOffset + 1. If automatic group management with subscribe is used,
+    * then the committed offsets must belong to the currently auto-assigned partitions.<br>
+    * <br>
+    * Offsets committed through multiple calls to this API are guaranteed to be sent in the same order as
+    * the invocations. Additionally note that
+    * offsets committed through this API are guaranteed to complete before a subsequent call to [[commitSync]]
+    * (and variants) returns.<br>
+    * <br>
+    * Note, that the recommended way for committing offsets in fs2-kafka is to use `commit` on
+    * [[CommittableConsumerRecord]], [[CommittableOffset]] or [[CommittableOffsetBatch]].
+    * [[commitAsync]] and [[commitSync]] usually needs only for some custom scenarios.
+    *
+    * @param offsets A map of offsets by partition with associate metadata.
+    * @see org.apache.kafka.clients.consumer.KafkaConsumer#commitAsync
+    */
+  def commitAsync(offsets: Map[TopicPartition, OffsetAndMetadata]): F[Unit]
+
+  /**
+    * Commit the specified offsets for the specified list of topics and partitions.<br>
+    * <br>
+    * This commits offsets to Kafka. The offsets committed using this API will be used on the first fetch after every
+    * rebalance and also on startup. As such, if you need to store offsets in anything other than Kafka, this API
+    * should not be used. The committed offset should be the next message your application will consume,
+    * i.e. lastProcessedMessageOffset + 1. If automatic group management with subscribe is used,
+    * then the committed offsets must belong to the currently auto-assigned partitions.<br>
+    * <br>
+    * Despite of it's name, this method is not blocking. But it's based on a blocking
+    * org.apache.kafka.clients.consumer.KafkaConsumer#commitSync method.<br>
+    * <br>
+    * Note, that the recommended way for committing offsets in fs2-kafka is to use `commit` on
+    * [[CommittableConsumerRecord]], [[CommittableOffset]] or [[CommittableOffsetBatch]].
+    * [[commitAsync]] and [[commitSync]] usually needs only for some custom scenarios.
+    *
+    * @param offsets A map of offsets by partition with associated metadata
+    * @see org.apache.kafka.clients.consumer.KafkaConsumer#commitSync
+    */
+  def commitSync(offsets: Map[TopicPartition, OffsetAndMetadata]): F[Unit]
+}

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -11,6 +11,7 @@ import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.consumer.NoOffsetForPartitionException
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.TopicPartition
+import org.scalatest.Assertion
 
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration._
@@ -179,42 +180,9 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
     }
 
     it("should commit the last processed offsets") {
-      withKafka { (config, topic) =>
-        createCustomTopic(topic, partitions = 3)
-        val produced = (0 until 100).map(n => s"key-$n" -> s"value->$n")
-        publishToKafka(topic, produced)
-
-        val committed =
-          Stream(consumerSettings[IO](config))
-            .flatMap(consumerStream[IO].using)
-            .evalTap(_.subscribe(topic.r))
-            .flatMap { consumer =>
-              consumer.stream
-                .take(produced.size.toLong)
-                .map(_.offset)
-                .fold(CommittableOffsetBatch.empty[IO])(_ updated _)
-                .evalMap(batch => batch.commit.as(batch.offsets))
-            }
-            .compile
-            .lastOrError
-            .unsafeRunSync()
-
-        assert {
-          committed.values.toList.foldMap(_.offset) == produced.size.toLong &&
-          withKafkaConsumer(consumerProperties(config)) { consumer =>
-            committed.values.toList.foldMap(_.offset)
-
-            committed.foldLeft(true) {
-              case (result, (topicPartition, offsetAndMetadata)) =>
-                result &&
-                  consumer
-                    .committed(Set(topicPartition).asJava)
-                    .asScala
-                    .get(topicPartition)
-                    .contains(offsetAndMetadata)
-            }
-          }
-        }
+      commitTest {
+        case (_, offsetBatch) =>
+          offsetBatch.commit
       }
     }
 
@@ -775,6 +743,24 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
     }
   }
 
+  describe("KafkaConsumer#commitAsync") {
+    it("should commit offsets of messages from the topic to which consumer assigned") {
+      commitTest {
+        case (consumer, offsetBatch) =>
+          consumer.commitAsync(offsetBatch.offsets)
+      }
+    }
+  }
+
+  describe("KafkaConsumer#commitSync") {
+    it("should commit offsets of messages from the topic to which consumer assigned") {
+      commitTest {
+        case (consumer, offsetBatch) =>
+          consumer.commitSync(offsetBatch.offsets)
+      }
+    }
+  }
+
   describe("KafkaConsumer#metrics") {
     it("should return metrics") {
       withKafka { (config, topic) =>
@@ -795,6 +781,46 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
             .unsafeRunSync()
 
         assert(res.nonEmpty)
+      }
+    }
+  }
+
+  private def commitTest(
+    commit: (KafkaConsumer[IO, String, String], CommittableOffsetBatch[IO]) => IO[Unit]
+  ): Assertion = {
+    withKafka { (config, topic) =>
+      val partitionsAmount = 3
+      createCustomTopic(topic, partitions = partitionsAmount)
+      val produced = (0 until 100).map(n => s"key-$n" -> s"value->$n")
+      publishToKafka(topic, produced)
+
+      val partitions = (0 until partitionsAmount).toSet
+
+      val createConsumer = consumerStream[IO]
+        .using(consumerSettings[IO](config))
+        .evalTap(_.subscribeTo(topic))
+
+      val committed = (for {
+        consumer <- createConsumer
+        consumed <- consumer.stream
+          .take(produced.size.toLong)
+          .map(_.offset)
+          .fold(CommittableOffsetBatch.empty[IO])(_ updated _)
+        _ <- Stream.eval(commit(consumer, consumed))
+      } yield consumed.offsets).compile.lastOrError.unsafeRunSync()
+
+      val actuallyCommitted = withKafkaConsumer(consumerProperties(config)) { consumer =>
+        consumer
+          .committed(partitions.map { partition =>
+            new TopicPartition(topic, partition)
+          }.asJava)
+          .asScala
+          .toMap
+      }
+
+      assert {
+        committed.values.toList.foldMap(_.offset) == produced.size.toLong &&
+        committed == actuallyCommitted
       }
     }
   }


### PR DESCRIPTION
I added `commitSync` and` commitAsync` methods. I decided to add both methods (not just `commitAsync`) because they have slightly different semantics. For example, `commitAsync` is based on` poll` calls, but `commitSync` not.

I also added tests for these methods. I managed to reuse the existed test code for this.