### PR TITLE
Improve ergonomics of instantiating producers

### DIFF
--- a/docs/src/main/mdoc/producers.md
+++ b/docs/src/main/mdoc/producers.md
@@ -138,20 +138,20 @@ The following settings are specific to the library.
 
 ## Producer Creation
 
-Once [`ProducerSettings`][producersettings] is defined, use `producerStream` to create a [`KafkaProducer`][kafkaproducer] instance.
+Once [`ProducerSettings`][producersettings] is defined, use `KafkaProducer.stream` to create a [`KafkaProducer`][kafkaproducer] instance.
 
 ```scala mdoc:silent
 object ProducerExample extends IOApp {
   def run(args: List[String]): IO[ExitCode] = {
     val stream =
-      producerStream(producerSettings)
+      KafkaProducer.stream(producerSettings)
 
     stream.compile.drain.as(ExitCode.Success)
   }
 }
 ```
 
-There is also `producerResource` for when it's preferable to work with `Resource`. Both these functions create an underlying Java Kafka producer. They both also guarantee resource cleanup, i.e. closing the Kafka producer instance.
+There is also `KafkaProducer.resource` for when it's preferable to work with `Resource`. Both these functions create an underlying Java Kafka producer. They both also guarantee resource cleanup, i.e. closing the Kafka producer instance.
 
 In the example above, we simply create the producer and then immediately shutdown after resource cleanup. [`KafkaProducer`][kafkaproducer] only supports producing records, and there is a separate producer available to support [transactions](transactions.md).
 
