### PR TITLE
Fix consumer lifecycle bincompat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.12, 2.13.3, 3.0.0-M3]
+        scala: [2.12.13, 2.13.3, 3.0.0-M3]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val testcontainersScalaVersion = "0.38.8"
 
 val vulcanVersion = "1.3.0"
 
-val scala212 = "2.12.12"
+val scala212 = "2.12.13"
 
 val scala213 = "2.13.3"
 

--- a/build.sbt
+++ b/build.sbt
@@ -247,9 +247,7 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.kafka.KafkaConsumer.stopConsuming"),
       ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.kafka.KafkaConsumer.commitAsync"),
       ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.kafka.KafkaConsumer.commitSync"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.*"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.consumer.KafkaConsumerLifecycle.terminate"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.consumer.KafkaConsumerLifecycle.awaitTermination")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.*")
     )
     // format: on
   }

--- a/build.sbt
+++ b/build.sbt
@@ -269,9 +269,7 @@ lazy val scalaSettings = Seq(
     "UTF-8",
     "-feature",
     "-language:implicitConversions",
-    "-unchecked",
-    // Used instead of @nowarn to prevent spurious warnings in Scala 2.12.13 - see https://gitter.im/scala/scala?at=602584589d5c644f66661387
-    """-Wconf:cat=deprecation&src=modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle\.scala:s"""
+    "-unchecked"
   ) ++ (
     if (scalaVersion.value.startsWith("2.13"))
       Seq(
@@ -302,6 +300,7 @@ lazy val scalaSettings = Seq(
         "-Xignore-scala2-macros"
       )
   ),
+  scalacOptions in (Compile, doc) += "-nowarn", // workaround for https://github.com/scala/bug/issues/12007
   scalacOptions in (Compile, console) --= Seq("-Xlint", "-Ywarn-unused"),
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
   Compile / unmanagedSourceDirectories ++=

--- a/build.sbt
+++ b/build.sbt
@@ -269,7 +269,9 @@ lazy val scalaSettings = Seq(
     "UTF-8",
     "-feature",
     "-language:implicitConversions",
-    "-unchecked"
+    "-unchecked",
+    // Used instead of @nowarn to prevent spurious warnings in Scala 2.12.13 - see https://gitter.im/scala/scala?at=602584589d5c644f66661387
+    """-Wconf:cat=deprecation&src=modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle\.scala:s"""
   ) ++ (
     if (scalaVersion.value.startsWith("2.13"))
       Seq(

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -549,9 +549,6 @@ object KafkaConsumer {
       override def toString: String =
         "KafkaConsumer$" + id
 
-      override def terminate: F[Unit] = fiber.cancel
-
-      override def awaitTermination: F[Unit] = fiber.join
     }
 
   @deprecated("use KafkaConsumer.resource", "1.2.0")

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle.scala
@@ -8,6 +8,8 @@ package fs2.kafka.consumer
 
 import cats.effect.Fiber
 
+import scala.annotation.nowarn
+
 trait KafkaConsumerLifecycle[F[_]] {
 
   /**
@@ -39,12 +41,14 @@ trait KafkaConsumerLifecycle[F[_]] {
     * consumer to shutdown. If you also want to wait for the shutdown
     * to complete, you can use `awaitTermination`.<br>
     */
-  def terminate: F[Unit]
+  @nowarn("cat=deprecation")
+  def terminate: F[Unit] = fiber.cancel
 
   /**
     * Shutdown and wait for it to complete. Note that `awaitTermination` is guaranteed
     * to complete after consumer shutdown, even when the consumer is
     * cancelled with `terminate`.<br>
     */
-  def awaitTermination: F[Unit]
+  @nowarn("cat=deprecation")
+  def awaitTermination: F[Unit] = fiber.join
 }

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle.scala
@@ -8,8 +8,6 @@ package fs2.kafka.consumer
 
 import cats.effect.Fiber
 
-import scala.annotation.nowarn
-
 trait KafkaConsumerLifecycle[F[_]] {
 
   /**
@@ -41,7 +39,7 @@ trait KafkaConsumerLifecycle[F[_]] {
     * consumer to shutdown. If you also want to wait for the shutdown
     * to complete, you can use `terminate >> awaitTermination`.<br>
     */
-  @nowarn("cat=deprecation")
+//  @nowarn("cat=deprecation")
   def terminate: F[Unit] = fiber.cancel
 
   /**
@@ -52,6 +50,6 @@ trait KafkaConsumerLifecycle[F[_]] {
     * This method will not initiate shutdown. To initiate shutdown and wait for
     * it to complete, you can use `terminate >> awaitTermination`.
     */
-  @nowarn("cat=deprecation")
+//  @nowarn("cat=deprecation")
   def awaitTermination: F[Unit] = fiber.join
 }

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle.scala
@@ -8,6 +8,8 @@ package fs2.kafka.consumer
 
 import cats.effect.Fiber
 
+import scala.annotation.nowarn
+
 trait KafkaConsumerLifecycle[F[_]] {
 
   /**
@@ -39,7 +41,7 @@ trait KafkaConsumerLifecycle[F[_]] {
     * consumer to shutdown. If you also want to wait for the shutdown
     * to complete, you can use `terminate >> awaitTermination`.<br>
     */
-//  @nowarn("cat=deprecation")
+  @nowarn("cat=deprecation")
   def terminate: F[Unit] = fiber.cancel
 
   /**
@@ -50,6 +52,6 @@ trait KafkaConsumerLifecycle[F[_]] {
     * This method will not initiate shutdown. To initiate shutdown and wait for
     * it to complete, you can use `terminate >> awaitTermination`.
     */
-//  @nowarn("cat=deprecation")
+  @nowarn("cat=deprecation")
   def awaitTermination: F[Unit] = fiber.join
 }

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle.scala
@@ -39,15 +39,18 @@ trait KafkaConsumerLifecycle[F[_]] {
     * Whenever `terminate` is invoked, an attempt will be made to stop the
     * underlying consumer. The `terminate` operation will not wait for the
     * consumer to shutdown. If you also want to wait for the shutdown
-    * to complete, you can use `awaitTermination`.<br>
+    * to complete, you can use `terminate >> awaitTermination`.<br>
     */
   @nowarn("cat=deprecation")
   def terminate: F[Unit] = fiber.cancel
 
   /**
-    * Shutdown and wait for it to complete. Note that `awaitTermination` is guaranteed
+    * Wait for consumer to shut down. Note that `awaitTermination` is guaranteed
     * to complete after consumer shutdown, even when the consumer is
-    * cancelled with `terminate`.<br>
+    * cancelled with `terminate`.
+    *
+    * This method will not initiate shutdown. To initiate shutdown and wait for
+    * it to complete, you can use `terminate >> awaitTermination`.
     */
   @nowarn("cat=deprecation")
   def awaitTermination: F[Unit] = fiber.join


### PR DESCRIPTION
I made a bincompat mistake with #504 - this fixes it by providing a default implementation of the new methods in `KafkaConsumerLifecycle`