### PR TITLE
Threadsafe transactions

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -73,7 +73,7 @@ object TransactionalKafkaProducer {
     (
       Resource.eval(settings.producerSettings.keySerializer),
       Resource.eval(settings.producerSettings.valueSerializer),
-      WithProducer(settings)
+      WithTransactionalProducer(settings)
     ).mapN { (keySerializer, valueSerializer, withProducer) =>
       new TransactionalKafkaProducer.Metrics[F, K, V] {
         override def produce[P](
@@ -96,7 +96,7 @@ object TransactionalKafkaProducer {
               else F.pure(batch.consumerGroupIds.head)
 
             consumerGroupId.flatMap { groupId =>
-              withProducer { (producer, blocking) =>
+              withProducer.exclusiveAccess { (producer, blocking) =>
                 blocking(producer.beginTransaction())
                   .bracketCase { _ =>
                     records.records

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithProducer.scala
@@ -6,7 +6,8 @@
 
 package fs2.kafka.internal
 
-import cats.effect.{Blocker, ContextShift, Resource, Sync}
+import cats.effect.concurrent.Semaphore
+import cats.effect.{Blocker, Concurrent, ContextShift, Resource, Sync}
 import cats.implicits._
 import fs2.kafka.{KafkaByteProducer, ProducerSettings, TransactionalProducerSettings}
 import fs2.kafka.internal.syntax._
@@ -35,24 +36,28 @@ private[kafka] object WithProducer {
   def apply[F[_], K, V](
     settings: TransactionalProducerSettings[F, K, V]
   )(
-    implicit F: Sync[F],
+    implicit F: Concurrent[F],
     context: ContextShift[F]
   ): Resource[F, WithProducer[F]] =
-    blockingResource(settings.producerSettings).flatMap { blocking =>
-      Resource[F, WithProducer[F]] {
-        settings.producerSettings.createProducer.flatMap { producer =>
-          val withProducer = create(producer, blocking)
+    (blockingResource(settings.producerSettings), Resource.eval(Semaphore(1))).tupled.flatMap {
+      case (_blocking, transactionSemaphore) =>
+        Resource[F, WithProducer[F]] {
+          settings.producerSettings.createProducer.flatMap { producer =>
+            val withProducer = new WithProducer[F] {
+              override def apply[A](f: (KafkaByteProducer, Blocking[F]) => F[A]): F[A] =
+                transactionSemaphore.withPermit(f(producer, _blocking))
+            }
 
-          val initTransactions = withProducer.blocking { _.initTransactions() }
+            val initTransactions = withProducer.blocking { _.initTransactions() }
 
-          val close = withProducer.blocking {
-            _.close(settings.producerSettings.closeTimeout.asJava)
+            val close = withProducer.blocking {
+              _.close(settings.producerSettings.closeTimeout.asJava)
+            }
+
+            initTransactions.as((withProducer, close))
           }
 
-          initTransactions.as((withProducer, close))
         }
-
-      }
     }
 
   private def blockingResource[F[_]: Sync: ContextShift](

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
@@ -43,7 +43,7 @@ private[kafka] object WithTransactionalProducer {
             Deliberately does not use the exclusive access functionality to close the producer. The close method on
             the underlying client waits until the buffer has been flushed to the broker or the timeout is exceeded.
             Because the transactional producer _always_ waits until the buffer is flushed and the transaction
-            committed on the broker before proceeding, upon gaining exclusive access ot the producer the buffer will
+            committed on the broker before proceeding, upon gaining exclusive access to the producer the buffer will
             always be empty. Therefore if we used exclusive access to close the underlying producer, the buffer
             would already be empty and the close timeout setting would be redundant.
 

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018-2022 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.internal
+
+import cats.effect.concurrent.Semaphore
+import cats.effect.{Concurrent, ContextShift, Resource}
+import cats.implicits._
+import fs2.kafka.internal.syntax._
+import fs2.kafka.{KafkaByteProducer, TransactionalProducerSettings}
+
+private[kafka] sealed abstract class WithTransactionalProducer[F[_]] {
+  def apply[A](f: (KafkaByteProducer, Blocking[F], ExclusiveAccess[F, A]) => F[A]): F[A]
+
+  def exclusiveAccess[A](f: (KafkaByteProducer, Blocking[F]) => F[A]): F[A] = apply {
+    case (producer, blocking, exclusive) => exclusive(f(producer, blocking))
+  }
+
+  def blocking[A](f: KafkaByteProducer => A): F[A] = apply {
+    case (producer, blocking, _) => blocking(f(producer))
+  }
+}
+
+private[kafka] object WithTransactionalProducer {
+  def apply[F[_], K, V](
+    settings: TransactionalProducerSettings[F, K, V]
+  )(
+    implicit F: Concurrent[F],
+    context: ContextShift[F]
+  ): Resource[F, WithTransactionalProducer[F]] =
+    (blockingResource(settings.producerSettings), Resource.eval(Semaphore(1))).tupled.flatMap {
+      case (blocking, accessSemaphore) =>
+        Resource[F, WithTransactionalProducer[F]] {
+          settings.producerSettings.createProducer.flatMap { producer =>
+            val withProducer = create(producer, blocking, accessSemaphore)
+
+            val initTransactions = withProducer.blocking { _.initTransactions() }
+
+            val close = withProducer.exclusiveAccess {
+              case (producer, blocking) =>
+                blocking(producer.close(settings.producerSettings.closeTimeout.asJava))
+            }
+
+            initTransactions.as((withProducer, close))
+          }
+
+        }
+    }
+
+  private def create[F[_]](
+    producer: KafkaByteProducer,
+    _blocking: Blocking[F],
+    transactionSemaphore: Semaphore[F]
+  ): WithTransactionalProducer[F] = new WithTransactionalProducer[F] {
+    override def apply[A](
+      f: (KafkaByteProducer, Blocking[F], ExclusiveAccess[F, A]) => F[A]
+    ): F[A] =
+      f(producer, _blocking, transactionSemaphore.withPermit)
+  }
+}

--- a/modules/core/src/main/scala/fs2/kafka/internal/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/package.scala
@@ -8,8 +8,8 @@ package fs2.kafka
 
 import cats.effect.{Blocker, ContextShift, Resource, Sync}
 
-package object internal {
-  type ExclusiveAccess[F[_], A] = F[A] => F[A]
+private[kafka] package object internal {
+  private[kafka] type ExclusiveAccess[F[_], A] = F[A] => F[A]
 
   private[kafka] def blockingResource[F[_]: Sync: ContextShift](
     settings: ProducerSettings[F, _, _]

--- a/modules/core/src/main/scala/fs2/kafka/internal/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/package.scala
@@ -8,7 +8,7 @@ package fs2.kafka
 
 import cats.effect.{Blocker, ContextShift, Resource, Sync}
 
-private[kafka] package object internal {
+package object internal {
   private[kafka] type ExclusiveAccess[F[_], A] = F[A] => F[A]
 
   private[kafka] def blockingResource[F[_]: Sync: ContextShift](

--- a/modules/core/src/main/scala/fs2/kafka/internal/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/package.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2018-2022 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package fs2.kafka
 
 import cats.effect.{Blocker, ContextShift, Resource, Sync}

--- a/modules/core/src/main/scala/fs2/kafka/internal/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/package.scala
@@ -1,0 +1,15 @@
+package fs2.kafka
+
+import cats.effect.{Blocker, ContextShift, Resource, Sync}
+
+package object internal {
+  type ExclusiveAccess[F[_], A] = F[A] => F[A]
+
+  private[kafka] def blockingResource[F[_]: Sync: ContextShift](
+    settings: ProducerSettings[F, _, _]
+  ): Resource[F, Blocking[F]] =
+    settings.blocker
+      .map(Resource.pure[F, Blocker])
+      .getOrElse(Blockers.producer)
+      .map(Blocking.fromBlocker[F])
+}


### PR DESCRIPTION
Addresses a bug with concurrent transactional producer access discovered in #883.

Introduces a semaphore around the transactional produce `WithProducer` implementation. This is because only one transaction may be started per producer at any one time, so produce requests must be queued.