### PR TITLE
Decouple resource instantiation from settings

### DIFF
--- a/docs/src/main/mdoc/admin.md
+++ b/docs/src/main/mdoc/admin.md
@@ -19,11 +19,6 @@ import fs2.kafka._
 
 [`AdminClientSettings`][adminclientsettings] is provided to avoid having to deal with `String` key-value settings.
 
-```scala mdoc:silent
-def adminClientSettings[F[_]: Sync](bootstrapServers: String): AdminClientSettings[F] =
-  AdminClientSettings[F].withBootstrapServers(bootstrapServers)
-```
-
 ### Default Settings
 
 There are several settings specific to the library.
@@ -40,7 +35,7 @@ Once settings are defined, we can use create an admin client in a `Stream`.
 def kafkaAdminClientStream[F[_]: Async](
   bootstrapServers: String
 ): Stream[F, KafkaAdminClient[F]] =
-  KafkaAdminClient.stream(adminClientSettings[F](bootstrapServers))
+  KafkaAdminClient.stream[F](AdminClientSettings(bootstrapServers))
 ```
 
 Alternatively, we can create an admin client in a `Resource` context.
@@ -49,7 +44,7 @@ Alternatively, we can create an admin client in a `Resource` context.
 def kafkaAdminClientResource[F[_]: Async](
   bootstrapServers: String
 ): Resource[F, KafkaAdminClient[F]] =
-  KafkaAdminClient.resource(adminClientSettings[F](bootstrapServers))
+  KafkaAdminClient.resource[F](AdminClientSettings(bootstrapServers))
 ```
 
 ## Topics

--- a/modules/core/src/main/scala/fs2/kafka/AdminClientSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/AdminClientSettings.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
   * [[AdminClientSettings]] instances are immutable and all modification
   * functions return a new [[AdminClientSettings]] instance.<br>
   * <br>
