### PR TITLE
Revert "Rename `KafkaX` type aliases to `JavaX`"

### DIFF
--- a/docs/src/main/mdoc/consumers.md
+++ b/docs/src/main/mdoc/consumers.md
@@ -77,7 +77,7 @@ If we have a Java Kafka deserializer, use `delegate` to create a `Deserializer`.
 
 ```scala mdoc:silent
 Deserializer.delegate[IO, String] {
-  new JavaDeserializer[String] {
+  new KafkaDeserializer[String] {
     def deserialize(topic: String, data: Array[Byte]): String =
       new String(data)
   }
@@ -88,7 +88,7 @@ If the deserializer performs _side effects_, follow with `suspend` to capture th
 
 ```scala mdoc:silent
 Deserializer.delegate[IO, String] {
-   new JavaDeserializer[String] {
+   new KafkaDeserializer[String] {
     def deserialize(topic: String, data: Array[Byte]): String = {
       println(s"deserializing record on topic $topic")
       new String(data)

--- a/docs/src/main/mdoc/producers.md
+++ b/docs/src/main/mdoc/producers.md
@@ -77,7 +77,7 @@ If we have a Java Kafka serializer, use `delegate` to create a `Serializer`.
 
 ```scala mdoc:silent
 Serializer.delegate[IO, String] {
-  new JavaSerializer[String] {
+  new KafkaSerializer[String] {
     def serialize(topic: String, value: String): Array[Byte] =
       value.getBytes("UTF-8")
   }
@@ -88,7 +88,7 @@ If the serializer performs _side effects_, follow with `suspend` to capture them
 
 ```scala mdoc:silent
 Serializer.delegate[IO, String] {
-   new JavaSerializer[String] {
+   new KafkaSerializer[String] {
     def serialize(topic: String, value: String): Array[Byte] = {
       println(s"serializing record on topic $topic")
       value.getBytes("UTF-8")

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerRecord.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerRecord.scala
@@ -165,7 +165,7 @@ object ConsumerRecord {
     )
 
   private[this] def deserializeFromBytes[F[_], K, V](
-    record: JavaByteConsumerRecord,
+    record: KafkaByteConsumerRecord,
     headers: Headers,
     keyDeserializer: Deserializer[F, K],
     valueDeserializer: Deserializer[F, V]
@@ -176,7 +176,7 @@ object ConsumerRecord {
   }
 
   private[kafka] def fromJava[F[_], K, V](
-    record: JavaByteConsumerRecord,
+    record: KafkaByteConsumerRecord,
     keyDeserializer: Deserializer[F, K],
     valueDeserializer: Deserializer[F, V]
   )(implicit F: Apply[F]): F[ConsumerRecord[K, V]] = {

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -347,7 +347,7 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
     * operation should be bracketed, using e.g. `Resource`, to ensure
     * the `close` function on the consumer is called.
     */
-  def createConsumer: F[JavaByteConsumer]
+  def createConsumer: F[KafkaByteConsumer]
 
   /**
     * Creates a new [[ConsumerSettings]] with the specified function for
@@ -355,7 +355,7 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
     * is the [[properties]] of the settings instance.
     */
   def withCreateConsumer(
-    createConsumer: Map[String, String] => F[JavaByteConsumer]
+    createConsumer: Map[String, String] => F[KafkaByteConsumer]
   ): ConsumerSettings[F, K, V]
 
   /**
@@ -412,7 +412,7 @@ object ConsumerSettings {
     override val commitRecovery: CommitRecovery,
     override val recordMetadata: ConsumerRecord[K, V] => String,
     override val maxPrefetchBatches: Int,
-    val createConsumerWith: Map[String, String] => F[JavaByteConsumer]
+    val createConsumerWith: Map[String, String] => F[KafkaByteConsumer]
   ) extends ConsumerSettings[F, K, V] {
     override def withBlocker(blocker: Blocker): ConsumerSettings[F, K, V] =
       copy(blocker = Some(blocker))
@@ -519,11 +519,11 @@ object ConsumerSettings {
     override def withCommitRecovery(commitRecovery: CommitRecovery): ConsumerSettings[F, K, V] =
       copy(commitRecovery = commitRecovery)
 
-    override def createConsumer: F[JavaByteConsumer] =
+    override def createConsumer: F[KafkaByteConsumer] =
       createConsumerWith(properties)
 
     override def withCreateConsumer(
-      createConsumerWith: Map[String, String] => F[JavaByteConsumer]
+      createConsumerWith: Map[String, String] => F[KafkaByteConsumer]
     ): ConsumerSettings[F, K, V] =
       copy(createConsumerWith = createConsumerWith)
 

--- a/modules/core/src/main/scala/fs2/kafka/Deserializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Deserializer.scala
@@ -88,7 +88,7 @@ object Deserializer {
     * so the impure behaviours can be captured properly.
     */
   def delegate[F[_], A](
-    deserializer: JavaDeserializer[A]
+    deserializer: KafkaDeserializer[A]
   )(implicit F: Sync[F]): Deserializer[F, A] =
     Deserializer.instance { (topic, headers, bytes) =>
       F.pure(deserializer.deserialize(topic, headers.asJava, bytes))

--- a/modules/core/src/main/scala/fs2/kafka/HeaderDeserializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/HeaderDeserializer.scala
@@ -115,7 +115,7 @@ object HeaderDeserializer {
     * and `configure` functions won't be called for the delegate. Also,
     * the topic is an empty `String` and no headers are provided.
     */
-  def delegate[A](deserializer: JavaDeserializer[A]): HeaderDeserializer[A] =
+  def delegate[A](deserializer: KafkaDeserializer[A]): HeaderDeserializer[A] =
     HeaderDeserializer.instance { bytes =>
       deserializer.deserialize("", bytes)
     }

--- a/modules/core/src/main/scala/fs2/kafka/HeaderSerializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/HeaderSerializer.scala
@@ -77,7 +77,7 @@ object HeaderSerializer {
     * `configure` functions won't be called for the delegate. Also,
     * the topic is an empty `String` and no headers are provided.
     */
-  def delegate[A](serializer: JavaSerializer[A]): HeaderSerializer[A] =
+  def delegate[A](serializer: KafkaSerializer[A]): HeaderSerializer[A] =
     HeaderSerializer.instance { a =>
       serializer.serialize("", a)
     }

--- a/modules/core/src/main/scala/fs2/kafka/Headers.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Headers.scala
@@ -69,7 +69,7 @@ sealed abstract class Headers {
   def isEmpty: Boolean
 
   /** The [[Headers]] as an immutable Java Kafka `Headers` instance. */
-  def asJava: JavaHeaders
+  def asJava: KafkaHeaders
 }
 
 object Headers {
@@ -100,35 +100,35 @@ object Headers {
     override val isEmpty: Boolean =
       false
 
-    override def asJava: JavaHeaders = {
-      val array: Array[JavaHeader] =
+    override def asJava: KafkaHeaders = {
+      val array: Array[KafkaHeader] =
         toChain.iterator.toArray
 
-      new JavaHeaders {
-        override def add(header: JavaHeader): JavaHeaders =
+      new KafkaHeaders {
+        override def add(header: KafkaHeader): KafkaHeaders =
           throw new IllegalStateException("Headers#asJava is immutable")
 
-        override def add(key: String, value: Array[Byte]): JavaHeaders =
+        override def add(key: String, value: Array[Byte]): KafkaHeaders =
           throw new IllegalStateException("Headers#asJava is immutable")
 
-        override def remove(key: String): JavaHeaders =
+        override def remove(key: String): KafkaHeaders =
           throw new IllegalStateException("Headers#asJava is immutable")
 
-        override def lastHeader(key: String): JavaHeader = {
+        override def lastHeader(key: String): KafkaHeader = {
           val index = array.lastIndexWhere(_.key == key)
           if (index != -1) array(index) else null
         }
 
-        override def headers(key: String): java.lang.Iterable[JavaHeader] =
-          new java.lang.Iterable[JavaHeader] {
-            override def iterator(): java.util.Iterator[JavaHeader] =
+        override def headers(key: String): java.lang.Iterable[KafkaHeader] =
+          new java.lang.Iterable[KafkaHeader] {
+            override def iterator(): java.util.Iterator[KafkaHeader] =
               array.iterator.filter(_.key == key).asJava
           }
 
-        override val toArray: Array[JavaHeader] =
+        override val toArray: Array[KafkaHeader] =
           array
 
-        override def iterator(): java.util.Iterator[JavaHeader] =
+        override def iterator(): java.util.Iterator[KafkaHeader] =
           array.iterator.asJava
       }
     }
@@ -200,42 +200,42 @@ object Headers {
       override val isEmpty: Boolean =
         true
 
-      override val asJava: JavaHeaders =
-        new JavaHeaders {
-          override def add(header: JavaHeader): JavaHeaders =
+      override val asJava: KafkaHeaders =
+        new KafkaHeaders {
+          override def add(header: KafkaHeader): KafkaHeaders =
             throw new IllegalStateException("Headers#asJava is immutable")
 
-          override def add(key: String, value: Array[Byte]): JavaHeaders =
+          override def add(key: String, value: Array[Byte]): KafkaHeaders =
             throw new IllegalStateException("Headers#asJava is immutable")
 
-          override def remove(key: String): JavaHeaders =
+          override def remove(key: String): KafkaHeaders =
             throw new IllegalStateException("Headers#asJava is immutable")
 
-          override def lastHeader(key: String): JavaHeader =
+          override def lastHeader(key: String): KafkaHeader =
             null
 
-          private[this] val emptyIterator: java.util.Iterator[JavaHeader] =
-            new java.util.Iterator[JavaHeader] {
+          private[this] val emptyIterator: java.util.Iterator[KafkaHeader] =
+            new java.util.Iterator[KafkaHeader] {
               override val hasNext: Boolean =
                 false
 
-              override def next(): JavaHeader =
+              override def next(): KafkaHeader =
                 throw new NoSuchElementException()
             }
 
-          private[this] val emptyIterable: java.lang.Iterable[JavaHeader] =
-            new java.lang.Iterable[JavaHeader] {
-              override val iterator: java.util.Iterator[JavaHeader] =
+          private[this] val emptyIterable: java.lang.Iterable[KafkaHeader] =
+            new java.lang.Iterable[KafkaHeader] {
+              override val iterator: java.util.Iterator[KafkaHeader] =
                 emptyIterator
             }
 
-          override def headers(key: String): java.lang.Iterable[JavaHeader] =
+          override def headers(key: String): java.lang.Iterable[KafkaHeader] =
             emptyIterable
 
-          override val toArray: Array[JavaHeader] =
+          override val toArray: Array[KafkaHeader] =
             Array.empty
 
-          override val iterator: java.util.Iterator[JavaHeader] =
+          override val iterator: java.util.Iterator[KafkaHeader] =
             emptyIterator
         }
 

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -158,7 +158,7 @@ object KafkaProducer {
   private[kafka] def produceRecord[F[_], K, V](
     keySerializer: Serializer[F, K],
     valueSerializer: Serializer[F, V],
-    producer: JavaByteProducer
+    producer: KafkaByteProducer
   )(
     implicit F: ConcurrentEffect[F]
   ): ProducerRecord[K, V] => F[F[(ProducerRecord[K, V], RecordMetadata)]] =
@@ -222,10 +222,10 @@ object KafkaProducer {
     keySerializer: Serializer[F, K],
     valueSerializer: Serializer[F, V],
     record: ProducerRecord[K, V]
-  )(implicit F: Apply[F]): F[JavaByteProducerRecord] =
+  )(implicit F: Apply[F]): F[KafkaByteProducerRecord] =
     serializeToBytes(keySerializer, valueSerializer, record).map {
       case (keyBytes, valueBytes) =>
-        new JavaByteProducerRecord(
+        new KafkaByteProducerRecord(
           record.topic,
           record.partition.fold[java.lang.Integer](null)(identity),
           record.timestamp.fold[java.lang.Long](null)(identity),

--- a/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -229,7 +229,7 @@ sealed abstract class ProducerSettings[F[_], K, V] {
     * operation should be bracketed, using e.g. `Resource`, to ensure
     * the `close` function on the producer is called.
     */
-  def createProducer: F[JavaByteProducer]
+  def createProducer: F[KafkaByteProducer]
 
   /**
     * Creates a new [[ProducerSettings]] with the specified function for
@@ -237,7 +237,7 @@ sealed abstract class ProducerSettings[F[_], K, V] {
     * is the [[properties]] of the settings instance.
     */
   def withCreateProducer(
-    createProducer: Map[String, String] => F[JavaByteProducer]
+    createProducer: Map[String, String] => F[KafkaByteProducer]
   ): ProducerSettings[F, K, V]
 }
 
@@ -249,7 +249,7 @@ object ProducerSettings {
     override val properties: Map[String, String],
     override val closeTimeout: FiniteDuration,
     override val parallelism: Int,
-    val createProducerWith: Map[String, String] => F[JavaByteProducer]
+    val createProducerWith: Map[String, String] => F[KafkaByteProducer]
   ) extends ProducerSettings[F, K, V] {
     override def withBlocker(blocker: Blocker): ProducerSettings[F, K, V] =
       copy(blocker = Some(blocker))
@@ -308,11 +308,11 @@ object ProducerSettings {
     override def withParallelism(parallelism: Int): ProducerSettings[F, K, V] =
       copy(parallelism = parallelism)
 
-    override def createProducer: F[JavaByteProducer] =
+    override def createProducer: F[KafkaByteProducer] =
       createProducerWith(properties)
 
     override def withCreateProducer(
-      createProducerWith: Map[String, String] => F[JavaByteProducer]
+      createProducerWith: Map[String, String] => F[KafkaByteProducer]
     ): ProducerSettings[F, K, V] =
       copy(createProducerWith = createProducerWith)
 

--- a/modules/core/src/main/scala/fs2/kafka/Serializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Serializer.scala
@@ -80,7 +80,7 @@ object Serializer {
     * If it's not pure, then use `suspend` after `delegate`,
     * so the impure behaviours can be captured properly.
     */
-  def delegate[F[_], A](serializer: JavaSerializer[A])(
+  def delegate[F[_], A](serializer: KafkaSerializer[A])(
     implicit F: Sync[F]
   ): Serializer[F, A] =
     Serializer.instance[F, A] { (topic, headers, a) =>

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -401,7 +401,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
       )
     )
 
-  private[this] def records(batch: JavaByteConsumerRecords): F[ConsumerRecords] =
+  private[this] def records(batch: KafkaByteConsumerRecords): F[ConsumerRecords] =
     batch.partitions.toVector
       .traverse { partition =>
         NonEmptyVector

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithProducer.scala
@@ -8,13 +8,13 @@ package fs2.kafka.internal
 
 import cats.effect.{Blocker, ContextShift, Resource, Sync}
 import cats.implicits._
-import fs2.kafka.{JavaByteProducer, ProducerSettings, TransactionalProducerSettings}
+import fs2.kafka.{KafkaByteProducer, ProducerSettings, TransactionalProducerSettings}
 import fs2.kafka.internal.syntax._
 
 private[kafka] sealed abstract class WithProducer[F[_]] {
-  def apply[A](f: (JavaByteProducer, Blocking[F]) => F[A]): F[A]
+  def apply[A](f: (KafkaByteProducer, Blocking[F]) => F[A]): F[A]
 
-  def blocking[A](f: JavaByteProducer => A): F[A] = apply {
+  def blocking[A](f: KafkaByteProducer => A): F[A] = apply {
     case (producer, blocking) => blocking(f(producer))
   }
 }
@@ -64,10 +64,10 @@ private[kafka] object WithProducer {
       .map(Blocking.fromBlocker[F])
 
   private def create[F[_]](
-    producer: JavaByteProducer,
+    producer: KafkaByteProducer,
     _blocking: Blocking[F]
   ): WithProducer[F] = new WithProducer[F] {
-    override def apply[A](f: (JavaByteProducer, Blocking[F]) => F[A]): F[A] =
+    override def apply[A](f: (KafkaByteProducer, Blocking[F]) => F[A]): F[A] =
       f(producer, _blocking)
   }
 }

--- a/modules/core/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -9,7 +9,7 @@ package fs2.kafka.internal
 import cats.{FlatMap, Foldable, Show}
 import cats.effect.{CancelToken, Concurrent, Sync}
 import cats.implicits._
-import fs2.kafka.{Header, Headers, JavaHeaders}
+import fs2.kafka.{Header, Headers, KafkaHeaders}
 import fs2.kafka.internal.converters.unsafeWrapArray
 import fs2.kafka.internal.converters.collection._
 import java.time.Duration
@@ -213,8 +213,8 @@ private[kafka] object syntax {
       }
   }
 
-  implicit final class JavaHeadersSyntax(
-    private val headers: JavaHeaders
+  implicit final class KafkaHeadersSyntax(
+    private val headers: KafkaHeaders
   ) extends AnyVal {
     def asScala: Headers =
       Headers.fromSeq {

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -13,67 +13,40 @@ package object kafka {
   type Id[+A] = A
 
   /** Alias for Java Kafka `Consumer[Array[Byte], Array[Byte]]`. */
-  type JavaByteConsumer =
+  type KafkaByteConsumer =
     org.apache.kafka.clients.consumer.Consumer[Array[Byte], Array[Byte]]
 
-  @deprecated("use JavaByteConsumer", "1.3.0")
-  type KafkaByteConsumer = JavaByteConsumer
-
   /** Alias for Java Kafka `Producer[Array[Byte], Array[Byte]]`. */
-  type JavaByteProducer =
+  type KafkaByteProducer =
     org.apache.kafka.clients.producer.Producer[Array[Byte], Array[Byte]]
 
-  @deprecated("use JavaByteProducer", "1.3.0")
-  type KafkaByteProducer = JavaByteProducer
-
   /** Alias for Java Kafka `Deserializer[A]`. */
-  type JavaDeserializer[A] =
+  type KafkaDeserializer[A] =
     org.apache.kafka.common.serialization.Deserializer[A]
 
-  @deprecated("use JavaDeserializer", "1.3.0")
-  type KafkaDeserializer[A] = JavaDeserializer[A]
-
   /** Alias for Java Kafka `Serializer[A]`. */
-  type JavaSerializer[A] =
+  type KafkaSerializer[A] =
     org.apache.kafka.common.serialization.Serializer[A]
 
-  @deprecated("use JavaSerializer", "1.3.0")
-  type KafkaSerializer[A] = JavaSerializer[A]
-
   /** Alias for Java Kafka `Header`. */
-  type JavaHeader =
+  type KafkaHeader =
     org.apache.kafka.common.header.Header
 
-  @deprecated("use JavaHeader", "1.3.0")
-  type KafkaHeader = JavaHeader
-
   /** Alias for Java Kafka `Headers`. */
-  type JavaHeaders =
+  type KafkaHeaders =
     org.apache.kafka.common.header.Headers
 
-  @deprecated("use JavaHeaders", "1.3.0")
-  type KafkaHeaders = JavaHeaders
-
   /** Alias for Java Kafka `ConsumerRecords[Array[Byte], Array[Byte]]`. */
-  type JavaByteConsumerRecords =
+  type KafkaByteConsumerRecords =
     org.apache.kafka.clients.consumer.ConsumerRecords[Array[Byte], Array[Byte]]
 
-  @deprecated("use JavaByteConsumerRecords", "1.3.0")
-  type KafkaByteConsumerRecords = JavaByteConsumerRecords
-
   /** Alias for Java Kafka `ConsumerRecord[Array[Byte], Array[Byte]]`. */
-  type JavaByteConsumerRecord =
+  type KafkaByteConsumerRecord =
     org.apache.kafka.clients.consumer.ConsumerRecord[Array[Byte], Array[Byte]]
 
-  @deprecated("use JavaByteConsumerRecord", "1.3.0")
-  type KafkaByteConsumerRecord = JavaByteConsumerRecord
-
   /** Alias for Java Kafka `ProducerRecord[Array[Byte], Array[Byte]]`. */
-  type JavaByteProducerRecord =
+  type KafkaByteProducerRecord =
     org.apache.kafka.clients.producer.ProducerRecord[Array[Byte], Array[Byte]]
-
-  @deprecated("use JavaByteProducerRecord", "1.3.0")
-  type KafkaByteProducerRecord = JavaByteProducerRecord
 
   /**
     * Commits offsets in batches of every `n` offsets or time window

--- a/modules/core/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
@@ -81,9 +81,9 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with ForEachTestContainer {
       ()
     }
 
-  implicit final val stringSerializer: JavaSerializer[String] = new StringSerializer
+  implicit final val stringSerializer: KafkaSerializer[String] = new StringSerializer
 
-  implicit final val stringDeserializer: JavaDeserializer[String] = new StringDeserializer
+  implicit final val stringDeserializer: KafkaDeserializer[String] = new StringDeserializer
 
   def createCustomTopic(
     topic: String,
@@ -175,8 +175,8 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with ForEachTestContainer {
     customProperties: Map[String, Object] = Map.empty
   )(
     implicit
-    keyDeserializer: JavaDeserializer[K],
-    valueDeserializer: JavaDeserializer[V]
+    keyDeserializer: KafkaDeserializer[K],
+    valueDeserializer: KafkaDeserializer[V]
   ): (K, V) =
     consumeNumberKeyedMessagesFrom[K, V](topic, 1, customProperties = customProperties)(
       keyDeserializer,
@@ -189,8 +189,8 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with ForEachTestContainer {
     customProperties: Map[String, Object] = Map.empty
   )(
     implicit
-    keyDeserializer: JavaDeserializer[K],
-    valueDeserializer: JavaDeserializer[V]
+    keyDeserializer: KafkaDeserializer[K],
+    valueDeserializer: KafkaDeserializer[V]
   ): List[(K, V)] =
     consumeNumberKeyedMessagesFromTopics(
       Set(topic),
@@ -209,8 +209,8 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with ForEachTestContainer {
     customProperties: Map[String, Object] = Map.empty
   )(
     implicit
-    keyDeserializer: JavaDeserializer[K],
-    valueDeserializer: JavaDeserializer[V]
+    keyDeserializer: KafkaDeserializer[K],
+    valueDeserializer: KafkaDeserializer[V]
   ): Map[String, List[(K, V)]] = {
     val consumerProperties = defaultConsumerProperties ++ customProperties
 
@@ -266,7 +266,7 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with ForEachTestContainer {
   def publishToKafka[T](
     topic: String,
     message: T
-  )(implicit serializer: JavaSerializer[T]): Unit =
+  )(implicit serializer: KafkaSerializer[T]): Unit =
     publishToKafka(
       new KProducer(
         (defaultProducerConfig: Map[String, Object]).asJava,
@@ -294,8 +294,8 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with ForEachTestContainer {
   }
 
   def publishToKafka[K, T](topic: String, messages: Seq[(K, T)])(
-    implicit keySerializer: JavaSerializer[K],
-    serializer: JavaSerializer[T]
+    implicit keySerializer: KafkaSerializer[K],
+    serializer: KafkaSerializer[T]
   ): Unit = {
     val producer =
       new KProducer(

--- a/modules/core/src/test/scala/fs2/kafka/ConsumerRecordSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ConsumerRecordSpec.scala
@@ -14,7 +14,7 @@ final class ConsumerRecordSpec extends BaseSpec {
         f: ConsumerRecord[String, String] => Assertion
       ): Assertion = {
         val record =
-          new JavaByteConsumerRecord(
+          new KafkaByteConsumerRecord(
             "topic",
             0,
             1,
@@ -48,7 +48,7 @@ final class ConsumerRecordSpec extends BaseSpec {
         f: ConsumerRecord[String, String] => Assertion
       ): Assertion = {
         val record =
-          new JavaByteConsumerRecord(
+          new KafkaByteConsumerRecord(
             "topic",
             0,
             1,
@@ -77,7 +77,7 @@ final class ConsumerRecordSpec extends BaseSpec {
         f: ConsumerRecord[String, String] => Assertion
       ): Assertion = {
         val record =
-          new JavaByteConsumerRecord(
+          new KafkaByteConsumerRecord(
             "topic",
             0,
             1,
@@ -106,7 +106,7 @@ final class ConsumerRecordSpec extends BaseSpec {
         f: ConsumerRecord[String, String] => Assertion
       ): Assertion = {
         val record =
-          new JavaByteConsumerRecord(
+          new KafkaByteConsumerRecord(
             "topic",
             0,
             1,

--- a/modules/core/src/test/scala/fs2/kafka/SerializerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/SerializerSpec.scala
@@ -66,7 +66,7 @@ final class SerializerSpec extends BaseCatsSpec with TestInstances {
     val serializer =
       Serializer
         .delegate[IO, Int](
-          new JavaSerializer[Int] {
+          new KafkaSerializer[Int] {
             override def close(): Unit = ()
             override def configure(props: java.util.Map[String, _], isKey: Boolean): Unit = ()
             override def serialize(topic: String, int: Int): Array[Byte] =
@@ -105,7 +105,7 @@ final class SerializerSpec extends BaseCatsSpec with TestInstances {
     val serializer =
       Serializer
         .delegate[IO, Int](
-          new JavaSerializer[Int] {
+          new KafkaSerializer[Int] {
             override def close(): Unit = ()
             override def configure(props: java.util.Map[String, _], isKey: Boolean): Unit = ()
             override def serialize(topic: String, int: Int): Array[Byte] =

--- a/modules/core/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
@@ -28,23 +28,23 @@ final class SyntaxSpec extends BaseSpec {
     }
   }
 
-  describe("JavaHeaders#asScala") {
+  describe("KafkaHeaders#asScala") {
     it("should convert empty") {
-      val JavaHeaders: JavaHeaders =
+      val kafkaHeaders: KafkaHeaders =
         new RecordHeaders()
 
-      assert(JavaHeaders.asScala == Headers.empty)
+      assert(kafkaHeaders.asScala == Headers.empty)
     }
 
     it("should convert non-empty") {
-      val JavaHeaders: JavaHeaders = {
+      val kafkaHeaders: KafkaHeaders = {
         val recordHeaders = new RecordHeaders()
         recordHeaders.add("key", Array())
         recordHeaders
       }
 
       assert {
-        val headers = JavaHeaders.asScala
+        val headers = kafkaHeaders.asScala
         headers.toChain.size == 1 &&
         headers("key").map(_.value.size) == Some(0)
       }


### PR DESCRIPTION
I'm reverting this until we decide about possible package reorganization in #502, so we don't create new aliases that then need to be deprecated.

Reverts fd4s/fs2-kafka#474