### PR TITLE
Add missing MkProducer argument, force compiler errors when they're missing

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
@@ -577,10 +577,10 @@ object KafkaAdminClient {
     * working in a `Stream` context, you might instead prefer to
     * use the [[KafkaAdminClient.resource]].
     */
-  def stream[F[_]: Async: MkAdminClient](
+  def stream[F[_]](
     settings: AdminClientSettings
-  ): Stream[F, KafkaAdminClient[F]] =
-    Stream.resource(KafkaAdminClient.resource(settings))
+  )(implicit F: Async[F], mk: MkAdminClient[F]): Stream[F, KafkaAdminClient[F]] =
+    Stream.resource(KafkaAdminClient.resource(settings)(F, mk))
 
   /*
    * Prevents the default `MkAdminClient` instance from being implicitly available

--- a/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
@@ -11,7 +11,6 @@ import cats.effect._
 import fs2.Stream
 import fs2.kafka.KafkaAdminClient._
 import fs2.kafka.admin.MkAdminClient
-import fs2.kafka.consumer.MkConsumer
 import fs2.kafka.internal.WithAdminClient
 import fs2.kafka.internal.converters.collection._
 import fs2.kafka.internal.syntax._

--- a/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
@@ -11,6 +11,7 @@ import cats.effect._
 import fs2.Stream
 import fs2.kafka.KafkaAdminClient._
 import fs2.kafka.admin.MkAdminClient
+import fs2.kafka.consumer.MkConsumer
 import fs2.kafka.internal.WithAdminClient
 import fs2.kafka.internal.converters.collection._
 import fs2.kafka.internal.syntax._
@@ -19,6 +20,8 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.acl.{AclBinding, AclBindingFilter}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.{Node, TopicPartition}
+
+import scala.annotation.nowarn
 
 /**
   * [[KafkaAdminClient]] represents an admin client for Kafka, which is able to
@@ -579,4 +582,16 @@ object KafkaAdminClient {
     settings: AdminClientSettings
   ): Stream[F, KafkaAdminClient[F]] =
     Stream.resource(KafkaAdminClient.resource(settings))
+
+  /*
+   * Prevents the default `MkAdminClient` instance from being implicitly available
+   * to code defined in this object, ensuring factory methods require an instance
+   * to be provided at the call site.
+   */
+  @nowarn("cat=unused")
+  implicit private def mkAmbig1[F[_]]: MkAdminClient[F] =
+    throw new AssertionError("should not be used")
+  @nowarn("cat=unused")
+  implicit private def mkAmbig2[F[_]]: MkAdminClient[F] =
+    throw new AssertionError("should not be used")
 }

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -24,6 +24,7 @@ import java.util
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.{Metric, MetricName, PartitionInfo, TopicPartition}
 
+import scala.annotation.nowarn
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.FiniteDuration
 import scala.util.matching.Regex
@@ -660,4 +661,15 @@ object KafkaConsumer {
       "ConsumerPartiallyApplied$" + System.identityHashCode(this)
   }
 
+  /*
+   * Prevents the default `MkConsumer` instance from being implicitly available
+   * to code defined in this object, ensuring factory methods require an instance
+   * to be provided at the call site.
+   */
+  @nowarn("cat=unused")
+  implicit private def mkAmbig1[F[_]]: MkConsumer[F] =
+    throw new AssertionError("should not be used")
+  @nowarn("cat=unused")
+  implicit private def mkAmbig2[F[_]]: MkConsumer[F] =
+    throw new AssertionError("should not be used")
 }

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -614,10 +614,10 @@ object KafkaConsumer {
     * KafkaConsumer.stream[F].using(settings)
     * }}}
     */
-  def stream[F[_]: Async: MkConsumer, K, V](
+  def stream[F[_], K, V](
     settings: ConsumerSettings[F, K, V]
-  ): Stream[F, KafkaConsumer[F, K, V]] =
-    Stream.resource(resource(settings))
+  )(implicit F: Async[F], mk: MkConsumer[F]): Stream[F, KafkaConsumer[F, K, V]] =
+    Stream.resource(resource(settings)(F, mk))
 
   def apply[F[_]]: ConsumerPartiallyApplied[F] =
     new ConsumerPartiallyApplied()
@@ -639,7 +639,7 @@ object KafkaConsumer {
       implicit F: Async[F],
       mk: MkConsumer[F]
     ): Resource[F, KafkaConsumer[F, K, V]] =
