### PR TITLE
Only draft releases for series/1.x

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -2,7 +2,7 @@ name: notes
 on:
   push:
     branches:
-      - series/*
+      - series/1.x
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Unfortunately, release-drafter doesn't seem to work well with multi-branch workflows.