### PR TITLE
Add producer convenience methods

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -58,7 +58,8 @@ abstract class KafkaProducer[F[_], K, V] {
 
 object KafkaProducer {
 
-  implicit class ProducerOps[F[_], K, V](private val producer: KafkaProducer[F, K, V]) extends AnyVal {
+  implicit class ProducerOps[F[_], K, V](private val producer: KafkaProducer[F, K, V])
+      extends AnyVal {
 
     /**
       * Produce a single [[ProducerRecord]] without a passthrough value,

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -58,13 +58,13 @@ abstract class KafkaProducer[F[_], K, V] {
 
 object KafkaProducer {
 
-  implicit class ProducerOps[F[_]: Functor, K, V](producer: KafkaProducer[F, K, V]) {
+  implicit class ProducerOps[F[_], K, V](private val producer: KafkaProducer[F, K, V]) extends AnyVal {
 
     /**
       * Produce a single [[ProducerRecord]] without a passthrough value,
       * see [[KafkaProducer.produce]] for general semantics.
       */
-    def produceOne_(record: ProducerRecord[K, V]): F[F[RecordMetadata]] =
+    def produceOne_(record: ProducerRecord[K, V])(implicit F: Functor[F]): F[F[RecordMetadata]] =
       produceOne(record, ()).map(_.map { res =>
         res.records.head.get._2 //Should always be present so get is ok
       })
@@ -73,7 +73,7 @@ object KafkaProducer {
       * Produce a single record to the specified topic using the provided key and value
       * without a passthrough value, see [[KafkaProducer.produce]] for general semantics.
       */
-    def produceOne_(topic: String, key: K, value: V): F[F[RecordMetadata]] =
+    def produceOne_(topic: String, key: K, value: V)(implicit F: Functor[F]): F[F[RecordMetadata]] =
       produceOne_(ProducerRecord(topic, key, value))
 
     /**
@@ -82,7 +82,7 @@ object KafkaProducer {
       */
     def produce_(
       records: ProducerRecords[K, V, _]
-    ): F[F[Chunk[(ProducerRecord[K, V], RecordMetadata)]]] =
+    )(implicit F: Functor[F]): F[F[Chunk[(ProducerRecord[K, V], RecordMetadata)]]] =
       producer.produce(records).map(_.map(_.records))
 
     /**

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -54,14 +54,33 @@ abstract class KafkaProducer[F[_], K, V] {
     records: ProducerRecords[K, V, P]
   ): F[F[ProducerResult[K, V, P]]]
 
+  /**
+    * Produces the specified [[ProducerRecords]] without a passthrough value, 
+    * see [[produce]] for general semantics.
+    */
   def produce_(records: ProducerRecords[K, V, _]): F[F[Chunk[(ProducerRecord[K, V], RecordMetadata)]]]
 
+  /**
+    * Produce a single [[ProducerRecord]], see [[produce]] for general semantics.
+    */
   def produceOne[P](record: ProducerRecord[K, V], passthrough: P): F[F[ProducerResult[K, V, P]]]
 
+  /**
+    * Produce a single record to the specified topic using the provided key and value,
+    * see [[produce]] for general semantics.
+    */
   def produceOne[P](topic: String, key: K, value: V, passthrough: P): F[F[ProducerResult[K, V, P]]]
 
+  /**
+    * Produce a single [[ProducerRecord]] without a passthrough value,
+    * see [[produce]] for general semantics.
+    */
   def produceOne_(producerRecord: ProducerRecord[K, V]): F[F[RecordMetadata]]
   
+  /**
+    * Produce a single record to the specified topic using the provided key and value
+    * without a passthrough value, see [[produce]] for general semantics.
+    */
   def produceOne_(topic: String, key: K, value: V): F[F[RecordMetadata]]
 }
 

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -67,7 +67,7 @@ object KafkaProducer {
       def produceOne_(record: ProducerRecord[K,V]): F[F[RecordMetadata]] = {
         produceOne(record, ()).map(_.flatMap { res =>
           val metadata = res.records.head.map(_._2)
-          MonadError[F,Throwable].fromOption(metadata, new IllegalStateException("Exactly one record metadata should be"))
+          MonadError[F,Throwable].fromOption(metadata, new IllegalStateException("Exactly one record metadata expected"))
         })
       }
 

--- a/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -135,7 +135,6 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
     }
   }
 
-
   it("should produce one without passthrough") {
     withTopic { topic =>
       createCustomTopic(topic, partitions = 3)

--- a/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -137,14 +137,13 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
 
 
   it("should produce one without passthrough") {
-    withKafka { (config, topic) =>
+    withTopic { topic =>
       createCustomTopic(topic, partitions = 3)
       val toProduce = ("some-key" -> "some-value")
 
       val produced =
         (for {
-          settings <- Stream(producerSettings[IO](config))
-          producer <- producerStream[IO].using(settings)
+          producer <- KafkaProducer.stream(producerSettings[IO])
           _ <- Stream.eval(IO(producer.toString should startWith("KafkaProducer$")))
           batched <- Stream
             .eval(producer.produceOne_(ProducerRecord(topic, toProduce._1, toProduce._2)))

--- a/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -156,6 +156,97 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
     }
   }
 
+  it("should produce one from individual topic, key and value without passthrough") {
+    withTopic { topic =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce = ("some-key" -> "some-value")
+
+      val produced =
+        (for {
+          producer <- KafkaProducer.stream(producerSettings[IO])
+          _ <- Stream.eval(IO(producer.toString should startWith("KafkaProducer$")))
+          batched <- Stream
+            .eval(producer.produceOne_(topic, toProduce._1, toProduce._2))
+          _ <- Stream.eval(batched)
+        } yield ()).compile.toVector.unsafeRunSync()
+
+      val consumed =
+        consumeNumberKeyedMessagesFrom[String, String](topic, produced.size)
+
+      consumed should contain only toProduce
+    }
+  }
+
+  it("should produce one") {
+    withTopic { topic =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce = ("some-key" -> "some-value")
+      val passthrough = "passthrough"
+
+      val result =
+        (for {
+          producer <- KafkaProducer.stream(producerSettings[IO])
+          _ <- Stream.eval(IO(producer.toString should startWith("KafkaProducer$")))
+          batched <- Stream
+            .eval(
+              producer.produceOne(ProducerRecord(topic, toProduce._1, toProduce._2), passthrough)
+            )
+          result <- Stream.eval(batched)
+        } yield result).compile.lastOrError.unsafeRunSync()
+
+      assert(result.passthrough == passthrough)
+    }
+  }
+
+  it("should produce one from individual topic, key and value") {
+    withTopic { topic =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce = ("some-key" -> "some-value")
+      val passthrough = "passthrough"
+
+      val result =
+        (for {
+          producer <- KafkaProducer.stream(producerSettings[IO])
+          _ <- Stream.eval(IO(producer.toString should startWith("KafkaProducer$")))
+          batched <- Stream
+            .eval(producer.produceOne(topic, toProduce._1, toProduce._2, passthrough))
+          result <- Stream.eval(batched)
+        } yield result).compile.lastOrError.unsafeRunSync()
+
+      assert(result.passthrough == passthrough)
+    }
+  }
+
+  it("should be able to produce records with multiple without passthrough") {
+    withTopic { topic =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce = (0 until 10).map(n => s"key-$n" -> s"value->$n").toList
+
+      val produced =
+        (for {
+          producer <- KafkaProducer.stream(producerSettings[IO])
+          records = ProducerRecords(toProduce.map {
+            case (key, value) =>
+              ProducerRecord(topic, key, value)
+          }, ())
+          result <- Stream.eval(producer.produce_(records).flatten)
+        } yield result).compile.lastOrError.unsafeRunSync()
+
+      val records =
+        produced.map {
+          case (record, _) =>
+            record.key -> record.value
+        }.toList
+
+      assert(records == toProduce)
+
+      val consumed =
+        consumeNumberKeyedMessagesFrom[String, String](topic, toProduce.size)
+
+      consumed should contain theSameElementsAs toProduce
+    }
+  }
+
   it("should get metrics") {
     withTopic { topic =>
       createCustomTopic(topic, partitions = 3)

--- a/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -135,6 +135,29 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
     }
   }
 
+
+  it("should produce one without passthrough") {
+    withKafka { (config, topic) =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce = ("some-key" -> "some-value")
+
+      val produced =
+        (for {
+          settings <- Stream(producerSettings[IO](config))
+          producer <- producerStream[IO].using(settings)
+          _ <- Stream.eval(IO(producer.toString should startWith("KafkaProducer$")))
+          batched <- Stream
+            .eval(producer.produceOne_(ProducerRecord(topic, toProduce._1, toProduce._2)))
+          _ <- Stream.eval(batched)
+        } yield ()).compile.toVector.unsafeRunSync()
+
+      val consumed =
+        consumeNumberKeyedMessagesFrom[String, String](topic, produced.size)
+
+      consumed should contain only toProduce
+    }
+  }
+
   it("should get metrics") {
     withTopic { topic =>
       createCustomTopic(topic, partitions = 3)


### PR DESCRIPTION
Per suggestions in #446 

Tests are def a bit anaemic, wasn't sure what the right balance between exhaustivity and maintainability was.

Didn't include a `pipe` method as suggested in the original issue as was not clear what the semantics should be (flatten the `F[F[...]]`?), but happy to add if clarified. 