### PR TITLE
Use ConsumerGroupMetadata for offset commits for stronger semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 target/
 .metals/
 .vscode/
+.bsp/
+.bloop/
+metals.sbt

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerGroupException.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerGroupException.scala
@@ -7,6 +7,7 @@
 package fs2.kafka
 
 import org.apache.kafka.common.KafkaException
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
 
 /**
   * Indicates that one or more of the following conditions occurred
@@ -15,14 +16,14 @@ import org.apache.kafka.common.KafkaException
   * - There were [[CommittableOffset]]s without a consumer group ID.<br>
   * - There were [[CommittableOffset]]s for multiple consumer group IDs.
   */
-sealed abstract class ConsumerGroupException(groupIds: Set[String])
+sealed abstract class ConsumerGroupException(groupIds: Set[ConsumerGroupMetadata])
     extends KafkaException({
-      val groupIdsString = groupIds.toList.sorted.mkString(", ")
+      val groupIdsString = groupIds.toList.sortBy(_.groupId).mkString(", ")
       s"multiple or missing consumer group ids [$groupIdsString]"
     })
 
 private[kafka] object ConsumerGroupException {
-  def apply(groupIds: Set[String]): ConsumerGroupException =
+  def apply(groupIds: Set[ConsumerGroupMetadata]): ConsumerGroupException =
     new ConsumerGroupException(groupIds) {
       override def toString: String =
         s"fs2.kafka.ConsumerGroupException: $getMessage"

--- a/modules/core/src/main/scala/fs2/kafka/instances.scala
+++ b/modules/core/src/main/scala/fs2/kafka/instances.scala
@@ -15,6 +15,7 @@ import cats.{Order, Show}
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
 
 object instances {
   implicit val fs2KafkaOffsetAndMetadataOrder: Order[OffsetAndMetadata] =
@@ -41,4 +42,7 @@ object instances {
 
   implicit val fs2KafkaTopicPartitionShow: Show[TopicPartition] =
     Show.show(tp => show"${tp.topic}-${tp.partition}")
+
+  implicit val fs2KafkaConsumerGroupMetadataShow: Show[ConsumerGroupMetadata] =
+    Show.fromToString
 }

--- a/modules/core/src/test/scala/fs2/kafka/BaseGenerators.scala
+++ b/modules/core/src/test/scala/fs2/kafka/BaseGenerators.scala
@@ -3,7 +3,7 @@ package fs2.kafka
 import cats.{ApplicativeError, ApplicativeThrow}
 import cats.effect._
 import cats.syntax.all._
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, OffsetAndMetadata}
 import org.apache.kafka.common.TopicPartition
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Cogen, Gen}
@@ -61,7 +61,7 @@ trait BaseGenerators {
     } yield CommittableOffset[F](
       topicPartition = topicPartition,
       offsetAndMetadata = offsetAndMetadata,
-      consumerGroupId = groupId,
+      groupMetadata = groupId.map(new ConsumerGroupMetadata(_)),
       commit = _ => F.unit
     )
 
@@ -75,7 +75,7 @@ trait BaseGenerators {
       (Cogen
         .perturb(_: Seed, offset.topicPartition))
         .andThen(Cogen.perturb(_, offset.offsetAndMetadata))
-        .andThen(Cogen.perturb(_, offset.consumerGroupId))
+        .andThen(Cogen.perturb(_, offset.consumerGroupMetadata.map(_.groupId)))
         .apply(seed)
     }
 

--- a/modules/core/src/test/scala/fs2/kafka/CommittableConsumerRecordSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/CommittableConsumerRecordSpec.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import cats.syntax.all._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
 
 final class CommittableConsumerRecordSpec extends BaseSpec {
   describe("CommittableConsumerRecord") {
@@ -14,7 +15,7 @@ final class CommittableConsumerRecordSpec extends BaseSpec {
           CommittableOffset[IO](
             topicPartition = new TopicPartition("topic", 0),
             offsetAndMetadata = new OffsetAndMetadata(0L),
-            consumerGroupId = Some("the-group"),
+            groupMetadata = Some(new ConsumerGroupMetadata("the-group")),
             commit = _ => IO.unit
           )
         )

--- a/modules/core/src/test/scala/fs2/kafka/CommittableOffsetBatchSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/CommittableOffsetBatchSpec.scala
@@ -48,7 +48,7 @@ final class CommittableOffsetBatchSpec extends BaseSpec {
               CommittableOffset[IO](
                 topicPartition = topicPartition,
                 offsetAndMetadata = newOffsetAndMetadata,
-                consumerGroupId = None,
+                groupMetadata = None,
                 commit = _ => IO.unit
               )
 

--- a/modules/core/src/test/scala/fs2/kafka/CommittableOffsetSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/CommittableOffsetSpec.scala
@@ -5,6 +5,7 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
 
 final class CommittableOffsetSpec extends BaseSpec {
   describe("CommittableOffset") {
@@ -16,7 +17,7 @@ final class CommittableOffsetSpec extends BaseSpec {
       CommittableOffset[IO](
         partition,
         offsetAndMetadata,
-        consumerGroupId = None,
+        groupMetadata = None,
         commit = offsets => IO { committed = offsets }
       ).commit.unsafeRunSync()
 
@@ -37,7 +38,12 @@ final class CommittableOffsetSpec extends BaseSpec {
       assert {
         val offsetAndMetadata = new OffsetAndMetadata(0L, "metadata")
         val offset =
-          CommittableOffset[IO](partition, offsetAndMetadata, Some("the-group"), _ => IO.unit)
+          CommittableOffset[IO](
+            partition,
+            offsetAndMetadata,
+            Some(new ConsumerGroupMetadata("the-group")),
+            _ => IO.unit
+          )
 
         offset.toString == "CommittableOffset(topic-0 -> (0, metadata), the-group)" &&
         offset.show == offset.toString
@@ -54,7 +60,12 @@ final class CommittableOffsetSpec extends BaseSpec {
       assert {
         val offsetAndMetadata = new OffsetAndMetadata(0L)
         val offset =
-          CommittableOffset[IO](partition, offsetAndMetadata, Some("the-group"), _ => IO.unit)
+          CommittableOffset[IO](
+            partition,
+            offsetAndMetadata,
+            Some(new ConsumerGroupMetadata("the-group")),
+            _ => IO.unit
+          )
 
         offset.toString == "CommittableOffset(topic-0 -> 0, the-group)" &&
         offset.show == offset.toString

--- a/modules/core/src/test/scala/fs2/kafka/KafkaSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaSpec.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.effect.Ref
 import fs2.{Chunk, Stream}
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, OffsetAndMetadata}
 import org.apache.kafka.common.TopicPartition
 
 import scala.concurrent.duration._
@@ -35,31 +35,31 @@ final class KafkaSpec extends BaseAsyncSpec {
     CommittableOffset[F](
       new TopicPartition("topic", 0),
       new OffsetAndMetadata(1L),
-      Some("group-1"),
+      Some(new ConsumerGroupMetadata("group-1")),
       commit
     ),
     CommittableOffset[F](
       new TopicPartition("topic", 0),
       new OffsetAndMetadata(2L),
-      Some("group-1"),
+      Some(new ConsumerGroupMetadata("group-1")),
       commit
     ),
     CommittableOffset[F](
       new TopicPartition("topic", 1),
       new OffsetAndMetadata(1L),
-      Some("group-1"),
+      Some(new ConsumerGroupMetadata("group-1")),
       commit
     ),
     CommittableOffset[F](
       new TopicPartition("topic", 1),
       new OffsetAndMetadata(2L),
-      Some("group-1"),
+      Some(new ConsumerGroupMetadata("group-1")),
       commit
     ),
     CommittableOffset[F](
       new TopicPartition("topic", 1),
       new OffsetAndMetadata(3L),
-      Some("group-1"),
+      Some(new ConsumerGroupMetadata("group-1")),
       commit
     )
   )

--- a/modules/core/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
@@ -43,7 +43,7 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with EitherValues {
             CommittableOffset[IO](
               new TopicPartition(topic, (i % 3).toInt),
               new OffsetAndMetadata(i),
-              Some("group"),
+              Some(new ConsumerGroupMetadata("group")),
               _ => IO.unit
             )
         )
@@ -125,7 +125,7 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with EitherValues {
             CommittableOffset[IO](
               new TopicPartition(topic, i % 3),
               new OffsetAndMetadata(i.toLong),
-              Some("group"),
+              Some(new ConsumerGroupMetadata("group")),
               _ => IO.unit
             )
         )
@@ -230,7 +230,7 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with EitherValues {
               CommittableOffset[IO](
                 new TopicPartition(topic, i % 3),
                 new OffsetAndMetadata(i.toLong),
-                Some("group"),
+                Some(new ConsumerGroupMetadata("group")),
                 _ => IO.unit
               )
           }
@@ -254,7 +254,7 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with EitherValues {
                       CommittableOffset[IO](
                         new TopicPartition(topic, 0),
                         new OffsetAndMetadata(0),
-                        Some("group"),
+                        Some(new ConsumerGroupMetadata("group")),
                         _ => IO.unit
                       )
                     )
@@ -314,7 +314,7 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with EitherValues {
               CommittableOffset(
                 new TopicPartition(topic, i % 3),
                 new OffsetAndMetadata(i.toLong),
-                Some("group"),
+                Some(new ConsumerGroupMetadata("group")),
                 _ => IO.unit
               )
           }
@@ -381,7 +381,7 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with EitherValues {
           offset = CommittableOffset(
             new TopicPartition(topic, 1),
             new OffsetAndMetadata(recordsToProduce.length.toLong),
-            Some("group"),
+            Some(new ConsumerGroupMetadata("group")),
             _ => IO.unit
           )
           records = TransactionalProducerRecords.one(

--- a/modules/core/src/test/scala/fs2/kafka/TransactionalProducerRecordsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/TransactionalProducerRecordsSpec.scala
@@ -5,6 +5,7 @@ import cats.instances.list._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 import fs2.Chunk
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
 
 class TransactionalProducerRecordsSpec extends BaseSpec {
   describe("TransactionalProducerRecords") {
@@ -15,7 +16,7 @@ class TransactionalProducerRecordsSpec extends BaseSpec {
         CommittableOffset[IO](
           new TopicPartition("topic", 1),
           new OffsetAndMetadata(1),
-          Some("the-group"),
+          Some(new ConsumerGroupMetadata("the-group")),
           _ => IO.unit
         )
 
@@ -38,7 +39,7 @@ class TransactionalProducerRecordsSpec extends BaseSpec {
       val offset = CommittableOffset[IO](
         new TopicPartition("topic", 1),
         new OffsetAndMetadata(1),
-        Some("the-group"),
+        Some(new ConsumerGroupMetadata("the-group")),
         _ => IO.unit
       )
 


### PR DESCRIPTION
As stated in https://kafka.apache.org/documentation/#upgrade_3_0_0:
> The `Producer#sendOffsetsToTransaction(Map offsets, String consumerGroupId)` method has been deprecated. Please use `Producer#sendOffsetsToTransaction(Map offsets, ConsumerGroupMetadata metadata)` instead, where the ConsumerGroupMetadata can be retrieved via `KafkaConsumer#groupMetadata()` for stronger semantics. Note that the full set of consumer group metadata is only understood by brokers or version 2.5 or higher, so you must upgrade your kafka cluster to get the stronger semantics. Otherwise, you can just pass in `new ConsumerGroupMetadata(consumerGroupId)` to work with older brokers. See [KIP-732](https://cwiki.apache.org/confluence/x/zJONCg) for more details.