-      KafkaConsumer.resource(settings)
+      KafkaConsumer.resource(settings)(F, mk)
 
     /**
       * Alternative version of `stream` where the `F[_]` is
@@ -655,7 +655,7 @@ object KafkaConsumer {
       implicit F: Async[F],
       mk: MkConsumer[F]
     ): Stream[F, KafkaConsumer[F, K, V]] =
-      KafkaConsumer.stream(settings)
+      KafkaConsumer.stream(settings)(F, mk)
 
     override def toString: String =
       "ConsumerPartiallyApplied$" + System.identityHashCode(this)

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -17,6 +17,8 @@ import org.apache.kafka.common.{Metric, MetricName}
 import cats.effect.std.Dispatcher
 import fs2.kafka.producer.MkProducer
 
+import scala.annotation.nowarn
+
 /**
   * [[KafkaProducer]] represents a producer of Kafka records, with the
   * ability to produce `ProducerRecord`s using [[produce]]. Records are
@@ -246,4 +248,16 @@ object KafkaProducer {
     override def toString: String =
       "ProducerPartiallyApplied$" + System.identityHashCode(this)
   }
+
+  /*
+   * Prevents the default `MkProducer` instance from being implicitly available
+   * to code defined in this object, ensuring factory methods require an instance
+   * to be provided at the call site.
+   */
+  @nowarn("cat=unused")
+  implicit private def mkAmbig1[F[_]]: MkProducer[F] =
+    throw new AssertionError("should not be used")
+  @nowarn("cat=unused")
+  implicit private def mkAmbig2[F[_]]: MkProducer[F] =
+    throw new AssertionError("should not be used")
 }

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
@@ -13,6 +13,8 @@ import fs2.kafka.internal._
 import cats.effect.std.Dispatcher
 import fs2.kafka.producer.MkProducer
 
+import scala.annotation.nowarn
+
 /**
   * [[KafkaProducerConnection]] represents a connection to a Kafka broker
   * that can be used to create [[KafkaProducer]] instances. All [[KafkaProducer]]
@@ -93,4 +95,16 @@ object KafkaProducerConnection {
         }
       }
     }
+
+  /*
+   * Prevents the default `MkProducer` instance from being implicitly available
+   * to code defined in this object, ensuring factory methods require an instance
+   * to be provided at the call site.
+   */
+  @nowarn("cat=unused")
+  implicit private def mkAmbig1[F[_]]: MkProducer[F] =
+    throw new AssertionError("should not be used")
+  @nowarn("cat=unused")
+  implicit private def mkAmbig2[F[_]]: MkProducer[F] =
+    throw new AssertionError("should not be used")
 }

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
@@ -63,7 +63,7 @@ object KafkaProducerConnection {
   )(
     implicit F: Async[F],
     mk: MkProducer[F]
-  ): Stream[F, KafkaProducerConnection[F]] = Stream.resource(resource(settings))
+  ): Stream[F, KafkaProducerConnection[F]] = Stream.resource(resource(settings)(F, mk))
 
   /**
     * Creates a new [[KafkaProducerConnection]] in the `Resource` context,

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
@@ -59,7 +59,8 @@ object KafkaProducerConnection {
   def stream[F[_]](
     settings: ProducerSettings[F, _, _]
   )(
-    implicit F: Async[F]
+    implicit F: Async[F],
+    mk: MkProducer[F]
   ): Stream[F, KafkaProducerConnection[F]] = Stream.resource(resource(settings))
 
   /**

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -136,7 +136,7 @@ object TransactionalKafkaProducer {
     implicit F: Async[F],
     mk: MkProducer[F]
   ): Stream[F, TransactionalKafkaProducer[F, K, V]] =
-    Stream.resource(resource(settings))
+    Stream.resource(resource(settings)(F, mk))
 
   def apply[F[_]]: TransactionalProducerPartiallyApplied[F] =
     new TransactionalProducerPartiallyApplied
@@ -158,7 +158,7 @@ object TransactionalKafkaProducer {
       implicit F: Async[F],
       mk: MkProducer[F]
     ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
-      TransactionalKafkaProducer.resource(settings)
+      TransactionalKafkaProducer.resource(settings)(F, mk)
 
     /**
       * Alternative version of `stream` where the `F[_]` is
@@ -174,7 +174,7 @@ object TransactionalKafkaProducer {
       implicit F: Async[F],
       mk: MkProducer[F]
     ): Stream[F, TransactionalKafkaProducer[F, K, V]] =
-      TransactionalKafkaProducer.stream(settings)
+      TransactionalKafkaProducer.stream(settings)(F, mk)
 
     override def toString: String =
       "TransactionalProducerPartiallyApplied$" + System.identityHashCode(this)

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -16,6 +16,8 @@ import org.apache.kafka.clients.producer.RecordMetadata
 import cats.effect.std.Dispatcher
 import fs2.kafka.producer.MkProducer
 
+import scala.annotation.nowarn
+
 /**
   * Represents a producer of Kafka records specialized for 'read-process-write'
   * streams, with the ability to atomically produce `ProducerRecord`s and commit
@@ -177,4 +179,16 @@ object TransactionalKafkaProducer {
     override def toString: String =
       "TransactionalProducerPartiallyApplied$" + System.identityHashCode(this)
   }
+
+  /*
+   * Prevents the default `MkProducer` instance from being implicitly available
+   * to code defined in this object, ensuring factory methods require an instance
+   * to be provided at the call site.
+   */
+  @nowarn("cat=unused")
+  implicit private def mkAmbig1[F[_]]: MkProducer[F] =
+    throw new AssertionError("should not be used")
+  @nowarn("cat=unused")
+  implicit private def mkAmbig2[F[_]]: MkProducer[F] =
+    throw new AssertionError("should not be used")
 }


### PR DESCRIPTION
I'm not 100% happy with the added boilerplate, or with it being needed, but I don't have a better idea. Any thoughts?