### PR TITLE
withParallelism default 100 -> 10000 in docs

### DIFF
--- a/docs/src/main/mdoc/producers.md
+++ b/docs/src/main/mdoc/producers.md
@@ -130,7 +130,7 @@ The following settings are specific to the library.
 
 - `withCloseTimeout` controls the timeout when waiting for producer shutdown. Default is 60 seconds.
 
-- `withParallelism` sets the max number of `ProducerRecords` to produce in the same batch when using the `produce` pipe. Default is 100.
+- `withParallelism` sets the max number of `ProducerRecords` to produce in the same batch when using the `produce` pipe. Default is 10000.
 
 - `withCreateProducer` changes how the underlying Java Kafka producer is created. The default merely creates a Java `KafkaProducer` instance using set properties, but this function allows overriding the behaviour for e.g. testing purposes.
 


### PR DESCRIPTION
the default value for `parallelism` in `ProducerSettings` is 10000 https://github.com/fd4s/fs2-kafka/blob/19f5210f0339f65d41cc4cb30a750c59754d78f1/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala#L326

Just fixing the docs to match this. 