### PR TITLE
correct deprecation message for adminClientStream

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -80,7 +80,7 @@ package object kafka {
   ): Resource[F, KafkaAdminClient[F]] =
     KafkaAdminClient.resource(settings)
 
-  @deprecated("use KafkaConsumer.stream", "1.2.0")
+  @deprecated("use KafkaAdminClient.stream", "1.2.0")
   def adminClientStream[F[_]](settings: AdminClientSettings[F])(
     implicit F: Concurrent[F],
     context: ContextShift[F]


### PR DESCRIPTION
noticed that the deprecation warning didn't match what change was required to fix it