### PR TITLE
Decouple type params of `MkX` traits from type param of settings 

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
@@ -22,13 +22,13 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer
   * lexical scope.
   */
 trait MkConsumer[F[_]] {
-  def apply(settings: ConsumerSettings[F, _, _]): F[KafkaByteConsumer]
+  def apply[G[_]](settings: ConsumerSettings[G, _, _]): F[KafkaByteConsumer]
 }
 
 object MkConsumer {
   implicit def mkConsumerForSync[F[_]](implicit F: Sync[F]): MkConsumer[F] =
-    settings =>
-      F.delay {
+    new MkConsumer[F] {
+      def apply[G[_]](settings: ConsumerSettings[G, _, _]): F[KafkaByteConsumer] = F.delay {
         val byteArrayDeserializer = new ByteArrayDeserializer
         new org.apache.kafka.clients.consumer.KafkaConsumer(
           (settings.properties: Map[String, AnyRef]).asJava,
@@ -36,4 +36,5 @@ object MkConsumer {
           byteArrayDeserializer
         )
       }
+    }
 }

--- a/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
@@ -23,13 +23,13 @@ import fs2.kafka.internal.converters.collection._
   * lexical scope.
   */
 trait MkProducer[F[_]] {
-  def apply(settings: ProducerSettings[F, _, _]): F[KafkaByteProducer]
+  def apply[G[_]](settings: ProducerSettings[G, _, _]): F[KafkaByteProducer]
 }
 
 object MkProducer {
   implicit def mkProducerForSync[F[_]](implicit F: Sync[F]): MkProducer[F] =
-    settings =>
-      F.delay {
+    new MkProducer[F] {
+      def apply[G[_]](settings: ProducerSettings[G, _, _]): F[KafkaByteProducer] = F.delay {
         val byteArraySerializer = new ByteArraySerializer
         new org.apache.kafka.clients.producer.KafkaProducer(
           (settings.properties: Map[String, AnyRef]).asJava,
@@ -37,4 +37,5 @@ object MkProducer {
           byteArraySerializer
         )
       }
+    }
 }


### PR DESCRIPTION
This will be needed for #553, since creating (e.g.) `Resource[F, KafkaProducer[G, K, V]]` will require `MkProducer[F]` but `Producersettings[G, K, V]`.