### PR TITLE
Add a basic version matrix to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
 
 For the latest version, see the badge at the top of this page. If your project uses cats-effect 2 you should instead use the latest release from the 1.x series.
 
+### Version matrix
+|fs2-kafka|scala|cats-effect/fs2|kafka-clients|
+|---------|-----|---------------|-------------|
+|3.x (milestones)|2.13, 3.1+|3.x|3.x|
+|2.x|2.12, 2.13, 3.1+|3.x|2.x|
+|1.x|2.12, 2.13, 3.0+|2.x|2.x|
+
 For further details, see the [microsite](https://fd4s.github.io/fs2-kafka/docs/overview).
 
 ## Integrations


### PR DESCRIPTION
This should reduce confusion in choosing a version. It mentions major versions only to avoid the need for frequent manual updates.