### PR TITLE
Replace Deferred with Promise in KafkaProducer, remove Dispatcher

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -13,7 +13,6 @@ import fs2.{Chunk, Stream}
 import fs2.kafka.internal._
 import fs2.kafka.internal.converters.collection._
 import org.apache.kafka.clients.producer.RecordMetadata
-import cats.effect.std.Dispatcher
 import fs2.kafka.producer.MkProducer
 
 import scala.annotation.nowarn
@@ -62,11 +61,8 @@ object TransactionalKafkaProducer {
     (
       Resource.eval(settings.producerSettings.keySerializer),
       Resource.eval(settings.producerSettings.valueSerializer),
-      WithProducer(mk, settings),
-      Dispatcher[F]
-    ).mapN { (keySerializer, valueSerializer, withProducer, dispatcher) =>
-      implicit val dispatcher0 = dispatcher
-
+      WithProducer(mk, settings)
+    ).mapN { (keySerializer, valueSerializer, withProducer) =>
       new TransactionalKafkaProducer[F, K, V] {
         override def produce[P](
           records: TransactionalProducerRecords[F, P, K, V]


### PR DESCRIPTION
Something like this will be needed for #553, since Dispatcher is allocated as `Resource[F, Dispatcher[F]]`. This change also removes a potential performance bottleneck (since Dispatcher does everything on a single fiber), and a potential source of bugs around Dispatcher lifecycle (it cancels running fibers when the resource is released - I've seen some error logs in tests relating to this, though I couldn't track down the cause.)