### PR TITLE
Improve scala-steward config for 1.x series

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,11 @@
+pullRequests.frequency = "14 days"
+
+updates.pin = [{
+  groupId = "org.typelevel",
+  artifactId="cats-effect",
+  version = "2."
+}, {
+  groupId = "co.fs2",
+  artifactId="fs2-core",
+  version = "2."
+}]

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
 val catsEffectVersion = "2.5.4"
 
-val catsVersion = "2.6.1"
-
 val confluentVersion = "6.2.2"
 
 val fs2Version = "2.5.10"


### PR DESCRIPTION
Make scala-steward less noisy for 1.x series. Also, I pinned cats-effect and fs2 versions to 2.x.