### PR TITLE
Move deserialization from KafkaConsumerActor to KafkaConsumer

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -28,7 +28,6 @@ import scala.annotation.nowarn
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.FiniteDuration
 import scala.util.matching.Regex
-import org.apache.kafka.clients.consumer.ConsumerConfig
 
 /**
   * [[KafkaConsumer]] represents a consumer of Kafka records, with the
@@ -170,7 +169,7 @@ object KafkaConsumer {
                 record = record,
                 offset = CommittableOffset(
                   topicPartition = partition,
-                  consumerGroupId = settings.properties.get(ConsumerConfig.GROUP_ID_CONFIG),
+                  consumerGroupId = actor.consumerGroupId,
                   offsetAndMetadata = new OffsetAndMetadata(
                     record.offset + 1L,
                     settings.recordMetadata(record)

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -202,31 +202,6 @@ object KafkaConsumer {
                     ConsumerRecord
                       .fromJava[F, K, V](rec, keyDes, valueDes)
                       .map(committableConsumerRecord(_, offsetCommit, partition))
-                  // val cr: F[ConsumerRecord[K, V]] = ccr.record.bitraverse(
-                  //   key =>
-                  //     keyDes
-                  //       .deserialize(ccr.offset.topicPartition.topic, ccr.record.headers, key),
-                  //   value =>
-                  //     valueDes
-                  //       .deserialize(ccr.offset.topicPartition.topic, ccr.record.headers, value)
-                  // )
-
-                  //   cr.map(
-                  //     cr =>
-                  //       CommittableConsumerRecord[F, K, V](
-                  //         cr,
-                  //         CommittableOffset(
-                  //           ccr.offset.topicPartition,
-                  //           new OffsetAndMetadata(
-                  //             ccr.offset.offsetAndMetadata.offset(),
-                  //             ccr.offset.offsetAndMetadata.leaderEpoch(),
-                  //             settings.recordMetadata(cr)
-                  //           ),
-                  //           ccr.offset.consumerGroupId,
-                  //           ccr.offset.commitOffsets
-                  //         )
-                  //       )
-                  //   )
                   }
 
                   val enqueueChunk = c.flatMap { chunk =>

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -585,12 +585,7 @@ private[kafka] final class KafkaConsumerActor[F[_]](
 
 private[kafka] object KafkaConsumerActor {
   final case class FetchRequest[F[_]](
-    callback: (
-      (
-        Chunk[KafkaByteConsumerRecord],
-        FetchCompletedReason
-      )
-    ) => F[Unit]
+    callback: ((Chunk[KafkaByteConsumerRecord], FetchCompletedReason)) => F[Unit]
   ) {
     def completeRevoked(
       chunk: Chunk[KafkaByteConsumerRecord]
@@ -626,12 +621,7 @@ private[kafka] object KafkaConsumerActor {
     def withFetch(
       partition: TopicPartition,
       streamId: StreamId,
-      callback: (
-        (
-          Chunk[KafkaByteConsumerRecord],
-          FetchCompletedReason
-        )
-      ) => F[Unit]
+      callback: ((Chunk[KafkaByteConsumerRecord], FetchCompletedReason)) => F[Unit]
     ): (State[F], List[FetchRequest[F]]) = {
       val newFetchRequest =
         FetchRequest(callback)

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -46,12 +46,10 @@ import scala.collection.immutable.SortedSet
   * backpressure, as long as `Fetch` requests are only issued when there
   * is more demand.
   */
