### PR TITLE
Add retries for schema registry errors

### DIFF
--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSerializer.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSerializer.scala
@@ -8,7 +8,7 @@ package fs2.kafka.vulcan
 
 import _root_.vulcan.Codec
 import cats.effect.Sync
-import cats.syntax.functor._
+import cats.syntax.all._
 import fs2.kafka.{RecordSerializer, Serializer}
 
 final class AvroSerializer[A] private[vulcan] (

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/SchemaRegistryClientRetry.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/SchemaRegistryClientRetry.scala
@@ -1,0 +1,62 @@
+package fs2.kafka.vulcan
+
+import cats.effect.Async
+import cats.syntax.applicativeError._
+import cats.syntax.flatMap._
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException
+import org.apache.kafka.common.errors.SerializationException
+
+import java.io.IOException
+
+import scala.concurrent.duration._
+
+/**
+  * [[SchemaRegistryClientRetry]] describes how to recover from
+  * exceptions raised while communicating with a schema registry.
+  * See [[SchemaRegistryClientRetry#Default]] for the default
+  * recovery strategy. If you do not wish to recover from any
+  * exceptions, you can use [[SchemaRegistryClientRetry#None]].<br>
+  * <br>
+  * To create a new [[SchemaRegistryClientRetry]], simply create a
+  * new instance and implement the [[withRetry]] function with the
+  * wanted recovery strategy. You can use [[isRetriable]] to
+  * identify the exceptions thrown by schema registry failures.
+  */
+trait SchemaRegistryClientRetry[F[_]] {
+
+  def withRetry[A](action: F[A]): F[A]
+}
+
+object SchemaRegistryClientRetry {
+  val isRetriable: Throwable => Boolean = {
+    case _: SerializationException     => true
+    case _: IOException                => true
+    case apiError: RestClientException => apiError.getErrorCode >= 500
+    case _                             => false
+  }
+
+  def Default[F[_]](implicit F: Async[F]): SchemaRegistryClientRetry[F] =
+    new SchemaRegistryClientRetry[F] {
+      override def withRetry[A](action: F[A]): F[A] = {
+        def retry(attempt: Int, action: F[A]): F[A] =
+          action.handleErrorWith(
+            err =>
+              if ((attempt + 1) <= 10 && isRetriable(err))
+                F.sleep((10 * Math.pow(2, attempt.toDouble)).millis) >> retry(attempt + 1, action)
+              else
+                F.raiseError(err)
+          )
+
+        retry(attempt = 1, action)
+      }
+
+      override def toString: String = "Default"
+    }
+
+  def None[F[_]]: SchemaRegistryClientRetry[F] =
+    new SchemaRegistryClientRetry[F] {
+      override def withRetry[A](action: F[A]): F[A] = action
+
+      override def toString: String = "None"
+    }
+}

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/SchemaRegistryClientRetry.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/SchemaRegistryClientRetry.scala
@@ -28,7 +28,7 @@ trait SchemaRegistryClientRetry[F[_]] {
 }
 
 object SchemaRegistryClientRetry {
-  val isRetriable: Throwable => Boolean = {
+  def isRetriable(error: Throwable): Boolean = {
     case _: SerializationException     => true
     case _: IOException                => true
     case apiError: RestClientException => apiError.getErrorCode >= 500

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/SchemaRegistryClientRetry.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/SchemaRegistryClientRetry.scala
@@ -50,7 +50,7 @@ object SchemaRegistryClientRetry {
         retry(attempt = 1, action)
       }
 
-      override def toString: String = "Default"
+      override def toString: String = "RetryPolicy.Default"
     }
 
   def None[F[_]]: SchemaRegistryClientRetry[F] =

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/SchemaRegistryClientRetry.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/SchemaRegistryClientRetry.scala
@@ -57,6 +57,6 @@ object SchemaRegistryClientRetry {
     new SchemaRegistryClientRetry[F] {
       override def withRetry[A](action: F[A]): F[A] = action
 
-      override def toString: String = "None"
+      override def toString: String = "RetryPolicy.None"
     }
 }


### PR DESCRIPTION
Fixes #663. Updated from abandoned PR #673: rebased to target 3.x and improved retry interface. Restructured PR description for readability

## Goal
Prevent transient schema registry API errors from blowing up Vulcan serialisation/deserialisation by adding retries with sensible default config.

## Implementation
* add a new `trait SchemaRegistryClientRetry[F[_]]` allowing a retry strategy on an arbitrary computation that uses the schema registry, `F[A]`, to be specified.
* add default implementation that retries on schema registry exceptions identified in the underlying Java code (see "What `Throwable`s should we retry?" below).
  * the default strategy uses a retry time backoff, requiring `Sync` to be upgraded to `Async` on some `AvroSettings` constructors; therefore this change is breaking and targets `3.x`

## Retry Interface Design
Feedback is very welcome here. I took care in designing this, drawing significant influence from discussions on issue https://github.com/fd4s/fs2-kafka/issues/623 about commit retry.

### Proposed Interface
```scala
trait SchemaRegistryClientRetry[F[_]] {

  def withRetry[A](action: F[A]): F[A]
}

// AvroSettings.scala
sealed abstract class AvroSettings[F[_]] {
  ...
  def schemaRegistryClientRetry: SchemaRegistryClientRetry[F]
}
```
**Benefits:** very flexible and composable; users can bring their own `F` to perform logging etc. Easy interop with e.g. `cats-retry` library. Robust against future implementation changes in Vulcan or the underlying Java libraries; the retry can be applied to any computation thanks to the type param.
**Cons:** required an intermediate trait to get the type parameter `[A]` because an anonymous function can't have a type param, e.g. we can't do `def schemaRegistryClientRetry: F[A] => F[A]`.

To try and get rid of the need of the type param and new trait, I also considered a variation of this proposal where the three Vulcan call sites that use the schema registry (directly or indirectly) could take one non-type-paramaterised anonymous function each as retry strategies (e.g. `def schemaRegistryGetSchemaRetry: F[ParsedSchema] => F[ParsedSchema]`), but this would leave the retry config extremely coupled to the implementation details of the existing ser/des. 

### Alternative 1
(this was my first iteration)
```scala
// AvroSettings.scala
sealed abstract class AvroSettings[F[_]] {
  ...
  def schemaRegistryRetryMaxAttempts: Int
  def schemaRegistryRetryBackoffStrategy: Int => FiniteDuration
}
```
**Benefits:** simple interface with no new traits.
**Cons:** inflexible; no provision to add logging etc. No `cats-retry` interop.

### Alternative 2
Implement tagless final traits as facades over the relevant Java schema registry classes, allow retries to be specified on their implementations.

**Cons:** this requires huge change.

## What `Throwable`s should we retry?
Some code analysis was required to determine where the schema registry is used and what exceptions it can throw. I wanted to avoid retrying on every error, which would include deterministic failures.
  * in general, schema registry client operations can throw `IOException` or `RestClientException`
  * for serialization, the relevant Java [KafkaAvroSerializer](https://github.com/confluentinc/schema-registry/blob/4cbf07a513f3a2fe999088abb5a74d544707c906/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java#L141-L147) error handling maps both `IOException` and `RestClientException` (if non-client http error code) to `SerializationException`
  * for deserialization, the [vulcan code](https://github.com/fd4s/fs2-kafka/blob/0cde0b0e8d227fa115271598dc4fb45102fa1c7c/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroDeserializer.scala#L32-L33) makes a call using the schema registry client itself and further calls are made by the underlying Java code ([1](https://github.com/fd4s/fs2-kafka/blob/0cde0b0e8d227fa115271598dc4fb45102fa1c7c/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroDeserializer.scala#L40), [2](https://github.com/confluentinc/schema-registry/blob/4cbf07a513f3a2fe999088abb5a74d544707c906/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java#L106-L107), [3](https://github.com/confluentinc/schema-registry/blob/4cbf07a513f3a2fe999088abb5a74d544707c906/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java#L305-L320)) which are mapped again to `SerializationException`

TL;DR this new helper function catches the relevant exceptions:
```scala
  val isRetriable: Throwable => Boolean = {
    case _: SerializationException     => true
    case _: IOException                => true
    case apiError: RestClientException => apiError.getErrorCode >= 500
    case _                             => false
  }
```
I made the function public so users of `cats-retry` etc. have it available to them for easy re-use.

## TODO
Once the interface is agreed, I need to add unit tests and docs.