### PR TITLE
Add transactional producer metrics

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/TransactionalProducerResource.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalProducerResource.scala
@@ -28,7 +28,7 @@ final class TransactionalProducerResource[F[_]] private[kafka] (
     */
   def using[K, V](settings: TransactionalProducerSettings[F, K, V])(
     implicit context: ContextShift[F]
-  ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
+  ): Resource[F, TransactionalKafkaProducer.Metrics[F, K, V]] =
     TransactionalKafkaProducer.resource(settings)(F, context)
 
   override def toString: String =

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalProducerStream.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalProducerStream.scala
@@ -29,7 +29,7 @@ final class TransactionalProducerStream[F[_]] private[kafka] (
     */
   def using[K, V](settings: TransactionalProducerSettings[F, K, V])(
     implicit context: ContextShift[F]
-  ): Stream[F, TransactionalKafkaProducer[F, K, V]] =
+  ): Stream[F, TransactionalKafkaProducer.Metrics[F, K, V]] =
     TransactionalKafkaProducer.stream(settings)(F, context)
 
   override def toString: String =

--- a/modules/core/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
@@ -283,4 +283,29 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with EitherValues {
       consumedOrError.isLeft shouldBe true
     }
   }
+
+  it("should get metrics") {
+    withTopic { topic =>
+      createCustomTopic(topic, partitions = 3)
+
+      val info =
+        TransactionalKafkaProducer[IO]
+          .stream(
+            TransactionalProducerSettings(
+              transactionalId = "id",
+              producerSettings = producerSettings[IO].withRetries(Int.MaxValue)
+            )
+          )
+          .evalMap(_.metrics)
+
+      val res =
+        info
+          .take(1)
+          .compile
+          .lastOrError
+          .unsafeRunSync()
+
+      assert(res.nonEmpty)
+    }
+  }
 }


### PR DESCRIPTION
Similar to consumer and producer metrics, expose underlying java client metrics.