### PR TITLE
Rebalance doesn't work reliably fix

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -166,7 +166,6 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
   private[this] def fetch(
     partition: TopicPartition,
     streamId: StreamId,
-    partitionStreamId: PartitionStreamId,
     callback: ((Chunk[CommittableConsumerRecord[F, K, V]], FetchCompletedReason)) => F[Unit]
   ): F[Unit] = {
     val assigned =
@@ -176,7 +175,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
       ref
         .modify { state =>
           val (newState, oldFetch) =
-            state.withFetch(partition, streamId, partitionStreamId, callback)
+            state.withFetch(partition, streamId, callback)
           (newState, (newState, oldFetch))
         }
         .flatMap {
@@ -567,8 +566,8 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
       case Request.Assign(partitions, callback)        => assign(partitions, callback)
       case Request.SubscribePattern(pattern, callback) => subscribe(pattern, callback)
       case Request.Unsubscribe(callback)               => unsubscribe(callback)
-      case Request.Fetch(partition, streamId, partitionStreamId, callback) =>
-        fetch(partition, streamId, partitionStreamId, callback)
+      case Request.Fetch(partition, streamId, callback) =>
+        fetch(partition, streamId, callback)
       case request @ Request.Commit(_, _)            => commit(request)
       case request @ Request.ManualCommitAsync(_, _) => manualCommitAsync(request)
       case request @ Request.ManualCommitSync(_, _)  => manualCommitSync(request)
@@ -634,11 +633,9 @@ private[kafka] object KafkaConsumerActor {
   }
 
   type StreamId = Int
-  type PartitionStreamId = Int
 
   final case class State[F[_], K, V](
     fetches: Map[TopicPartition, Map[StreamId, FetchRequest[F, K, V]]],
-    partitionStreamIds: Map[TopicPartition, PartitionStreamId],
     records: Map[TopicPartition, NonEmptyVector[CommittableConsumerRecord[F, K, V]]],
     pendingCommits: Chain[Request.Commit[F, K, V]],
     onRebalances: Chain[OnRebalance[F, K, V]],
@@ -655,48 +652,29 @@ private[kafka] object KafkaConsumerActor {
     def withFetch(
       partition: TopicPartition,
       streamId: StreamId,
-      partitionStreamId: PartitionStreamId,
       callback: ((Chunk[CommittableConsumerRecord[F, K, V]], FetchCompletedReason)) => F[Unit]
     ): (State[F, K, V], List[FetchRequest[F, K, V]]) = {
       val newFetchRequest =
         FetchRequest(callback)
 
-      val oldPartitionFetches =
+      val oldPartitionFetches: Map[StreamId, FetchRequest[F, K, V]] =
         fetches.getOrElse(partition, Map.empty)
 
-      val oldPartitionFetch =
-        oldPartitionFetches.get(streamId)
+      val newFetches: Map[TopicPartition, Map[StreamId, FetchRequest[F, K, V]]] =
+        fetches.updated(partition, oldPartitionFetches.updated(streamId, newFetchRequest))
 
-      val oldPartitionStreamId =
-        partitionStreamIds.getOrElse(partition, 0)
-
-      val hasMoreRecentPartitionStreamIds =
-        oldPartitionStreamId > partitionStreamId
-
-      val newFetches =
-        fetches.updated(partition, {
-          if (hasMoreRecentPartitionStreamIds) oldPartitionFetches - streamId
-          else oldPartitionFetches.updated(streamId, newFetchRequest)
-        })
-
-      val newPartitionStreamIds =
-        partitionStreamIds.updated(partition, oldPartitionStreamId max partitionStreamId)
-
-      val fetchesToRevoke =
-        if (hasMoreRecentPartitionStreamIds)
-          newFetchRequest :: oldPartitionFetch.toList
-        else oldPartitionFetch.toList
+      val fetchesToRevoke: List[FetchRequest[F, K, V]] =
+        oldPartitionFetches.get(streamId).toList
 
       (
-        copy(fetches = newFetches, partitionStreamIds = newPartitionStreamIds),
+        copy(fetches = newFetches),
         fetchesToRevoke
       )
     }
 
     def withoutFetches(partitions: Set[TopicPartition]): State[F, K, V] =
       copy(
-        fetches = fetches.filterKeysStrict(!partitions.contains(_)),
-        partitionStreamIds = partitionStreamIds.filterKeysStrict(!partitions.contains(_))
+        fetches = fetches.filterKeysStrict(!partitions.contains(_))
       )
 
     def withRecords(
@@ -707,7 +685,6 @@ private[kafka] object KafkaConsumerActor {
     def withoutFetchesAndRecords(partitions: Set[TopicPartition]): State[F, K, V] =
       copy(
         fetches = fetches.filterKeysStrict(!partitions.contains(_)),
-        partitionStreamIds = partitionStreamIds.filterKeysStrict(!partitions.contains(_)),
         records = records.filterKeysStrict(!partitions.contains(_))
       )
 
@@ -743,17 +720,7 @@ private[kafka] object KafkaConsumerActor {
               append(fs.mkString("[", ", ", "]"))
           }("", ", ", "")
 
-      val partitionStreamIdsString =
-        partitionStreamIds.toList
-          .sortBy { case (tp, _) => tp }
-          .mkStringAppend {
-            case (append, (tp, id)) =>
-              append(tp.toString)
-              append(" -> ")
-              append(id.toString)
-          }("", ", ", "")
-
-      s"State(fetches = Map($fetchesString), partitionStreamIds = Map($partitionStreamIdsString), records = Map(${recordsString(records)}), pendingCommits = $pendingCommits, onRebalances = $onRebalances, rebalancing = $rebalancing, subscribed = $subscribed, streaming = $streaming)"
+      s"State(fetches = Map($fetchesString), records = Map(${recordsString(records)}), pendingCommits = $pendingCommits, onRebalances = $onRebalances, rebalancing = $rebalancing, subscribed = $subscribed, streaming = $streaming)"
     }
   }
 
@@ -761,7 +728,6 @@ private[kafka] object KafkaConsumerActor {
     def empty[F[_], K, V]: State[F, K, V] =
       State(
         fetches = Map.empty,
-        partitionStreamIds = Map.empty,
         records = Map.empty,
         pendingCommits = Chain.empty,
         onRebalances = Chain.empty,
@@ -830,7 +796,6 @@ private[kafka] object KafkaConsumerActor {
     final case class Fetch[F[_], K, V](
       partition: TopicPartition,
       streamId: StreamId,
-      partitionStreamId: PartitionStreamId,
       callback: ((Chunk[CommittableConsumerRecord[F, K, V]], FetchCompletedReason)) => F[Unit]
     ) extends Request[F, K, V]
 


### PR DESCRIPTION
This is a fix for #532

Some words about expected behavior. fs2 is a pull-based library: stream will not push the new step until the previous step is completed. So, if we have a `flatMap` on a stream, the next step will be executed only when the current inner stream completes. Projecting this onto our situation, if we have a code like this: 
```scala
consumer.partitionsMapStream.flatMap { assignment =>
  val innerStream = handle(assignment)
  innerStream
} 
```
the next assignment will be received only when the `innerStream` finished. If `innerStream` is based on partition streams from the `assignment`, it will automatically work: on rebalance, old streams are finished, and `innerStream` is finished too. And this is the expected behavior.

But sometimes not all old partition streams finished. And that's why the rebalance doesn't work. I added a test case for this, which is failed on the current stable branch.

Actually, I didn't found a root cause for this issue. Mostly because the current solution for the finishing old partition streams is pretty complex, and also distributed across multiple files (`KafkaConsumer` and `KafkaConsumerActor`). I decided to try to change and simplify old partition streams completion logic. And it worked.

In my implementation I don't try to track all partition streams with `partitionStreamId`. I just interrupt old partition streams on rebalance. Actually, this is a lot closer to the kafka ideology: when the partition revoked, I interrupt old streams. When the partition assigned, I create new streams for each partition. It turns out that having `Ref[F, Deferred[F, Unit]]` is enough for this. On each rebalance I created a new `Deferred` and saved it in `Ref`, and at the same time, I completed the old `Deferred`. Each partition stream in a current assignment subscribed on the `Deferred` from the current assignment, and when it completes, streams interrupts. All logic is in the one method `partitionsMapStream`.

Because of a new logic for closing old partition streams functionality with tracking `partitionStreamId` is redundant now. So, I deleted it. I think it removes a bit of the inner complexity of a library.