### PR TITLE
KafkaConsumer signed partition stream

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -333,6 +333,15 @@ object KafkaConsumer {
         }
       }
 
+      override def signedPartitionedStream: Stream[F, (TopicPartition, Stream[F, CommittableConsumerRecord[F, K, V]])] = {
+        partitionsMapStream.flatMap { partitionsMap =>
+          Stream.emits(partitionsMap.toVector.map {
+            case (topicPartition, partitionStream) =>
+              topicPartition -> partitionStream
+          })
+        }
+      }
+
       override def stream: Stream[F, CommittableConsumerRecord[F, K, V]] =
         partitionedStream.parJoinUnbounded
 

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
@@ -42,6 +42,10 @@ trait KafkaConsume[F[_], K, V] {
   def partitionedStream: Stream[F, Stream[F, CommittableConsumerRecord[F, K, V]]]
 
   /**
+    * Same as partitionedStream but topic 'Stream' is tupled with 'TopicPartition'
+    */
+  def signedPartitionedStream: Stream[F, (TopicPartition, Stream[F, CommittableConsumerRecord[F, K, V]])]
+  /**
     * `Stream` where each element contains a current assignment. The current
     * assignment is the `Map`, where keys is a `TopicPartition`, and values are
     * streams with records for a particular `TopicPartition`.<br>


### PR DESCRIPTION
my suggestion of KafkaConsumer API enhancement. Having topic partition instance tupled with a topic stream is useful for logging and metrics. I know it's doable via 'partitionsMapStream' but it'd be nice to have it out of the box 