-  * Use [[AdminClientSettings.apply]] for the default settings, and
+  * Use [[AdminClientSettings#apply]] for the default settings, and
   * then apply any desired modifications on top of that instance.
   */
 sealed abstract class AdminClientSettings {

--- a/modules/core/src/main/scala/fs2/kafka/AdminClientSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/AdminClientSettings.scala
@@ -6,10 +6,8 @@
 
 package fs2.kafka
 
-import cats.effect.Sync
 import cats.Show
-import fs2.kafka.internal.converters.collection._
-import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig}
+import org.apache.kafka.clients.admin.AdminClientConfig
 import scala.concurrent.duration._
 
 /**
@@ -22,10 +20,10 @@ import scala.concurrent.duration._
   * [[AdminClientSettings]] instances are immutable and all modification
   * functions return a new [[AdminClientSettings]] instance.<br>
   * <br>
-  * Use [[AdminClientSettings#apply]] for the default settings, and
+  * Use [[AdminClientSettings.apply]] for the default settings, and
   * then apply any desired modifications on top of that instance.
   */
-sealed abstract class AdminClientSettings[F[_]] {
+sealed abstract class AdminClientSettings {
 
   /**
     * Properties which can be provided when creating a Java `KafkaAdminClient`
@@ -43,7 +41,7 @@ sealed abstract class AdminClientSettings[F[_]] {
     * AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG
     * }}}
     */
-  def withBootstrapServers(bootstrapServers: String): AdminClientSettings[F]
+  def withBootstrapServers(bootstrapServers: String): AdminClientSettings
 
   /**
     * Returns a new [[AdminClientSettings]] instance with the specified
@@ -54,7 +52,7 @@ sealed abstract class AdminClientSettings[F[_]] {
     * AdminClientConfig.CLIENT_ID_CONFIG
     * }}}
     */
-  def withClientId(clientId: String): AdminClientSettings[F]
+  def withClientId(clientId: String): AdminClientSettings
 
   /**
     * Returns a new [[AdminClientSettings]] instance with the specified
@@ -66,7 +64,7 @@ sealed abstract class AdminClientSettings[F[_]] {
     * AdminClientConfig.RECONNECT_BACKOFF_MS_CONFIG
     * }}}
     */
-  def withReconnectBackoff(reconnectBackoff: FiniteDuration): AdminClientSettings[F]
+  def withReconnectBackoff(reconnectBackoff: FiniteDuration): AdminClientSettings
 
   /**
     * Returns a new [[AdminClientSettings]] instance with the specified
@@ -78,7 +76,7 @@ sealed abstract class AdminClientSettings[F[_]] {
     * AdminClientConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG
     * }}}
     */
-  def withReconnectBackoffMax(reconnectBackoffMax: FiniteDuration): AdminClientSettings[F]
+  def withReconnectBackoffMax(reconnectBackoffMax: FiniteDuration): AdminClientSettings
 
   /**
     * Returns a new [[AdminClientSettings]] instance with the specified
@@ -90,7 +88,7 @@ sealed abstract class AdminClientSettings[F[_]] {
     * AdminClientConfig.RETRY_BACKOFF_MS_CONFIG
     * }}}
     */
-  def withRetryBackoff(retryBackoff: FiniteDuration): AdminClientSettings[F]
+  def withRetryBackoff(retryBackoff: FiniteDuration): AdminClientSettings
 
   /**
     * Returns a new [[AdminClientSettings]] instance with the specified
@@ -102,7 +100,7 @@ sealed abstract class AdminClientSettings[F[_]] {
     * AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG
     * }}}
     */
-  def withConnectionsMaxIdle(connectionsMaxIdle: FiniteDuration): AdminClientSettings[F]
+  def withConnectionsMaxIdle(connectionsMaxIdle: FiniteDuration): AdminClientSettings
 
   /**
     * Returns a new [[AdminClientSettings]] instance with the specified
@@ -114,7 +112,7 @@ sealed abstract class AdminClientSettings[F[_]] {
     * AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG
     * }}}
     */
-  def withRequestTimeout(requestTimeout: FiniteDuration): AdminClientSettings[F]
+  def withRequestTimeout(requestTimeout: FiniteDuration): AdminClientSettings
 
   /**
     * Returns a new [[AdminClientSettings]] instance with the specified
@@ -126,7 +124,7 @@ sealed abstract class AdminClientSettings[F[_]] {
     * AdminClientConfig.METADATA_MAX_AGE_CONFIG
     * }}}
     */
-  def withMetadataMaxAge(metadataMaxAge: FiniteDuration): AdminClientSettings[F]
+  def withMetadataMaxAge(metadataMaxAge: FiniteDuration): AdminClientSettings
 
   /**
     * Returns a new [[AdminClientSettings]] instance with the specified
@@ -138,28 +136,28 @@ sealed abstract class AdminClientSettings[F[_]] {
     * AdminClientConfig.RETRIES_CONFIG
     * }}}
     */
-  def withRetries(retries: Int): AdminClientSettings[F]
+  def withRetries(retries: Int): AdminClientSettings
 
   /**
     * Includes a property with the specified `key` and `value`.
     * The key should be one of the keys in `AdminClientConfig`,
     * and the value should be a valid choice for the key.
     */
-  def withProperty(key: String, value: String): AdminClientSettings[F]
+  def withProperty(key: String, value: String): AdminClientSettings
 
   /**
     * Includes the specified keys and values as properties. The
     * keys should be part of the `AdminClientConfig` keys, and
     * the values should be valid choices for the keys.
     */
-  def withProperties(properties: (String, String)*): AdminClientSettings[F]
+  def withProperties(properties: (String, String)*): AdminClientSettings
 
   /**
     * Includes the specified keys and values as properties. The
     * keys should be part of the `AdminClientConfig` keys, and
     * the values should be valid choices for the keys.
     */
-  def withProperties(properties: Map[String, String]): AdminClientSettings[F]
+  def withProperties(properties: Map[String, String]): AdminClientSettings
 
   /**
     * The time to wait for the Java `KafkaAdminClient` to shutdown.<br>
@@ -171,39 +169,22 @@ sealed abstract class AdminClientSettings[F[_]] {
   /**
     * Creates a new [[AdminClientSettings]] with the specified [[closeTimeout]].
     */
-  def withCloseTimeout(closeTimeout: FiniteDuration): AdminClientSettings[F]
-
-  /**
-    * Creates a new `KafkaAdminClient` using the [[properties]]. Note that
-    * this operation should be bracketed, using e.g. `Resource`, to ensure
-    * the `close` function on the admin client is called.
-    */
-  def createAdminClient: F[AdminClient]
-
-  /**
-    * Creates a new [[AdminClientSettings]] with the specified function for
-    * creating `AdminClient` instances in [[createAdminClient]]. The argument
-    * is the [[properties]] of the settings instance.
-    */
-  def withCreateAdminClient(
-    createAdminClient: Map[String, String] => F[AdminClient]
-  ): AdminClientSettings[F]
+  def withCloseTimeout(closeTimeout: FiniteDuration): AdminClientSettings
 }
 
 object AdminClientSettings {
-  private[this] final case class AdminClientSettingsImpl[F[_]](
+  private[this] final case class AdminClientSettingsImpl(
     override val properties: Map[String, String],
-    override val closeTimeout: FiniteDuration,
-    val createAdminClientWith: Map[String, String] => F[AdminClient]
-  ) extends AdminClientSettings[F] {
+    override val closeTimeout: FiniteDuration
+  ) extends AdminClientSettings {
 
-    override def withBootstrapServers(bootstrapServers: String): AdminClientSettings[F] =
+    override def withBootstrapServers(bootstrapServers: String): AdminClientSettings =
       withProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
 
-    override def withClientId(clientId: String): AdminClientSettings[F] =
+    override def withClientId(clientId: String): AdminClientSettings =
       withProperty(AdminClientConfig.CLIENT_ID_CONFIG, clientId)
 
-    override def withReconnectBackoff(reconnectBackoff: FiniteDuration): AdminClientSettings[F] =
+    override def withReconnectBackoff(reconnectBackoff: FiniteDuration): AdminClientSettings =
       withProperty(
         AdminClientConfig.RECONNECT_BACKOFF_MS_CONFIG,
         reconnectBackoff.toMillis.toString
@@ -211,68 +192,61 @@ object AdminClientSettings {
 
     override def withReconnectBackoffMax(
       reconnectBackoffMax: FiniteDuration
-    ): AdminClientSettings[F] =
+    ): AdminClientSettings =
       withProperty(
         AdminClientConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG,
         reconnectBackoffMax.toMillis.toString
       )
 
-    override def withRetryBackoff(retryBackoff: FiniteDuration): AdminClientSettings[F] =
+    override def withRetryBackoff(retryBackoff: FiniteDuration): AdminClientSettings =
       withProperty(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG, retryBackoff.toMillis.toString)
 
     override def withConnectionsMaxIdle(
       connectionsMaxIdle: FiniteDuration
-    ): AdminClientSettings[F] =
+    ): AdminClientSettings =
       withProperty(
         AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG,
         connectionsMaxIdle.toMillis.toString
       )
 
-    override def withRequestTimeout(requestTimeout: FiniteDuration): AdminClientSettings[F] =
+    override def withRequestTimeout(requestTimeout: FiniteDuration): AdminClientSettings =
       withProperty(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeout.toMillis.toString)
 
-    override def withMetadataMaxAge(metadataMaxAge: FiniteDuration): AdminClientSettings[F] =
+    override def withMetadataMaxAge(metadataMaxAge: FiniteDuration): AdminClientSettings =
       withProperty(AdminClientConfig.METADATA_MAX_AGE_CONFIG, metadataMaxAge.toMillis.toString)
 
-    override def withRetries(retries: Int): AdminClientSettings[F] =
+    override def withRetries(retries: Int): AdminClientSettings =
       withProperty(AdminClientConfig.RETRIES_CONFIG, retries.toString)
 
-    override def withProperty(key: String, value: String): AdminClientSettings[F] =
+    override def withProperty(key: String, value: String): AdminClientSettings =
       copy(properties = properties.updated(key, value))
 
-    override def withProperties(properties: (String, String)*): AdminClientSettings[F] =
+    override def withProperties(properties: (String, String)*): AdminClientSettings =
       copy(properties = this.properties ++ properties.toMap)
 
-    override def withProperties(properties: Map[String, String]): AdminClientSettings[F] =
+    override def withProperties(properties: Map[String, String]): AdminClientSettings =
       copy(properties = this.properties ++ properties)
 
-    override def withCloseTimeout(closeTimeout: FiniteDuration): AdminClientSettings[F] =
+    override def withCloseTimeout(closeTimeout: FiniteDuration): AdminClientSettings =
       copy(closeTimeout = closeTimeout)
-
-    override def createAdminClient: F[AdminClient] =
-      createAdminClientWith(properties)
-
-    override def withCreateAdminClient(
-      createAdminClientWith: Map[String, String] => F[AdminClient]
-    ): AdminClientSettings[F] =
-      copy(createAdminClientWith = createAdminClientWith)
 
     override def toString: String =
       s"AdminClientSettings(closeTimeout = $closeTimeout)"
   }
 
-  def apply[F[_]](implicit F: Sync[F]): AdminClientSettings[F] =
+  @deprecated("use the overload that takes an argument for BootstrapSettings", "2.0.0")
+  def apply: AdminClientSettings =
     AdminClientSettingsImpl(
       properties = Map.empty,
-      closeTimeout = 20.seconds,
-      createAdminClientWith = properties =>
-        F.blocking {
-          AdminClient.create {
-            (properties: Map[String, AnyRef]).asJava
-          }
-        }
+      closeTimeout = 20.seconds
     )
 
-  implicit def adminClientSettingsShow[F[_]]: Show[AdminClientSettings[F]] =
+  def apply(bootstrapServers: String): AdminClientSettings =
+    AdminClientSettingsImpl(
+      properties = Map.empty,
+      closeTimeout = 20.seconds
+    ).withBootstrapServers(bootstrapServers)
+
+  implicit def adminClientSettingsShow[F[_]]: Show[AdminClientSettings] =
     Show.fromToString
 }

--- a/modules/core/src/main/scala/fs2/kafka/AdminClientSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/AdminClientSettings.scala
@@ -234,7 +234,7 @@ object AdminClientSettings {
       s"AdminClientSettings(closeTimeout = $closeTimeout)"
   }
 
-  @deprecated("use the overload that takes an argument for BootstrapSettings", "2.0.0")
+  @deprecated("use the overload that takes an argument for BootstrapServers", "2.0.0")
   def apply: AdminClientSettings =
     AdminClientSettingsImpl(
       properties = Map.empty,

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -559,7 +559,8 @@ object KafkaConsumer {
   def resource[F[_], K, V](
     settings: ConsumerSettings[F, K, V]
   )(
-    implicit F: Async[F]
+    implicit F: Async[F],
+    mk: MkConsumer[F]
   ): Resource[F, KafkaConsumer[F, K, V]] =
     for {
       keyDeserializer <- Resource.eval(settings.keyDeserializer)
@@ -573,7 +574,7 @@ object KafkaConsumer {
       streamId <- Resource.eval(Ref.of[F, StreamId](0))
       dispatcher <- Dispatcher[F]
       stopConsumingDeferred <- Resource.eval(Deferred[F, Unit])
-      withConsumer <- WithConsumer(settings)
+      withConsumer <- WithConsumer(settings, mk)
       actor = {
         implicit val jitter0: Jitter[F] = jitter
         implicit val logging0: Logging[F] = logging

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -574,7 +574,7 @@ object KafkaConsumer {
       streamId <- Resource.eval(Ref.of[F, StreamId](0))
       dispatcher <- Dispatcher[F]
       stopConsumingDeferred <- Resource.eval(Deferred[F, Unit])
-      withConsumer <- WithConsumer(settings, mk)
+      withConsumer <- WithConsumer(mk, settings)
       actor = {
         implicit val jitter0: Jitter[F] = jitter
         implicit val logging0: Logging[F] = logging
@@ -613,8 +613,8 @@ object KafkaConsumer {
     * KafkaConsumer.stream[F].using(settings)
     * }}}
     */
-  def stream[F[_], K, V](settings: ConsumerSettings[F, K, V])(
-    implicit F: Async[F]
+  def stream[F[_]: Async: MkConsumer, K, V](
+    settings: ConsumerSettings[F, K, V]
   ): Stream[F, KafkaConsumer[F, K, V]] =
     Stream.resource(resource(settings))
 
@@ -635,7 +635,8 @@ object KafkaConsumer {
       * }}}
       */
     def resource[K, V](settings: ConsumerSettings[F, K, V])(
-      implicit F: Async[F]
+      implicit F: Async[F],
+      mk: MkConsumer[F]
     ): Resource[F, KafkaConsumer[F, K, V]] =
       KafkaConsumer.resource(settings)
 
@@ -650,7 +651,8 @@ object KafkaConsumer {
       * }}}
       */
     def stream[K, V](settings: ConsumerSettings[F, K, V])(
-      implicit F: Async[F]
+      implicit F: Async[F],
+      mk: MkConsumer[F]
     ): Stream[F, KafkaConsumer[F, K, V]] =
       KafkaConsumer.stream(settings)
 

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
@@ -11,6 +11,7 @@ import cats.implicits._
 import fs2.Stream
 import fs2.kafka.internal._
 import cats.effect.std.Dispatcher
+import fs2.kafka.producer.MkProducer
 
 /**
   * [[KafkaProducerConnection]] represents a connection to a Kafka broker
@@ -72,10 +73,11 @@ object KafkaProducerConnection {
   def resource[F[_]](
     settings: ProducerSettings[F, _, _]
   )(
-    implicit F: Async[F]
+    implicit F: Async[F],
+    mk: MkProducer[F]
   ): Resource[F, KafkaProducerConnection[F]] =
     Dispatcher[F].flatMap { implicit dispatcher =>
-      WithProducer(settings).map { withProducer =>
+      WithProducer(mk, settings).map { withProducer =>
         new KafkaProducerConnection[F] {
           override def withSerializers[K, V](
             keySerializer: Serializer[F, K],

--- a/modules/core/src/main/scala/fs2/kafka/admin/MkAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/admin/MkAdminClient.scala
@@ -8,9 +8,20 @@ package fs2.kafka.admin
 
 import cats.effect.Sync
 import fs2.kafka.AdminClientSettings
+import fs2.kafka.consumer.MkConsumer
 import org.apache.kafka.clients.admin.AdminClient
 import fs2.kafka.internal.converters.collection._
 
+/**
+  * A capability trait representing the ability to instantiate the Java
+  * `AdminClient` that underlies the fs2-kafka `KafkaAdminClient`. This
+  * is needed in order to instantiate [[fs2.kafka.KafkaAdminClient]].
+  *
+  * By default, the instance provided by [[MkAdminClient.mkAdminClientForSync]]
+  * will be used. However this behaviour can be overridden, e.g. for
+  * testing purposes, by placing an alternative implicit instance in
+  * lexical scope.
+  */
 trait MkAdminClient[F[_]] {
   def apply(settings: AdminClientSettings): F[AdminClient]
 }

--- a/modules/core/src/main/scala/fs2/kafka/admin/MkAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/admin/MkAdminClient.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2018-2021 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package fs2.kafka.admin
 
 import cats.effect.Sync

--- a/modules/core/src/main/scala/fs2/kafka/admin/MkAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/admin/MkAdminClient.scala
@@ -1,0 +1,20 @@
+package fs2.kafka.admin
+
+import cats.effect.Sync
+import fs2.kafka.AdminClientSettings
+import org.apache.kafka.clients.admin.AdminClient
+import fs2.kafka.internal.converters.collection._
+
+trait MkAdminClient[F[_]] {
+  def apply(settings: AdminClientSettings): F[AdminClient]
+}
+
+object MkAdminClient {
+  implicit def mkAdminClientForSync[F[_]](implicit F: Sync[F]): MkAdminClient[F] =
+    settings =>
+      F.blocking {
+        AdminClient.create {
+          (settings.properties: Map[String, AnyRef]).asJava
+        }
+      }
+}

--- a/modules/core/src/main/scala/fs2/kafka/admin/MkAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/admin/MkAdminClient.scala
@@ -8,7 +8,6 @@ package fs2.kafka.admin
 
 import cats.effect.Sync
 import fs2.kafka.AdminClientSettings
-import fs2.kafka.consumer.MkConsumer
 import org.apache.kafka.clients.admin.AdminClient
 import fs2.kafka.internal.converters.collection._
 

--- a/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2018-2021 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package fs2.kafka.consumer
 
 import cats.effect.Sync

--- a/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
@@ -1,0 +1,23 @@
+package fs2.kafka.consumer
+
+import cats.effect.Sync
+import fs2.kafka.KafkaByteConsumer
+import fs2.kafka.internal.converters.collection._
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+
+trait MkConsumer[F[_]] {
+  def make(properties: Map[String, String]): F[KafkaByteConsumer]
+}
+
+object MkConsumer {
+  implicit def mkConsumerForSync[F[_]](implicit F: Sync[F]): MkConsumer[F] =
+    properties =>
+      F.delay {
+        val byteArrayDeserializer = new ByteArrayDeserializer
+        new org.apache.kafka.clients.consumer.KafkaConsumer(
+          (properties: Map[String, AnyRef]).asJava,
+          byteArrayDeserializer,
+          byteArrayDeserializer
+        )
+      }
+}

--- a/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
@@ -1,21 +1,21 @@
 package fs2.kafka.consumer
 
 import cats.effect.Sync
-import fs2.kafka.KafkaByteConsumer
+import fs2.kafka.{ConsumerSettings, KafkaByteConsumer}
 import fs2.kafka.internal.converters.collection._
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 
 trait MkConsumer[F[_]] {
-  def make(properties: Map[String, String]): F[KafkaByteConsumer]
+  def apply(settings: ConsumerSettings[F, _, _]): F[KafkaByteConsumer]
 }
 
 object MkConsumer {
   implicit def mkConsumerForSync[F[_]](implicit F: Sync[F]): MkConsumer[F] =
-    properties =>
+    settings =>
       F.delay {
         val byteArrayDeserializer = new ByteArrayDeserializer
         new org.apache.kafka.clients.consumer.KafkaConsumer(
-          (properties: Map[String, AnyRef]).asJava,
+          (settings.properties: Map[String, AnyRef]).asJava,
           byteArrayDeserializer,
           byteArrayDeserializer
         )

--- a/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
@@ -11,6 +11,16 @@ import fs2.kafka.{ConsumerSettings, KafkaByteConsumer}
 import fs2.kafka.internal.converters.collection._
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 
+/**
+  * A capability trait representing the ability to instantiate the Java
+  * `Consumer` that underlies the fs2-kafka `KafkaConsumer`. This is needed
+  * in order to instantiate [[fs2.kafka.KafkaConsumer]].
+  *
+  * By default, the instance provided by [[MkConsumer.mkConsumerForSync]]
+  * will be used. However this behaviour can be overridden, e.g. for
+  * testing purposes, by placing an alternative implicit instance in
+  * lexical scope.
+  */
 trait MkConsumer[F[_]] {
   def apply(settings: ConsumerSettings[F, _, _]): F[KafkaByteConsumer]
 }

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithAdminClient.scala
@@ -6,9 +6,10 @@
 
 package fs2.kafka.internal
 
-import cats.effect.{Resource, Async}
+import cats.effect.{Async, Resource}
 import cats.implicits._
 import fs2.kafka.AdminClientSettings
+import fs2.kafka.admin.MkAdminClient
 import fs2.kafka.internal.syntax._
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.common.KafkaFuture
@@ -19,10 +20,11 @@ private[kafka] sealed abstract class WithAdminClient[F[_]] {
 
 private[kafka] object WithAdminClient {
   def apply[F[_]](
-    settings: AdminClientSettings[F]
+    mk: MkAdminClient[F],
+    settings: AdminClientSettings
   )(implicit F: Async[F]): Resource[F, WithAdminClient[F]] =
     Resource[F, WithAdminClient[F]] {
-      settings.createAdminClient.map { adminClient =>
+      mk(settings).map { adminClient =>
         val withAdminClient =
           new WithAdminClient[F] {
             override def apply[A](f: AdminClient => KafkaFuture[A]): F[A] =

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
@@ -29,7 +29,7 @@ private[kafka] object WithConsumer {
     implicit F: Async[F]
   ): Resource[F, WithConsumer[F]] =
     Resource.make {
-      (mk.make(settings.properties), Semaphore[F](1L))
+      (mk(settings), Semaphore[F](1L))
         .mapN { (consumer, semaphore) =>
           new WithConsumer[F] {
             override def apply[A](f: (KafkaByteConsumer, Blocking[F]) => F[A]): F[A] =

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
@@ -6,10 +6,11 @@
 
 package fs2.kafka.internal
 
-import cats.effect.{Resource, Async}
+import cats.effect.{Async, Resource}
 import cats.effect.std.Semaphore
 import cats.implicits._
-import fs2.kafka.{KafkaByteConsumer, ConsumerSettings}
+import fs2.kafka.consumer.MkConsumer
+import fs2.kafka.{ConsumerSettings, KafkaByteConsumer}
 import fs2.kafka.internal.syntax._
 
 private[kafka] sealed abstract class WithConsumer[F[_]] {
@@ -22,12 +23,13 @@ private[kafka] sealed abstract class WithConsumer[F[_]] {
 
 private[kafka] object WithConsumer {
   def apply[F[_], K, V](
-    settings: ConsumerSettings[F, K, V]
+    settings: ConsumerSettings[F, K, V],
+    mk: MkConsumer[F]
   )(
     implicit F: Async[F]
   ): Resource[F, WithConsumer[F]] =
     Resource.make {
-      (settings.createConsumer, Semaphore[F](1L))
+      (mk.make(settings.properties), Semaphore[F](1L))
         .mapN { (consumer, semaphore) =>
           new WithConsumer[F] {
             override def apply[A](f: (KafkaByteConsumer, Blocking[F]) => F[A]): F[A] =

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
@@ -23,8 +23,8 @@ private[kafka] sealed abstract class WithConsumer[F[_]] {
 
 private[kafka] object WithConsumer {
   def apply[F[_], K, V](
-    settings: ConsumerSettings[F, K, V],
-    mk: MkConsumer[F]
+    mk: MkConsumer[F],
+    settings: ConsumerSettings[F, K, V]
   )(
     implicit F: Async[F]
   ): Resource[F, WithConsumer[F]] =

--- a/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
@@ -7,7 +7,6 @@
 package fs2.kafka.producer
 
 import cats.effect.Sync
-import fs2.kafka.consumer.MkConsumer
 import fs2.kafka.{KafkaByteProducer, ProducerSettings}
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import fs2.kafka.internal.converters.collection._

--- a/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
@@ -1,0 +1,23 @@
+package fs2.kafka.producer
+
+import cats.effect.Sync
+import fs2.kafka.{KafkaByteProducer, ProducerSettings}
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import fs2.kafka.internal.converters.collection._
+
+trait MkProducer[F[_]] {
+  def apply(settings: ProducerSettings[F, _, _]): F[KafkaByteProducer]
+}
+
+object MkProducer {
+  implicit def mkProducerForSync[F[_]](implicit F: Sync[F]): MkProducer[F] =
+    settings =>
+      F.delay {
+        val byteArraySerializer = new ByteArraySerializer
+        new org.apache.kafka.clients.producer.KafkaProducer(
+          (settings.properties: Map[String, AnyRef]).asJava,
+          byteArraySerializer,
+          byteArraySerializer
+        )
+      }
+}

--- a/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
@@ -7,10 +7,22 @@
 package fs2.kafka.producer
 
 import cats.effect.Sync
+import fs2.kafka.consumer.MkConsumer
 import fs2.kafka.{KafkaByteProducer, ProducerSettings}
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import fs2.kafka.internal.converters.collection._
 
+/**
+  * A capability trait representing the ability to instantiate the Java
+  * `Producer` that underlies the fs2-kafka `KafkaProducer`. This is needed
+  * in order to instantiate [[fs2.kafka.KafkaProducer]] and
+  * [[fs2.kafka.TransactionalKafkaProducer]].
+  *
+  * By default, the instance provided by [[MkProducer.mkProducerForSync]]
+  * will be used. However this behaviour can be overridden, e.g. for
+  * testing purposes, by placing an alternative implicit instance in
+  * lexical scope.
+  */
 trait MkProducer[F[_]] {
   def apply(settings: ProducerSettings[F, _, _]): F[KafkaByteProducer]
 }

--- a/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2018-2021 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package fs2.kafka.producer
 
 import cats.effect.Sync

--- a/modules/core/src/test/scala/fs2/kafka/AdminClientSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/AdminClientSettingsSpec.scala
@@ -1,10 +1,8 @@
 package fs2.kafka
 
-import cats.effect.{IO}
 import cats.implicits._
 import org.apache.kafka.clients.admin.AdminClientConfig
 import scala.concurrent.duration._
-import cats.effect.unsafe.implicits.global
 
 final class AdminClientSettingsSpec extends BaseSpec {
   describe("AdminClientSettings") {
@@ -119,17 +117,6 @@ final class AdminClientSettingsSpec extends BaseSpec {
       }
     }
 
-    it("should provide withCreateAdminClient") {
-      assert {
-        settings
-          .withCreateAdminClient(_ => IO.raiseError(new RuntimeException))
-          .createAdminClient
-          .attempt
-          .unsafeRunSync()
-          .isLeft
-      }
-    }
-
     it("should have a Show instance and matching toString") {
       assert {
         settings.toString == "AdminClientSettings(closeTimeout = 20 seconds)" &&
@@ -138,6 +125,6 @@ final class AdminClientSettingsSpec extends BaseSpec {
     }
   }
 
-  val settings =
-    AdminClientSettings[IO]
+  def settings =
+    AdminClientSettings("test")
 }

--- a/modules/core/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
@@ -26,7 +26,7 @@ This file contains code derived from the Embedded Kafka library
  */
 package fs2.kafka
 
-import cats.effect.{IO, Sync}
+import cats.effect.Sync
 import fs2.kafka.internal.converters.collection._
 import java.util.UUID
 
@@ -40,7 +40,7 @@ import org.apache.kafka.clients.producer.{
   KafkaProducer => KProducer,
   ProducerRecord => KProducerRecord
 }
-import org.apache.kafka.common.serialization.{ByteArrayDeserializer}
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
 
 import scala.concurrent.duration._
 import org.apache.kafka.clients.admin.NewTopic
@@ -120,12 +120,8 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with ForEachTestContainer {
     res
   }
 
-  final def adminClientProperties: Map[String, String] =
-    Map(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> container.bootstrapServers)
-
-  final def adminClientSettings: AdminClientSettings[IO] =
-    AdminClientSettings[IO]
-      .withProperties(adminClientProperties)
+  final def adminClientSettings: AdminClientSettings =
+    AdminClientSettings(bootstrapServers = container.bootstrapServers)
 
   final def defaultConsumerProperties: Map[String, String] =
     Map(

--- a/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -223,17 +223,6 @@ final class ConsumerSettingsSpec extends BaseSpec {
       }
     }
 
-    it("should provide withCreateConsumer") {
-      assert {
-        settings
-          .withCreateConsumer(_ => IO.raiseError(new RuntimeException))
-          .createConsumer
-          .attempt
-          .unsafeRunSync()
-          .isLeft
-      }
-    }
-
     it("should provide withRecordMetadata") {
       val record = ConsumerRecord("topic", 0, 0L, "key", "value")
 

--- a/modules/core/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
@@ -115,17 +115,6 @@ final class ProducerSettingsSpec extends BaseSpec {
       }
     }
 
-    it("should provide withCreateProducer") {
-      assert {
-        settings
-          .withCreateProducer(_ => IO.raiseError(new RuntimeException))
-          .createProducer
-          .attempt
-          .unsafeRunSync()
-          .isLeft
-      }
-    }
-
     it("should provide withProperty/withProperties") {
       assert {
         settings.withProperty("a", "b").properties("a").contains("b") &&


### PR DESCRIPTION
This is binary-breaking but mostly source-compatible, so it seems worth doing before 2.0.0 given it's likely to be needed for #553.