@@ -196,7 +196,7 @@ If we're producing in multiple places in our stream, we can create the `KafkaPro
 object PartitionedProduceExample extends IOApp {
   def run(args: List[String]): IO[ExitCode] = {
     val stream =
-      producerStream[IO]
+      KafkaProducer.stream[IO]
         .using(producerSettings)
         .flatMap { producer =>
           consumerStream[IO]
@@ -227,7 +227,7 @@ If we need more control of how records are produced, we can use `KafkaProducer#p
 object KafkaProducerProduceExample extends IOApp {
   def run(args: List[String]): IO[ExitCode] = {
     val stream =
-      producerStream[IO]
+      KafkaProducer.stream[IO]
         .using(producerSettings)
         .flatMap { producer =>
           consumerStream[IO]
@@ -259,7 +259,7 @@ Sometimes there is a need to wait for individual `ProducerRecords` to send. In t
 object KafkaProducerProduceFlattenExample extends IOApp {
   def run(args: List[String]): IO[ExitCode] = {
     val stream =
-      producerStream[IO]
+      KafkaProducer.stream[IO]
         .using(producerSettings)
         .flatMap { producer =>
           consumerStream[IO]

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -190,7 +190,7 @@ object KafkaProducer {
   def pipe[F[_]: Concurrent: ContextShift, K, V, P](
     settings: ProducerSettings[F, K, V]
   ): Pipe[F, ProducerRecords[K, V, P], ProducerResult[K, V, P]] =
-    records => stream(settings).flatMap(produce(settings, _).apply(records))
+    records => stream(settings).flatMap(pipe(settings, _).apply(records))
 
   /**
     * Produces records in batches using the provided [[KafkaProducer]].

--- a/modules/core/src/main/scala/fs2/kafka/ProducerResource.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ProducerResource.scala
@@ -10,11 +10,11 @@ import cats.effect.{Concurrent, ContextShift, Resource}
 
 /**
   * [[ProducerResource]] provides support for inferring the key and value
-  * type from [[ProducerSettings]] when using `producerResource` with the
+  * type from [[ProducerSettings]] when using `KafkaProducer.resource` with the
   * following syntax.
   *
   * {{{
-  * producerResource[F].using(settings)
+  * KafkaProducer.resource[F].using(settings)
   * }}}
   */
 final class ProducerResource[F[_]] private[kafka] (
@@ -23,13 +23,13 @@ final class ProducerResource[F[_]] private[kafka] (
 
   /**
     * Creates a new [[KafkaProducer]] in the `Resource` context.
-    * This is equivalent to using `producerResource` directly,
+    * This is equivalent to using `KafkaProducer.resource` directly,
     * except we're able to infer the key and value type.
     */
   def using[K, V](settings: ProducerSettings[F, K, V])(
     implicit context: ContextShift[F]
   ): Resource[F, KafkaProducer.Metrics[F, K, V]] =
-    producerResource(settings)(F, context)
+    KafkaProducer.resource(settings)(F, context)
 
   override def toString: String =
     "ProducerResource$" + System.identityHashCode(this)

--- a/modules/core/src/main/scala/fs2/kafka/ProducerStream.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ProducerStream.scala
@@ -11,11 +11,11 @@ import fs2.Stream
 
 /**
   * [[ProducerStream]] provides support for inferring the key and value
-  * type from [[ProducerSettings]] when using `producerStream` with the
+  * type from [[ProducerSettings]] when using `KafkaProducer.stream` with the
   * following syntax.
   *
   * {{{
-  * producerStream[F].using(settings)
+  * KafkaProducer.stream[F].using(settings)
   * }}}
   */
 final class ProducerStream[F[_]] private[kafka] (
@@ -24,13 +24,13 @@ final class ProducerStream[F[_]] private[kafka] (
 
   /**
     * Creates a new [[KafkaProducer]] in the `Stream` context.
-    * This is equivalent to using `producerStream` directly,
+    * This is equivalent to using `KafkaProducer.stream` directly,
     * except we're able to infer the key and value type.
     */
   def using[K, V](settings: ProducerSettings[F, K, V])(
     implicit context: ContextShift[F]
   ): Stream[F, KafkaProducer.Metrics[F, K, V]] =
-    producerStream(settings)(F, context)
+    KafkaProducer.stream(settings)(F, context)
 
   override def toString: String =
     "ProducerStream$" + System.identityHashCode(this)

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -60,17 +60,13 @@ package object kafka {
   ): Pipe[F, CommittableOffset[F], Unit] =
     _.groupWithin(n, d).evalMap(CommittableOffsetBatch.fromFoldable(_).commit)
 
-  /**
-    * Alias for `KafkaProducer.pipe
-    */
+  @deprecated("use KafkaProducer.pipe", "1.2.0")
   def produce[F[_]: Concurrent: ContextShift, K, V, P](
     settings: ProducerSettings[F, K, V]
   ): Pipe[F, ProducerRecords[K, V, P], ProducerResult[K, V, P]] =
     KafkaProducer.pipe(settings)
 
-  /**
-    * Alias for `KafkaProducer.pipe`
-    */
+  @deprecated("use KafkaProducer.pipe", "1.2.0")
   def produce[F[_]: Concurrent, K, V, P](
     settings: ProducerSettings[F, K, V],
     producer: KafkaProducer[F, K, V]
@@ -162,29 +158,21 @@ package object kafka {
   def consumerStream[F[_]](implicit F: ConcurrentEffect[F]): ConsumerStream[F] =
     new ConsumerStream[F](F)
 
-  /**
-    * Alias for `KafkaProducer.resource`
-    */
+  @deprecated("use KafkaProducer.resource", "1.2.0")
   def producerResource[F[_]: Concurrent: ContextShift, K, V](
     settings: ProducerSettings[F, K, V]
   ): Resource[F, KafkaProducer.Metrics[F, K, V]] =
     KafkaProducer.resource(settings)
 
-  /**
-    * Alias for `KafkaProducer.resource`
-    */
+  @deprecated("use KafkaProducer.resource", "1.2.0")
   def producerResource[F[_]: Concurrent]: ProducerResource[F] = KafkaProducer.resource
 
-  /**
-    * Alias for `KafkaProducer.stream`
-    */
+  @deprecated("use KafkaProducer.stream", "1.2.0")
   def producerStream[F[_]: Concurrent: ContextShift, K, V](
     settings: ProducerSettings[F, K, V]
   ): Stream[F, KafkaProducer.Metrics[F, K, V]] = KafkaProducer.stream(settings)
 
-  /**
-    * Alias for `KafkaProducer.stream`
-    */
+  @deprecated("use KafkaProducer.stream", "1.2.0")
   def producerStream[F[_]: Concurrent]: ProducerStream[F] =
     KafkaProducer.stream[F]
 

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -61,7 +61,7 @@ package object kafka {
     _.groupWithin(n, d).evalMap(CommittableOffsetBatch.fromFoldable(_).commit)
 
   /**
-    * Alias for [[KafkaProducer.pipe]]
+    * Alias for `KafkaProducer.pipe
     */
   def produce[F[_]: Concurrent: ContextShift, K, V, P](
     settings: ProducerSettings[F, K, V]
@@ -69,7 +69,7 @@ package object kafka {
     KafkaProducer.pipe(settings)
 
   /**
-    * Alias for [[KafkaProducer.pipe]]
+    * Alias for `KafkaProducer.pipe`
     */
   def produce[F[_]: Concurrent, K, V, P](
     settings: ProducerSettings[F, K, V],
@@ -163,7 +163,7 @@ package object kafka {
     new ConsumerStream[F](F)
 
   /**
-    * Alias for [[KafkaProducer.resource]]
+    * Alias for `KafkaProducer.resource`
     */
   def producerResource[F[_]: Concurrent: ContextShift, K, V](
     settings: ProducerSettings[F, K, V]
@@ -171,19 +171,19 @@ package object kafka {
     KafkaProducer.resource(settings)
 
   /**
-    * Alias for [[KafkaProducer.resource]]
+    * Alias for `KafkaProducer.resource`
     */
   def producerResource[F[_]: Concurrent]: ProducerResource[F] = KafkaProducer.resource
 
   /**
-    * Alias for [[KafkaProducer.stream]]
+    * Alias for `KafkaProducer.stream`
     */
   def producerStream[F[_]: Concurrent: ContextShift, K, V](
     settings: ProducerSettings[F, K, V]
   ): Stream[F, KafkaProducer.Metrics[F, K, V]] = KafkaProducer.stream(settings)
 
   /**
-    * Alias for [[KafkaProducer.stream]]
+    * Alias for `KafkaProducer.stream`
     */
   def producerStream[F[_]: Concurrent]: ProducerStream[F] =
     KafkaProducer.stream[F]

--- a/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -5,6 +5,22 @@ import cats.implicits._
 import fs2.{Chunk, Stream}
 
 final class KafkaProducerSpec extends BaseKafkaSpec {
+
+  describe("creating producers") {
+    it("should support defined syntax") {
+      val settings =
+        ProducerSettings[IO, String, String]
+
+      KafkaProducer.resource[IO, String, String](settings)
+      KafkaProducer.resource[IO].toString should startWith("ProducerResource$")
+      KafkaProducer.resource[IO].using(settings)
+
+      KafkaProducer.stream[IO, String, String](settings)
+      KafkaProducer.stream[IO].toString should startWith("ProducerStream$")
+      KafkaProducer.stream[IO].using(settings)
+    }
+  }
+
   it("should be able to produce records with single") {
     withKafka { (config, topic) =>
       createCustomTopic(topic, partitions = 3)

--- a/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -13,7 +13,7 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
       val produced =
         (for {
           settings <- Stream(producerSettings[IO](config))
-          producer <- producerStream[IO].using(settings)
+          producer <- KafkaProducer.stream[IO].using(settings)
           _ <- Stream.eval(IO(producer.toString should startWith("KafkaProducer$")))
           records <- Stream.chunk(Chunk.seq(toProduce).map {
             case passthrough @ (key, value) =>
@@ -43,7 +43,7 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
 
       val produced =
         (for {
-          producer <- producerStream[IO].using(producerSettings(config))
+          producer <- KafkaProducer.stream[IO].using(producerSettings(config))
           records = ProducerRecords(toProduce.map {
             case (key, value) =>
               ProducerRecord(topic, key, value)
@@ -73,7 +73,7 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
 
       val result =
         (for {
-          producer <- producerStream[IO].using(producerSettings(config))
+          producer <- KafkaProducer.stream[IO].using(producerSettings(config))
           records = ProducerRecords(Nil, passthrough)
           result <- Stream.eval(producer.produce(records).flatten)
         } yield result).compile.lastOrError.unsafeRunSync()
@@ -89,7 +89,7 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
 
       val result =
         (for {
-          producer <- producerStream[IO].using(producerSettings(config))
+          producer <- KafkaProducer.stream[IO].using(producerSettings(config))
           result <- Stream.eval {
             producer.produce(ProducerRecords(Nil, passthrough)).flatten
           }
@@ -104,7 +104,8 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
       createCustomTopic(topic, partitions = 3)
 
       val info =
-        producerStream[IO]
+        KafkaProducer
+          .stream[IO]
           .using(producerSettings(config))
           .evalMap(_.metrics)
 

--- a/modules/core/src/test/scala/fs2/kafka/PackageSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/PackageSpec.scala
@@ -28,21 +28,6 @@ final class PackageSpec extends BaseAsyncSpec {
     }
   }
 
-  describe("creating producers") {
-    it("should support defined syntax") {
-      val settings =
-        ProducerSettings[IO, String, String]
-
-      producerResource[IO, String, String](settings)
-      producerResource[IO].toString should startWith("ProducerResource$")
-      producerResource[IO].using(settings)
-
-      producerStream[IO, String, String](settings)
-      producerStream[IO].toString should startWith("ProducerStream$")
-      producerStream[IO].using(settings)
-    }
-  }
-
   describe("creating transactional producers") {
     it("should support defined syntax") {
       val settings = TransactionalProducerSettings("id", ProducerSettings[IO, String, String])


### PR DESCRIPTION
I think methods on companion objects are more idiomatic in Scala - they're also more discoverable, especially with autocompletion tooling. I'd be inclined to deprecate the package object methods and remove them in v2 - thoughts?