-private[kafka] final class KafkaConsumerActor[F[_], K, V](
-  settings: ConsumerSettings[F, K, V],
-  keyDeserializer: Deserializer[F, K],
-  valueDeserializer: Deserializer[F, V],
-  ref: Ref[F, State[F, K, V]],
-  requests: Queue[F, Request[F, K, V]],
+private[kafka] final class KafkaConsumerActor[F[_]](
+  settings: ConsumerSettings[F, _, _],
+  ref: Ref[F, State[F]],
+  requests: Queue[F, Request[F]],
   withConsumer: WithConsumer[F]
 )(
   implicit F: Async[F],
@@ -62,7 +60,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
   import logging._
 
   private[this] type ConsumerRecords =
-    Map[TopicPartition, NonEmptyVector[CommittableConsumerRecord[F, K, V]]]
+    Map[TopicPartition, NonEmptyVector[CommittableConsumerRecord[F, Array[Byte], Array[Byte]]]]
 
   private[this] val consumerGroupId: Option[String] =
     settings.properties.get(ConsumerConfig.GROUP_ID_CONFIG)
@@ -164,7 +162,9 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
   private[this] def fetch(
     partition: TopicPartition,
     streamId: StreamId,
-    callback: ((Chunk[CommittableConsumerRecord[F, K, V]], FetchCompletedReason)) => F[Unit]
+    callback: (
+      (Chunk[CommittableConsumerRecord[F, Array[Byte], Array[Byte]]], FetchCompletedReason)
+    ) => F[Unit]
   ): F[Unit] = {
     val assigned =
       withConsumer.blocking { _.assignment.contains(partition) }
@@ -259,7 +259,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
       }
 
   private[this] def revoked(revoked: SortedSet[TopicPartition]): F[Unit] = {
-    def withState[A] = StateT.apply[Id, State[F, K, V], A](_)
+    def withState[A] = StateT.apply[Id, State[F], A](_)
 
     def completeWithRecords(withRecords: Set[TopicPartition]) = withState { st =>
       if (withRecords.nonEmpty) {
@@ -379,17 +379,16 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
     }
 
   private[this] def committableConsumerRecord(
-    record: ConsumerRecord[K, V],
+    record: ConsumerRecord[Array[Byte], Array[Byte]],
     partition: TopicPartition
-  ): CommittableConsumerRecord[F, K, V] =
+  ): CommittableConsumerRecord[F, Array[Byte], Array[Byte]] =
     CommittableConsumerRecord(
       record = record,
       offset = CommittableOffset(
         topicPartition = partition,
         consumerGroupId = consumerGroupId,
         offsetAndMetadata = new OffsetAndMetadata(
-          record.offset + 1L,
-          settings.recordMetadata(record)
+          record.offset + 1L
         ),
         commit = offsetCommit
       )
@@ -402,7 +401,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
           .fromVectorUnsafe(batch.records(partition).toVector)
           .traverse { record =>
             ConsumerRecord
-              .fromJava(record, keyDeserializer, valueDeserializer)
+              .fromJava(record, Deserializer.identity, Deserializer.identity)
               .map(committableConsumerRecord(_, partition))
           }
           .map((partition, _))
@@ -413,7 +412,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
     settings.pollTimeout.asJava
 
   private[this] val poll: F[Unit] = {
-    def pollConsumer(state: State[F, K, V]): F[ConsumerRecords] =
+    def pollConsumer(state: State[F]): F[ConsumerRecords] =
       withConsumer
         .blocking { consumer =>
           val assigned = consumer.assignment.toSet
@@ -435,7 +434,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
 
     def handlePoll(newRecords: ConsumerRecords, initialRebalancing: Boolean): F[Unit] = {
       def handleBatch(
-        state: State[F, K, V],
+        state: State[F],
         pendingCommits: Option[HandlePollResult.PendingCommits]
       ) =
         if (state.fetches.isEmpty) {
@@ -509,7 +508,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
           }
         }
 
-      def handlePendingCommits(state: State[F, K, V]) = {
+      def handlePendingCommits(state: State[F]) = {
         val currentRebalancing = state.rebalancing
 
         if (initialRebalancing && !currentRebalancing && state.pendingCommits.nonEmpty) {
@@ -553,7 +552,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
     }
   }
 
-  def handle(request: Request[F, K, V]): F[Unit] =
+  def handle(request: Request[F]): F[Unit] =
     request match {
       case Request.Assignment(callback, onRebalance)   => assignment(callback, onRebalance)
       case Request.Poll()                              => poll
@@ -614,13 +613,19 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
 }
 
 private[kafka] object KafkaConsumerActor {
-  final case class FetchRequest[F[_], K, V](
-    callback: ((Chunk[CommittableConsumerRecord[F, K, V]], FetchCompletedReason)) => F[Unit]
+  final case class FetchRequest[F[_]](
+    callback: (
+      (Chunk[CommittableConsumerRecord[F, Array[Byte], Array[Byte]]], FetchCompletedReason)
+    ) => F[Unit]
   ) {
-    def completeRevoked(chunk: Chunk[CommittableConsumerRecord[F, K, V]]): F[Unit] =
+    def completeRevoked(
+      chunk: Chunk[CommittableConsumerRecord[F, Array[Byte], Array[Byte]]]
+    ): F[Unit] =
       callback((chunk, FetchCompletedReason.TopicPartitionRevoked))
 
-    def completeRecords(chunk: Chunk[CommittableConsumerRecord[F, K, V]]): F[Unit] =
+    def completeRecords(
+      chunk: Chunk[CommittableConsumerRecord[F, Array[Byte], Array[Byte]]]
+    ): F[Unit] =
       callback((chunk, FetchCompletedReason.FetchedRecords))
 
     override def toString: String =
@@ -629,16 +634,18 @@ private[kafka] object KafkaConsumerActor {
 
   type StreamId = Int
 
-  final case class State[F[_], K, V](
-    fetches: Map[TopicPartition, Map[StreamId, FetchRequest[F, K, V]]],
-    records: Map[TopicPartition, NonEmptyVector[CommittableConsumerRecord[F, K, V]]],
+  final case class State[F[_]](
+    fetches: Map[TopicPartition, Map[StreamId, FetchRequest[F]]],
+    records: Map[TopicPartition, NonEmptyVector[
+      CommittableConsumerRecord[F, Array[Byte], Array[Byte]]
+    ]],
     pendingCommits: Chain[Request.Commit[F]],
     onRebalances: Chain[OnRebalance[F]],
     rebalancing: Boolean,
     subscribed: Boolean,
     streaming: Boolean
   ) {
-    def withOnRebalance(onRebalance: OnRebalance[F]): State[F, K, V] =
+    def withOnRebalance(onRebalance: OnRebalance[F]): State[F] =
       copy(onRebalances = onRebalances append onRebalance)
 
     /**
@@ -647,18 +654,20 @@ private[kafka] object KafkaConsumerActor {
     def withFetch(
       partition: TopicPartition,
       streamId: StreamId,
-      callback: ((Chunk[CommittableConsumerRecord[F, K, V]], FetchCompletedReason)) => F[Unit]
-    ): (State[F, K, V], List[FetchRequest[F, K, V]]) = {
+      callback: (
+        (Chunk[CommittableConsumerRecord[F, Array[Byte], Array[Byte]]], FetchCompletedReason)
+      ) => F[Unit]
+    ): (State[F], List[FetchRequest[F]]) = {
       val newFetchRequest =
         FetchRequest(callback)
 
-      val oldPartitionFetches: Map[StreamId, FetchRequest[F, K, V]] =
+      val oldPartitionFetches: Map[StreamId, FetchRequest[F]] =
         fetches.getOrElse(partition, Map.empty)
 
-      val newFetches: Map[TopicPartition, Map[StreamId, FetchRequest[F, K, V]]] =
+      val newFetches: Map[TopicPartition, Map[StreamId, FetchRequest[F]]] =
         fetches.updated(partition, oldPartitionFetches.updated(streamId, newFetchRequest))
 
-      val fetchesToRevoke: List[FetchRequest[F, K, V]] =
+      val fetchesToRevoke: List[FetchRequest[F]] =
         oldPartitionFetches.get(streamId).toList
 
       (
@@ -667,41 +676,43 @@ private[kafka] object KafkaConsumerActor {
       )
     }
 
-    def withoutFetches(partitions: Set[TopicPartition]): State[F, K, V] =
+    def withoutFetches(partitions: Set[TopicPartition]): State[F] =
       copy(
         fetches = fetches.filterKeysStrict(!partitions.contains(_))
       )
 
     def withRecords(
-      records: Map[TopicPartition, NonEmptyVector[CommittableConsumerRecord[F, K, V]]]
-    ): State[F, K, V] =
+      records: Map[TopicPartition, NonEmptyVector[
+        CommittableConsumerRecord[F, Array[Byte], Array[Byte]]
+      ]]
+    ): State[F] =
       copy(records = this.records combine records)
 
-    def withoutFetchesAndRecords(partitions: Set[TopicPartition]): State[F, K, V] =
+    def withoutFetchesAndRecords(partitions: Set[TopicPartition]): State[F] =
       copy(
         fetches = fetches.filterKeysStrict(!partitions.contains(_)),
         records = records.filterKeysStrict(!partitions.contains(_))
       )
 
-    def withoutRecords(partitions: Set[TopicPartition]): State[F, K, V] =
+    def withoutRecords(partitions: Set[TopicPartition]): State[F] =
       copy(records = records.filterKeysStrict(!partitions.contains(_)))
 
-    def withPendingCommit(pendingCommit: Request.Commit[F]): State[F, K, V] =
+    def withPendingCommit(pendingCommit: Request.Commit[F]): State[F] =
       copy(pendingCommits = pendingCommits append pendingCommit)
 
-    def withoutPendingCommits: State[F, K, V] =
+    def withoutPendingCommits: State[F] =
       if (pendingCommits.isEmpty) this else copy(pendingCommits = Chain.empty)
 
-    def withRebalancing(rebalancing: Boolean): State[F, K, V] =
+    def withRebalancing(rebalancing: Boolean): State[F] =
       if (this.rebalancing == rebalancing) this else copy(rebalancing = rebalancing)
 
-    def asSubscribed: State[F, K, V] =
+    def asSubscribed: State[F] =
       if (subscribed) this else copy(subscribed = true)
 
-    def asUnsubscribed: State[F, K, V] =
+    def asUnsubscribed: State[F] =
       if (!subscribed) this else copy(subscribed = false)
 
-    def asStreaming: State[F, K, V] =
+    def asStreaming: State[F] =
       if (streaming) this else copy(streaming = true)
 
     override def toString: String = {
@@ -720,7 +731,7 @@ private[kafka] object KafkaConsumerActor {
   }
 
   object State {
-    def empty[F[_], K, V]: State[F, K, V] =
+    def empty[F[_]]: State[F] =
       State(
         fetches = Map.empty,
         records = Map.empty,
@@ -753,15 +764,15 @@ private[kafka] object KafkaConsumerActor {
       "OnRebalance$" + System.identityHashCode(this)
   }
 
-  sealed abstract class Request[F[_], -K, -V]
+  sealed abstract class Request[F[_]]
 
   object Request {
     final case class Assignment[F[_]](
       callback: Either[Throwable, SortedSet[TopicPartition]] => F[Unit],
       onRebalance: Option[OnRebalance[F]]
-    ) extends Request[F, Any, Any]
+    ) extends Request[F]
 
-    final case class Poll[F[_]]() extends Request[F, Any, Any]
+    final case class Poll[F[_]]() extends Request[F]
 
     private[this] val pollInstance: Poll[Nothing] =
       Poll[Nothing]()
@@ -772,41 +783,43 @@ private[kafka] object KafkaConsumerActor {
     final case class SubscribeTopics[F[_]](
       topics: NonEmptyList[String],
       callback: Either[Throwable, Unit] => F[Unit]
-    ) extends Request[F, Any, Any]
+    ) extends Request[F]
 
     final case class Assign[F[_]](
       topicPartitions: NonEmptySet[TopicPartition],
       callback: Either[Throwable, Unit] => F[Unit]
-    ) extends Request[F, Any, Any]
+    ) extends Request[F]
 
     final case class SubscribePattern[F[_]](
       pattern: Pattern,
       callback: Either[Throwable, Unit] => F[Unit]
-    ) extends Request[F, Any, Any]
+    ) extends Request[F]
 
     final case class Unsubscribe[F[_]](
       callback: Either[Throwable, Unit] => F[Unit]
-    ) extends Request[F, Any, Any]
+    ) extends Request[F]
 
-    final case class Fetch[F[_], -K, -V](
+    final case class Fetch[F[_]](
       partition: TopicPartition,
       streamId: StreamId,
-      callback: ((Chunk[CommittableConsumerRecord[F, K, V]], FetchCompletedReason)) => F[Unit]
-    ) extends Request[F, K, V]
+      callback: (
+        (Chunk[CommittableConsumerRecord[F, Array[Byte], Array[Byte]]], FetchCompletedReason)
+      ) => F[Unit]
+    ) extends Request[F]
 
     final case class Commit[F[_]](
       offsets: Map[TopicPartition, OffsetAndMetadata],
       callback: Either[Throwable, Unit] => Unit
-    ) extends Request[F, Any, Any]
+    ) extends Request[F]
 
     final case class ManualCommitAsync[F[_]](
       offsets: Map[TopicPartition, OffsetAndMetadata],
       callback: Either[Throwable, Unit] => F[Unit]
-    ) extends Request[F, Any, Any]
+    ) extends Request[F]
 
     final case class ManualCommitSync[F[_]](
       offsets: Map[TopicPartition, OffsetAndMetadata],
       callback: Either[Throwable, Unit] => F[Unit]
-    ) extends Request[F, Any, Any]
+    ) extends Request[F]
   }
 }

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.consumer.{ConsumerRebalanceListener, OffsetAndMe
 import org.apache.kafka.common.TopicPartition
 
 import scala.collection.immutable.SortedSet
+import org.apache.kafka.clients.consumer.ConsumerConfig
 
 /**
   * [[KafkaConsumerActor]] wraps a Java `KafkaConsumer` and works similar to
@@ -57,6 +58,9 @@ private[kafka] final class KafkaConsumerActor[F[_]](
 
   private[this] type ConsumerRecords =
     Map[TopicPartition, NonEmptyVector[KafkaByteConsumerRecord]]
+
+  private[kafka] val consumerGroupId: Option[String] =
+    settings.properties.get(ConsumerConfig.GROUP_ID_CONFIG)
 
   private[this] val consumerRebalanceListener: ConsumerRebalanceListener =
     new ConsumerRebalanceListener {

--- a/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
@@ -17,7 +17,6 @@ import fs2.kafka.internal.syntax._
 import java.util.regex.Pattern
 import org.apache.kafka.common.TopicPartition
 import scala.collection.immutable.SortedSet
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
 
 private[kafka] sealed abstract class LogEntry {
   def level: LogLevel
@@ -63,13 +62,7 @@ private[kafka] object LogEntry {
 
   final case class StoredFetch[F[_]](
     partition: TopicPartition,
-    callback: (
-      (
-        Chunk[KafkaByteConsumerRecord],
-        Map[TopicPartition, OffsetAndMetadata] => F[Unit],
-        FetchCompletedReason
-      )
-    ) => F[Unit],
+    callback: ((Chunk[KafkaByteConsumerRecord], FetchCompletedReason)) => F[Unit],
     state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug

--- a/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
@@ -27,7 +27,7 @@ private[kafka] sealed abstract class LogEntry {
 private[kafka] object LogEntry {
   final case class SubscribedTopics[F[_]](
     topics: NonEmptyList[String],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -36,7 +36,7 @@ private[kafka] object LogEntry {
 
   final case class ManuallyAssignedPartitions[F[_]](
     partitions: NonEmptySet[TopicPartition],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -45,7 +45,7 @@ private[kafka] object LogEntry {
 
   final case class SubscribedPattern[F[_]](
     pattern: Pattern,
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -53,17 +53,19 @@ private[kafka] object LogEntry {
   }
 
   final case class Unsubscribed[F[_]](
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
       s"Consumer unsubscribed from all partitions. Current state [$state]."
   }
 
-  final case class StoredFetch[F[_], K, V](
+  final case class StoredFetch[F[_]](
     partition: TopicPartition,
-    callback: ((Chunk[CommittableConsumerRecord[F, K, V]], FetchCompletedReason)) => F[Unit],
-    state: State[F, K, V]
+    callback: (
+      (Chunk[CommittableConsumerRecord[F, Array[Byte], Array[Byte]]], FetchCompletedReason)
+    ) => F[Unit],
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -72,7 +74,7 @@ private[kafka] object LogEntry {
 
   final case class StoredOnRebalance[F[_]](
     onRebalance: OnRebalance[F],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -81,7 +83,7 @@ private[kafka] object LogEntry {
 
   final case class AssignedPartitions[F[_]](
     partitions: SortedSet[TopicPartition],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -90,7 +92,7 @@ private[kafka] object LogEntry {
 
   final case class RevokedPartitions[F[_]](
     partitions: SortedSet[TopicPartition],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -99,7 +101,7 @@ private[kafka] object LogEntry {
 
   final case class CompletedFetchesWithRecords[F[_]](
     records: Records[F],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -108,7 +110,7 @@ private[kafka] object LogEntry {
 
   final case class RevokedFetchesWithRecords[F[_]](
     records: Records[F],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -117,7 +119,7 @@ private[kafka] object LogEntry {
 
   final case class RevokedFetchesWithoutRecords[F[_]](
     partitions: Set[TopicPartition],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -126,7 +128,7 @@ private[kafka] object LogEntry {
 
   final case class RemovedRevokedRecords[F[_]](
     records: Records[F],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -135,7 +137,7 @@ private[kafka] object LogEntry {
 
   final case class StoredRecords[F[_]](
     records: Records[F],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -153,7 +155,7 @@ private[kafka] object LogEntry {
 
   final case class StoredPendingCommit[F[_]](
     commit: Request.Commit[F],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =
@@ -162,7 +164,7 @@ private[kafka] object LogEntry {
 
   final case class CommittedPendingCommits[F[_]](
     pendingCommits: Chain[Request.Commit[F]],
-    state: State[F, _, _]
+    state: State[F]
   ) extends LogEntry {
     override def level: LogLevel = Debug
     override def message: String =

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -9,7 +9,11 @@ import cats.effect.unsafe.implicits.global
 import fs2.Stream
 import fs2.concurrent.SignallingRef
 import fs2.kafka.internal.converters.collection._
-import org.apache.kafka.clients.consumer.{ConsumerConfig, CooperativeStickyAssignor, NoOffsetForPartitionException}
+import org.apache.kafka.clients.consumer.{
+  ConsumerConfig,
+  CooperativeStickyAssignor,
+  NoOffsetForPartitionException
+}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.TimeoutException
 import org.scalatest.Assertion
@@ -559,7 +563,9 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
                 .stream(
                   consumerSettings[IO]
                     .withProperties(
-                      ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG -> classOf[CooperativeStickyAssignor].getName
+                      ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG -> classOf[
+                        CooperativeStickyAssignor
+                      ].getName
                     )
                 )
                 .subscribeTo(topic)
@@ -801,9 +807,10 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
               .stream(
                 consumerSettings[IO]
                   .withProperties(
-                    ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG -> classOf[CooperativeStickyAssignor].getName
+                    ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG -> classOf[
+                      CooperativeStickyAssignor
+                    ].getName
                   )
-
               )
               .subscribeTo(topic)
               .evalMap { consumer =>


### PR DESCRIPTION
Postpones deserialising records until they are pushed onto a consumer stream, reducing the complexity of `KafkaConsumerActor`.

This means that a deserialization error in a partitioned stream will cause only the specific partition stream to fail, rather than crash the actor - I think that's a good thing, but maybe we should reproduce the existing behaviour (with a configurable toggle) in the 2.x series?