### PR TITLE
Bump Cats to 2.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val catsEffectVersion = "2.2.0"
 
-val catsVersion = "2.1.2"
+val catsVersion = "2.2.0"
 
 val confluentVersion = "6.0.0"
 


### PR DESCRIPTION
I ran into a `NoSuchMethodError` in the FS2 runtime regarding `Chain.traverse` into `Seq`, and building this project locally with Cats 2.2.0 seemed to fix the issue. FS2 and Cats Effect are both depending on Cats 2.2.0, while this project depends on 2.1.1 directly. 

I'm not sure if there are other implications of making this change.