### PR TITLE
Allow use of custom blocking context for `Consumer` and `Producer`

### DIFF
--- a/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -4,10 +4,21 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import org.apache.kafka.clients.consumer.ConsumerConfig
+
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 final class ConsumerSettingsSpec extends BaseSpec {
   describe("ConsumerSettings") {
+    it("should be able to set a custom blocking context") {
+      assert {
+        settings.customBlockingContext.isEmpty &&
+        settings.withCustomBlockingContext(ExecutionContext.global).customBlockingContext === Some(
+          ExecutionContext.global
+        )
+      }
+    }
+
     it("should provide withBootstrapServers") {
       assert {
         settings

--- a/modules/core/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
@@ -4,6 +4,8 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import org.apache.kafka.clients.producer.ProducerConfig
+
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 final class ProducerSettingsSpec extends BaseSpec {
@@ -159,6 +161,16 @@ final class ProducerSettingsSpec extends BaseSpec {
       ProducerSettings[IO, Int, String].valueSerializer.unsafeRunSync() shouldBe serializerInstance
       ProducerSettings[IO, String, String]
     }
+
+    it("should be able to set a custom blocking context") {
+      assert {
+        settings.customBlockingContext.isEmpty &&
+        settings.withCustomBlockingContext(ExecutionContext.global).customBlockingContext === Some(
+          ExecutionContext.global
+        )
+      }
+    }
+
   }
 
   val settings = ProducerSettings[IO, String, String]


### PR DESCRIPTION
I haven't done this for `AdminClient`, as the only blocking operation we do on `AdminClient` is `close`. However if anyone strongly thinks we should provide it for consistency then I'm open to that.

Resolves #589 