### PR TITLE
Introduce type-level distinction between key and value serializers/deserializers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 target/
 .metals/
 .vscode/
+.bloop/
+metals.sbt

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerRecord.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerRecord.scala
@@ -167,8 +167,8 @@ object ConsumerRecord {
   private[this] def deserializeFromBytes[F[_], K, V](
     record: KafkaByteConsumerRecord,
     headers: Headers,
-    keyDeserializer: Deserializer[F, K],
-    valueDeserializer: Deserializer[F, V]
+    keyDeserializer: KeyDeserializer[F, K],
+    valueDeserializer: ValueDeserializer[F, V]
   )(implicit F: Apply[F]): F[(K, V)] = {
     val key = keyDeserializer.deserialize(record.topic, headers, record.key)
     val value = valueDeserializer.deserialize(record.topic, headers, record.value)
@@ -177,8 +177,8 @@ object ConsumerRecord {
 
   private[kafka] def fromJava[F[_], K, V](
     record: KafkaByteConsumerRecord,
-    keyDeserializer: Deserializer[F, K],
-    valueDeserializer: Deserializer[F, V]
+    keyDeserializer: KeyDeserializer[F, K],
+    valueDeserializer: ValueDeserializer[F, V]
   )(implicit F: Apply[F]): F[ConsumerRecord[K, V]] = {
     val headers = record.headers.asScala
     deserializeFromBytes(record, headers, keyDeserializer, valueDeserializer).map {

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -40,12 +40,12 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
   /**
     * The `Deserializer` to use for deserializing record keys.
     */
-  def keyDeserializer: F[Deserializer[F, K]]
+  def keyDeserializer: F[KeyDeserializer[F, K]]
 
   /**
     * The `Deserializer` to use for deserializing record values.
     */
-  def valueDeserializer: F[Deserializer[F, V]]
+  def valueDeserializer: F[ValueDeserializer[F, V]]
 
   /**
     * A custom `ExecutionContext` to use for blocking Kafka operations. If not
@@ -395,8 +395,8 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
 
 object ConsumerSettings {
   private[this] final case class ConsumerSettingsImpl[F[_], K, V](
-    override val keyDeserializer: F[Deserializer[F, K]],
-    override val valueDeserializer: F[Deserializer[F, V]],
+    override val keyDeserializer: F[KeyDeserializer[F, K]],
+    override val valueDeserializer: F[ValueDeserializer[F, V]],
     override val customBlockingContext: Option[ExecutionContext],
     override val properties: Map[String, String],
     override val closeTimeout: FiniteDuration,
@@ -530,8 +530,8 @@ object ConsumerSettings {
   }
 
   private[this] def create[F[_], K, V](
-    keyDeserializer: F[Deserializer[F, K]],
-    valueDeserializer: F[Deserializer[F, V]]
+    keyDeserializer: F[KeyDeserializer[F, K]],
+    valueDeserializer: F[ValueDeserializer[F, V]]
   ): ConsumerSettings[F, K, V] =
     ConsumerSettingsImpl(
       customBlockingContext = None,
@@ -551,8 +551,8 @@ object ConsumerSettings {
     )
 
   def apply[F[_], K, V](
-    keyDeserializer: Deserializer[F, K],
-    valueDeserializer: Deserializer[F, V]
+    keyDeserializer: KeyDeserializer[F, K],
+    valueDeserializer: ValueDeserializer[F, V]
   )(implicit F: Applicative[F]): ConsumerSettings[F, K, V] =
     create(
       keyDeserializer = F.pure(keyDeserializer),
@@ -561,7 +561,7 @@ object ConsumerSettings {
 
   def apply[F[_], K, V](
     keyDeserializer: RecordDeserializer[F, K],
-    valueDeserializer: Deserializer[F, V]
+    valueDeserializer: ValueDeserializer[F, V]
   )(implicit F: Applicative[F]): ConsumerSettings[F, K, V] =
     create(
       keyDeserializer = keyDeserializer.forKey,
@@ -569,7 +569,7 @@ object ConsumerSettings {
     )
 
   def apply[F[_], K, V](
-    keyDeserializer: Deserializer[F, K],
+    keyDeserializer: KeyDeserializer[F, K],
     valueDeserializer: RecordDeserializer[F, V]
   )(implicit F: Applicative[F]): ConsumerSettings[F, K, V] =
     create(

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -141,8 +141,8 @@ object KafkaProducer {
 
   private[kafka] def from[F[_]: Async, K, V](
     withProducer: WithProducer[F],
-    keySerializer: Serializer[F, K],
-    valueSerializer: Serializer[F, V]
+    keySerializer: KeySerializer[F, K],
+    valueSerializer: ValueSerializer[F, V]
   ): KafkaProducer.Metrics[F, K, V] =
     new KafkaProducer.Metrics[F, K, V] {
       override def produce[P](
@@ -178,8 +178,8 @@ object KafkaProducer {
     Stream.resource(KafkaProducer.resource(settings))
 
   private[kafka] def produceRecord[F[_], K, V](
-    keySerializer: Serializer[F, K],
-    valueSerializer: Serializer[F, V],
+    keySerializer: KeySerializer[F, K],
+    valueSerializer: ValueSerializer[F, V],
     producer: KafkaByteProducer,
     blocking: Blocking[F]
   )(
@@ -225,8 +225,8 @@ object KafkaProducer {
     _.evalMap(producer.produce).mapAsync(settings.parallelism)(identity)
 
   private[this] def serializeToBytes[F[_], K, V](
-    keySerializer: Serializer[F, K],
-    valueSerializer: Serializer[F, V],
+    keySerializer: KeySerializer[F, K],
+    valueSerializer: ValueSerializer[F, V],
     record: ProducerRecord[K, V]
   )(implicit F: Apply[F]): F[(Array[Byte], Array[Byte])] = {
     val keyBytes =
@@ -239,8 +239,8 @@ object KafkaProducer {
   }
 
   private[this] def asJavaRecord[F[_], K, V](
-    keySerializer: Serializer[F, K],
-    valueSerializer: Serializer[F, V],
+    keySerializer: KeySerializer[F, K],
+    valueSerializer: ValueSerializer[F, V],
     record: ProducerRecord[K, V]
   )(implicit F: Apply[F]): F[KafkaByteProducerRecord] =
     serializeToBytes(keySerializer, valueSerializer, record).map {

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
@@ -30,8 +30,8 @@ sealed abstract class KafkaProducerConnection[F[_]] {
     * }}}
     */
   def withSerializers[K, V](
-    keySerializer: Serializer[F, K],
-    valueSerializer: Serializer[F, V]
+    keySerializer: KeySerializer[F, K],
+    valueSerializer: ValueSerializer[F, V]
   ): KafkaProducer.Metrics[F, K, V]
 
   /**
@@ -106,8 +106,8 @@ object KafkaProducerConnection {
     WithProducer(mk, settings).map { withProducer =>
       new KafkaProducerConnection[G] {
         override def withSerializers[K, V](
-          keySerializer: Serializer[G, K],
-          valueSerializer: Serializer[G, V]
+          keySerializer: KeySerializer[G, K],
+          valueSerializer: ValueSerializer[G, V]
         ): KafkaProducer.Metrics[G, K, V] =
           KafkaProducer.from(withProducer, keySerializer, valueSerializer)
 
@@ -115,6 +115,7 @@ object KafkaProducerConnection {
           settings: ProducerSettings[G, K, V]
         ): G[KafkaProducer.Metrics[G, K, V]] =
           (settings.keySerializer, settings.valueSerializer).mapN(withSerializers)
+
       }
     }
 

--- a/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -31,12 +31,12 @@ sealed abstract class ProducerSettings[F[_], K, V] {
   /**
     * The `Serializer` to use for serializing record keys.
     */
-  def keySerializer: F[Serializer[F, K]]
+  def keySerializer: F[KeySerializer[F, K]]
 
   /**
     * The `Serializer` to use for serializing record values.
     */
-  def valueSerializer: F[Serializer[F, V]]
+  def valueSerializer: F[ValueSerializer[F, V]]
 
   /**
     * A custom [[ExecutionContext]] to use for blocking Kafka operations.
@@ -235,8 +235,8 @@ sealed abstract class ProducerSettings[F[_], K, V] {
 
 object ProducerSettings {
   private[this] final case class ProducerSettingsImpl[F[_], K, V](
-    override val keySerializer: F[Serializer[F, K]],
-    override val valueSerializer: F[Serializer[F, V]],
+    override val keySerializer: F[KeySerializer[F, K]],
+    override val valueSerializer: F[ValueSerializer[F, V]],
     override val customBlockingContext: Option[ExecutionContext],
     override val properties: Map[String, String],
     override val closeTimeout: FiniteDuration,
@@ -312,8 +312,8 @@ object ProducerSettings {
   }
 
   private[this] def create[F[_], K, V](
-    keySerializer: F[Serializer[F, K]],
-    valueSerializer: F[Serializer[F, V]]
+    keySerializer: F[KeySerializer[F, K]],
+    valueSerializer: F[ValueSerializer[F, V]]
   ): ProducerSettings[F, K, V] =
     ProducerSettingsImpl(
       keySerializer = keySerializer,
@@ -327,8 +327,8 @@ object ProducerSettings {
     )
 
   def apply[F[_], K, V](
-    keySerializer: Serializer[F, K],
-    valueSerializer: Serializer[F, V]
+    keySerializer: KeySerializer[F, K],
+    valueSerializer: ValueSerializer[F, V]
   )(implicit F: Applicative[F]): ProducerSettings[F, K, V] =
     create(
       keySerializer = F.pure(keySerializer),
@@ -337,7 +337,7 @@ object ProducerSettings {
 
   def apply[F[_], K, V](
     keySerializer: RecordSerializer[F, K],
-    valueSerializer: Serializer[F, V]
+    valueSerializer: ValueSerializer[F, V]
   )(implicit F: Applicative[F]): ProducerSettings[F, K, V] =
     create(
       keySerializer = keySerializer.forKey,
@@ -345,7 +345,7 @@ object ProducerSettings {
     )
 
   def apply[F[_], K, V](
-    keySerializer: Serializer[F, K],
+    keySerializer: KeySerializer[F, K],
     valueSerializer: RecordSerializer[F, V]
   )(implicit F: Applicative[F]): ProducerSettings[F, K, V] =
     create(

--- a/modules/core/src/main/scala/fs2/kafka/RecordDeserializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/RecordDeserializer.scala
@@ -25,7 +25,7 @@ sealed abstract class RecordDeserializer[F[_], A] {
     * causing the consumer to fail.
     */
   final def attempt(implicit F: Functor[F]): RecordDeserializer[F, Either[Throwable, A]] =
-    RecordDeserializer.instance(forKey.map((_: KeyDeserializer[F, A]).attempt), forValue.map(_.attempt))
+    RecordDeserializer.instance(forKey.map(_.attempt), forValue.map(_.attempt))
 }
 
 object RecordDeserializer {

--- a/modules/core/src/main/scala/fs2/kafka/RecordSerializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/RecordSerializer.scala
@@ -6,7 +6,8 @@
 
 package fs2.kafka
 
-import cats.Applicative
+import cats._
+import cats.syntax.all._
 
 /**
   * Serializer which may vary depending on whether a record
@@ -14,9 +15,9 @@ import cats.Applicative
   * a creation effect.
   */
 sealed abstract class RecordSerializer[F[_], A] {
-  def forKey: F[Serializer[F, A]]
+  def forKey: F[KeySerializer[F, A]]
 
-  def forValue: F[Serializer[F, A]]
+  def forValue: F[ValueSerializer[F, A]]
 }
 
 object RecordSerializer {
@@ -25,26 +26,26 @@ object RecordSerializer {
   ): RecordSerializer[F, A] =
     serializer
 
-  def const[F[_], A](
+  def const[F[_]: Functor, A](
     serializer: => F[Serializer[F, A]]
   ): RecordSerializer[F, A] =
     RecordSerializer.instance(
-      forKey = serializer,
-      forValue = serializer
+      forKey = serializer.widen,
+      forValue = serializer.widen
     )
 
   def instance[F[_], A](
-    forKey: => F[Serializer[F, A]],
-    forValue: => F[Serializer[F, A]]
+    forKey: => F[KeySerializer[F, A]],
+    forValue: => F[ValueSerializer[F, A]]
   ): RecordSerializer[F, A] = {
     def _forKey = forKey
     def _forValue = forValue
 
     new RecordSerializer[F, A] {
-      override def forKey: F[Serializer[F, A]] =
+      override def forKey: F[KeySerializer[F, A]] =
         _forKey
 
-      override def forValue: F[Serializer[F, A]] =
+      override def forValue: F[ValueSerializer[F, A]] =
         _forValue
 
       override def toString: String =

--- a/modules/core/src/main/scala/fs2/kafka/Serializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Serializer.scala
@@ -13,6 +13,7 @@ import java.nio.charset.{Charset, StandardCharsets}
 import java.util.UUID
 
 sealed abstract class GenSerializer[-T <: KeyOrValue, F[_], A] {
+
   /**
     * Attempts to serialize the specified value of type `A` into
     * bytes. The Kafka topic name, to which the serialized bytes
@@ -215,7 +216,9 @@ object GenSerializer {
 
   implicit def contravariant[T <: KeyOrValue, F[_]]: Contravariant[GenSerializer[T, F, *]] =
     new Contravariant[GenSerializer[T, F, *]] {
-      override def contramap[A, B](serializer: GenSerializer[T, F, A])(f: B => A): GenSerializer[T, F, B] =
+      override def contramap[A, B](
+        serializer: GenSerializer[T, F, A]
+      )(f: B => A): GenSerializer[T, F, B] =
         serializer.contramap(f)
     }
 

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -49,8 +49,8 @@ import scala.collection.immutable.SortedSet
   */
 private[kafka] final class KafkaConsumerActor[F[_], K, V](
   settings: ConsumerSettings[F, K, V],
-  keyDeserializer: Deserializer[F, K],
-  valueDeserializer: Deserializer[F, V],
+  keyDeserializer: KeyDeserializer[F, K],
+  valueDeserializer: ValueDeserializer[F, V],
   ref: Ref[F, State[F, K, V]],
   requests: Queue[F, Request[F, K, V]],
   withConsumer: WithConsumer[F]

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -63,4 +63,9 @@ package object kafka {
   type KeySerializer[F[_], A] = GenSerializer[SerdeType.Key, F, A]
   type ValueSerializer[F[_], A] = GenSerializer[SerdeType.Value, F, A]
   val Serializer: GenSerializer.type = GenSerializer
+
+  type Deserializer[F[_], A] = GenDeserializer[SerdeType.KeyOrValue, F, A]
+  type KeyDeserializer[F[_], A] = GenDeserializer[SerdeType.Key, F, A]
+  type ValueDeserializer[F[_], A] = GenDeserializer[SerdeType.Value, F, A]
+  val Deserializer: GenDeserializer.type = GenDeserializer
 }

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -59,13 +59,20 @@ package object kafka {
   ): Pipe[F, CommittableOffset[F], Unit] =
     _.groupWithin(n, d).evalMap(CommittableOffsetBatch.fromFoldable(_).commit)
 
-  type Serializer[F[_], A] = GenSerializer[SerdeType.KeyOrValue, F, A]
-  type KeySerializer[F[_], A] = GenSerializer[SerdeType.Key, F, A]
-  type ValueSerializer[F[_], A] = GenSerializer[SerdeType.Value, F, A]
+  type Serializer[F[_], A] = GenSerializer[KeyOrValue, F, A]
+  type KeySerializer[F[_], A] = GenSerializer[Key, F, A]
+  type ValueSerializer[F[_], A] = GenSerializer[Value, F, A]
   val Serializer: GenSerializer.type = GenSerializer
 
-  type Deserializer[F[_], A] = GenDeserializer[SerdeType.KeyOrValue, F, A]
-  type KeyDeserializer[F[_], A] = GenDeserializer[SerdeType.Key, F, A]
-  type ValueDeserializer[F[_], A] = GenDeserializer[SerdeType.Value, F, A]
+  type Deserializer[F[_], A] = GenDeserializer[KeyOrValue, F, A]
+  type KeyDeserializer[F[_], A] = GenDeserializer[Key, F, A]
+  type ValueDeserializer[F[_], A] = GenDeserializer[Value, F, A]
   val Deserializer: GenDeserializer.type = GenDeserializer
+}
+
+package kafka {
+  sealed trait KeyOrValue
+  sealed trait Key extends KeyOrValue
+  sealed trait Value extends KeyOrValue
+
 }

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -58,4 +58,9 @@ package object kafka {
     implicit F: Temporal[F]
   ): Pipe[F, CommittableOffset[F], Unit] =
     _.groupWithin(n, d).evalMap(CommittableOffsetBatch.fromFoldable(_).commit)
+
+  type Serializer[F[_], A] = GenSerializer[SerdeType.KeyOrValue, F, A]
+  type KeySerializer[F[_], A] = GenSerializer[SerdeType.Key, F, A]
+  type ValueSerializer[F[_], A] = GenSerializer[SerdeType.Value, F, A]
+  val Serializer: GenSerializer.type = GenSerializer
 }

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -71,8 +71,10 @@ package object kafka {
 }
 
 package kafka {
+
+  /** Phantom types to indicate whether a [[Serializer]]/[[Deserializer]] if for keys, values, or both
+    */
   sealed trait KeyOrValue
   sealed trait Key extends KeyOrValue
   sealed trait Value extends KeyOrValue
-
 }

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroDeserializer.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroDeserializer.scala
@@ -46,8 +46,8 @@ final class AvroDeserializer[A] private[vulcan] (
           }
 
         RecordDeserializer.instance(
-          forKey = createDeserializer(true),
-          forValue = createDeserializer(false)
+          forKey = createDeserializer(true).widen,
+          forValue = createDeserializer(false).widen
         )
 
       case Left(error) =>

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSerializer.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSerializer.scala
@@ -31,8 +31,8 @@ final class AvroSerializer[A] private[vulcan] (
       }
 
     RecordSerializer.instance(
-      forKey = createSerializer(true),
-      forValue = createSerializer(false)
+      forKey = createSerializer(true).widen,
+      forValue = createSerializer(false).widen
     )
   }
 


### PR DESCRIPTION
Introduces phantom types `KeyOrValue`, `Key` and `Value`, and generalises `Serializer` to `GenSerializer` with an extra type parameter for `KeyOrValue` subtype - `Serializer`, `KeySerializer` and `ValueSerializer` become aliases with different values set for that type parameter. Same goes for `Deserializer`.