### PR TITLE
Alias `stream` as `records`

### DIFF
--- a/docs/src/main/mdoc/consumers.md
+++ b/docs/src/main/mdoc/consumers.md
@@ -201,7 +201,7 @@ object ConsumerStreamExample extends IOApp {
     val stream =
       KafkaConsumer.stream(consumerSettings)
         .subscribeTo("topic")
-        .stream
+        .records
 
     stream.compile.drain.as(ExitCode.Success)
   }
@@ -221,7 +221,7 @@ object ConsumerPartitionedStreamExample extends IOApp {
     val stream =
       KafkaConsumer.stream(consumerSettings)
         .subscribeTo("topic")
-        .partitionedStream
+        .partitionedRecords
         .map { partitionStream =>
           partitionStream
             .evalMap { committable =>
@@ -262,7 +262,7 @@ object ConsumerMapAsyncExample extends IOApp {
     val stream =
       KafkaConsumer.stream(consumerSettings)
         .subscribeTo("topic")
-        .stream
+        .records
         .mapAsync(25) { committable =>
           processRecord(committable.record)
         }
@@ -289,7 +289,7 @@ object ConsumerCommitBatchExample extends IOApp {
     val stream =
       KafkaConsumer.stream(consumerSettings)
         .subscribeTo("topic")
-        .stream
+        .records
         .mapAsync(25) { committable =>
           processRecord(committable.record)
             .as(committable.offset)

--- a/docs/src/main/mdoc/producers.md
+++ b/docs/src/main/mdoc/producers.md
@@ -171,7 +171,7 @@ object ProduceExample extends IOApp {
     val stream =
       KafkaConsumer.stream(consumerSettings)
         .subscribeTo("topic")
-        .stream
+        .records
         .map { committable =>
           val key = committable.record.key
           val value = committable.record.value
@@ -199,7 +199,7 @@ object PartitionedProduceExample extends IOApp {
         .flatMap { producer =>
           KafkaConsumer.stream(consumerSettings)
             .subscribeTo("topic")
-            .partitionedStream
+            .partitionedRecords
             .map { partition =>
               partition
                 .map { committable =>
@@ -228,7 +228,7 @@ object KafkaProducerProduceExample extends IOApp {
         .flatMap { producer =>
           KafkaConsumer.stream(consumerSettings)
             .subscribeTo("topic")
-            .stream
+            .records
             .map { committable =>
               val key = committable.record.key
               val value = committable.record.value
@@ -258,7 +258,7 @@ object KafkaProducerProduceFlattenExample extends IOApp {
         .flatMap { producer =>
           KafkaConsumer.stream(consumerSettings)
             .subscribeTo("topic")
-            .stream
+            .records
             .map { committable =>
               val key = committable.record.key
               val value = committable.record.value

--- a/docs/src/main/mdoc/quick-example.md
+++ b/docs/src/main/mdoc/quick-example.md
@@ -5,7 +5,7 @@ title: Quick Example
 
 Following is an example showing how to:
 
-- use `KafkaConsumer.stream` in order to stream records from Kafka,
+- use `KafkaConsumer#records` in order to stream records from Kafka,
 - use `produce` to produce newly created records to Kafka,
 - use `commitBatchWithin` to commit consumed offsets in batches.
 
@@ -32,7 +32,7 @@ object Main extends IOApp {
     val stream =
       KafkaConsumer.stream(consumerSettings)
         .subscribeTo("topic")
-        .stream
+        .records
         .mapAsync(25) { committable =>
           processRecord(committable.record)
             .map { case (key, value) =>

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -735,15 +735,27 @@ object KafkaConsumer {
       self.evalTap(_.subscribeTo(firstTopic, remainingTopics: _*))
 
     /**
+      * A [[Stream]] of records from the allocated [[KafkaConsumer]]. Alias for [[stream]].
+      * See [[KafkaConsume#stream]]
+      */
+    def records: Stream[F, CommittableConsumerRecord[F, K, V]] = stream
+
+    /**
       * A [[Stream]] of records from the allocated [[KafkaConsumer]].
       * See [[KafkaConsume#stream]]
       */
-    def stream: Stream[F, CommittableConsumerRecord[F, K, V]] = self.flatMap(_.stream)
+    def stream: Stream[F, CommittableConsumerRecord[F, K, V]] = self.flatMap(_.records)
+
+    /**
+      * Alias for [[partitionedStream]]. See [[KafkaConsume#partitionedStream]]
+      */
+    def partitionedRecords: Stream[F, Stream[F, CommittableConsumerRecord[F, K, V]]] =
+      partitionedStream
 
     /**
       * See [[KafkaConsume#partitionedStream]]
       */
     def partitionedStream: Stream[F, Stream[F, CommittableConsumerRecord[F, K, V]]] =
-      self.flatMap(_.partitionedStream)
+      self.flatMap(_.partitionedRecords)
   }
 }

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
@@ -31,7 +31,7 @@ trait KafkaConsume[F[_], K, V] {
   /**
     * Alias for [[partitionedStream]]
     */
-  def partitionedRecords: Stream[F, Stream[F, CommittableConsumerRecord[F, K, V]]] =
+  final def partitionedRecords: Stream[F, Stream[F, CommittableConsumerRecord[F, K, V]]] =
     partitionedStream
 
   /**

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
@@ -13,14 +13,26 @@ import org.apache.kafka.common.TopicPartition
 trait KafkaConsume[F[_], K, V] {
 
   /**
+    * Consume from all assigned partitions, producing a stream
+    * of [[CommittableConsumerRecord]]s. Alias for [[stream]].
+    */
+  final def records: Stream[F, CommittableConsumerRecord[F, K, V]] = stream
+
+  /**
     * Alias for `partitionedStream.parJoinUnbounded`.
-    * See [[partitionedStream]] for more information.
+    * See [[partitionedRecords]] for more information.
     *
     * @note you have to first use `subscribe` to subscribe the consumer
     *       before using this `Stream`. If you forgot to subscribe, there
     *       will be a [[NotSubscribedException]] raised in the `Stream`.
     */
   def stream: Stream[F, CommittableConsumerRecord[F, K, V]]
+
+  /**
+    * Alias for [[partitionedStream]]
+    */
+  def partitionedRecords: Stream[F, Stream[F, CommittableConsumerRecord[F, K, V]]] =
+    partitionedStream
 
   /**
     * `Stream` where the elements themselves are `Stream`s which continually
@@ -32,7 +44,7 @@ trait KafkaConsume[F[_], K, V] {
     * limit will be the number of assigned partitions.<br>
     * <br>
     * If you do not want to process all partitions in parallel, then you
-    * can use [[stream]] instead, where records for all partitions are in
+    * can use [[records]] instead, where records for all partitions are in
     * a single `Stream`.
     *
     * @note you have to first use `subscribe` to subscribe the consumer
@@ -61,8 +73,8 @@ trait KafkaConsume[F[_], K, V] {
     * @note you have to first use `subscribe` to subscribe the consumer
     *       before using this `Stream`. If you forgot to subscribe, there
     *       will be a [[NotSubscribedException]] raised in the `Stream`.
-    * @see [[stream]]
-    * @see [[partitionedStream]]
+    * @see [[records]]
+    * @see [[partitionedRecords]]
     */
   def partitionsMapStream
     : Stream[F, Map[TopicPartition, Stream[F, CommittableConsumerRecord[F, K, V]]]]
@@ -76,7 +88,7 @@ trait KafkaConsume[F[_], K, V] {
     * 2. All currently running streams will continue to run until all in-flight messages will be processed.
     *    It means that streams will be completed when all fetched messages will be processed.<br>
     * <br>
-    * If some of the [[stream]] methods will be called after [[stopConsuming]] call,
+    * If some of the [[records]] methods will be called after [[stopConsuming]] call,
     * these methods will return empty streams.<br>
     * <br>
     * More than one call of [[stopConsuming]] will have no effect.

--- a/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -319,7 +319,7 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
     KafkaConsumer
       .stream(consumerSettings[IO])
       .evalTap(_.subscribe(topic.r))
-      .stream
+      .records
       .take(produced.size.toLong)
       .map(_.offset)
       .chunks


### PR DESCRIPTION
I think this improves clarity, especially with the extension methods on allocating streams. I'd like to get this in for the next release, as having two uses of `.stream` with totally different meanings looks weird to me.

I don't see why we can't do this in the 1.x/2.x series - we can consider later whether we want to deprecate `stream` at some time in the future.