### PR TITLE
Additional consumer functionality exposed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -280,6 +280,7 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.deleteConsumerGroups"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaProducerConnection.produce"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaProducerConnection.metrics"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.consumer.KafkaOffsets.committed"),
 
       // package-private
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaProducer.from"),

--- a/build.sbt
+++ b/build.sbt
@@ -278,7 +278,7 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.deleteConsumerGroups"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaProducerConnection.produce"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaProducerConnection.metrics"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.consumer.KafkaOffsets.committed"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("fs2.kafka.KafkaConsumer.committed"),
 
       // package-private
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaProducer.from"),

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -501,6 +501,17 @@ object KafkaConsumer {
       override def position(partition: TopicPartition, timeout: FiniteDuration): F[Long] =
         withConsumer.blocking { _.position(partition, timeout.asJava) }
 
+      override def committed(
+        partitions: Set[TopicPartition]
+      ): F[Map[TopicPartition, OffsetAndMetadata]] =
+        withConsumer.blocking(_.committed(partitions.asJava).toMap)
+
+      override def committed(
+        partitions: Set[TopicPartition],
+        timeout: FiniteDuration
+      ): F[Map[TopicPartition, OffsetAndMetadata]] =
+        withConsumer.blocking(_.committed(partitions.asJava, timeout.asJava).toMap)
+
       override def subscribeTo(firstTopic: String, remainingTopics: String*): F[Unit] =
         subscribe(NonEmptyList.of(firstTopic, remainingTopics: _*))
 

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -71,7 +71,7 @@ import scala.util.matching.Regex
 sealed abstract class KafkaConsumer[F[_], K, V]
     extends KafkaConsume[F, K, V]
     with KafkaAssignment[F]
-    with KafkaOffsets[F]
+    with KafkaOffsetsV2[F]
     with KafkaSubscription[F]
     with KafkaTopics[F]
     with KafkaCommit[F]
@@ -505,6 +505,25 @@ object KafkaConsumer {
 
       override def position(partition: TopicPartition, timeout: FiniteDuration): F[Long] =
         withConsumer.blocking { _.position(partition, timeout.asJava) }
+
+      override def committed(
+        partitions: Set[TopicPartition]
+      ): F[Map[TopicPartition, OffsetAndMetadata]] =
+        withConsumer.blocking {
+          _.committed(partitions.asJava)
+            .asInstanceOf[util.Map[TopicPartition, OffsetAndMetadata]]
+            .toMap
+        }
+
+      override def committed(
+        partitions: Set[TopicPartition],
+        timeout: FiniteDuration
+      ): F[Map[TopicPartition, OffsetAndMetadata]] =
+        withConsumer.blocking {
+          _.committed(partitions.asJava, timeout.asJava)
+            .asInstanceOf[util.Map[TopicPartition, OffsetAndMetadata]]
+            .toMap
+        }
 
       override def subscribe[G[_]](topics: G[String])(implicit G: Reducible[G]): F[Unit] =
         withPermit {

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -504,13 +504,21 @@ object KafkaConsumer {
       override def committed(
         partitions: Set[TopicPartition]
       ): F[Map[TopicPartition, OffsetAndMetadata]] =
-        withConsumer.blocking(_.committed(partitions.asJava).toMap)
+        withConsumer.blocking {
+          _.committed(partitions.asJava)
+            .asInstanceOf[util.Map[TopicPartition, OffsetAndMetadata]]
+            .toMap
+        }
 
       override def committed(
         partitions: Set[TopicPartition],
         timeout: FiniteDuration
       ): F[Map[TopicPartition, OffsetAndMetadata]] =
-        withConsumer.blocking(_.committed(partitions.asJava, timeout.asJava).toMap)
+        withConsumer.blocking {
+          _.committed(partitions.asJava, timeout.asJava)
+            .asInstanceOf[util.Map[TopicPartition, OffsetAndMetadata]]
+            .toMap
+        }
 
       override def subscribeTo(firstTopic: String, remainingTopics: String*): F[Unit] =
         subscribe(NonEmptyList.of(firstTopic, remainingTopics: _*))

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsets.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsets.scala
@@ -7,7 +7,6 @@
 package fs2.kafka.consumer
 
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import cats.Foldable
 import scala.concurrent.duration.FiniteDuration
 
@@ -73,21 +72,5 @@ trait KafkaOffsets[F[_]] {
     * Returns the offset of the next record that will be fetched.
     */
   def position(partition: TopicPartition, timeout: FiniteDuration): F[Long]
-
-  /**
-    * Returns the last committed offsets for the given partitions.
-    */
-  def committed(partitions: Set[TopicPartition]): F[Map[TopicPartition, OffsetAndMetadata]]
-
-  /**
-    * Returns the last committed offsets for the given partitions.<br>
-    * <br>
-    * Timeout is determined by `default.api.timeout.ms`, which
-    * is set using [[ConsumerSettings#withDefaultApiTimeout]].
-    */
-  def committed(
-    partitions: Set[TopicPartition],
-    timeout: FiniteDuration
-  ): F[Map[TopicPartition, OffsetAndMetadata]]
 
 }

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsets.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsets.scala
@@ -7,6 +7,7 @@
 package fs2.kafka.consumer
 
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import cats.Foldable
 import scala.concurrent.duration.FiniteDuration
 
@@ -72,5 +73,18 @@ trait KafkaOffsets[F[_]] {
     * Returns the offset of the next record that will be fetched.
     */
   def position(partition: TopicPartition, timeout: FiniteDuration): F[Long]
+
+  /**
+    * Returns the last committed offsets for the given partitions.
+    */
+  def committed(partitions: Set[TopicPartition]): F[Map[TopicPartition, OffsetAndMetadata]]
+
+  /**
+    * Returns the last committed offsets for the given partitions.<br>
+    * <br>
+    * Timeout is determined by `default.api.timeout.ms`, which
+    * is set using [[ConsumerSettings#withDefaultApiTimeout]].
+    */
+  def committed(partitions: Set[TopicPartition], timeout: FiniteDuration): F[Map[TopicPartition, OffsetAndMetadata]]
 
 }

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsets.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsets.scala
@@ -85,6 +85,9 @@ trait KafkaOffsets[F[_]] {
     * Timeout is determined by `default.api.timeout.ms`, which
     * is set using [[ConsumerSettings#withDefaultApiTimeout]].
     */
-  def committed(partitions: Set[TopicPartition], timeout: FiniteDuration): F[Map[TopicPartition, OffsetAndMetadata]]
+  def committed(
+    partitions: Set[TopicPartition],
+    timeout: FiniteDuration
+  ): F[Map[TopicPartition, OffsetAndMetadata]]
 
 }

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsetsV2.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsetsV2.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2018-2022 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package fs2.kafka.consumer
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsetsV2.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsetsV2.scala
@@ -1,0 +1,25 @@
+package fs2.kafka.consumer
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+
+import scala.concurrent.duration.FiniteDuration
+
+trait KafkaOffsetsV2[F[_]] extends KafkaOffsets[F] {
+
+  /**
+    * Returns the last committed offsets for the given partitions.
+    */
+  def committed(partitions: Set[TopicPartition]): F[Map[TopicPartition, OffsetAndMetadata]]
+
+  /**
+    * Returns the last committed offsets for the given partitions.<br>
+    * <br>
+    * Timeout is determined by `default.api.timeout.ms`, which
+    * is set using [[ConsumerSettings#withDefaultApiTimeout]].
+    */
+  def committed(
+    partitions: Set[TopicPartition],
+    timeout: FiniteDuration
+  ): F[Map[TopicPartition, OffsetAndMetadata]]
+}

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -1107,31 +1107,37 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
 
       val partitions = (0 until partitionsAmount).toSet
 
+      val topicPartitions = partitions.map(partition => new TopicPartition(topic, partition))
+
       val createConsumer = KafkaConsumer
         .stream(consumerSettings[IO])
         .subscribeTo(topic)
 
-      val committed = (for {
-        consumer <- createConsumer
-        consumed <- consumer.records
-          .take(produced.size.toLong)
-          .map(_.offset)
-          .fold(CommittableOffsetBatch.empty[IO])(_ updated _)
-        _ <- Stream.eval(commit(consumer, consumed))
-      } yield consumed.offsets).compile.lastOrError.unsafeRunSync()
+      val committed = {
+        for {
+          consumer <- createConsumer
+          consumed <- consumer.records
+            .take(produced.size.toLong)
+            .map(_.offset)
+            .fold(CommittableOffsetBatch.empty[IO])(_ updated _)
+          _ <- Stream.eval(commit(consumer, consumed))
+          committed <- Stream.eval(consumer.committed(topicPartitions))
+          committedWithTimeout <- Stream.eval(consumer.committed(topicPartitions, 10.seconds))
+        } yield List(consumed.offsets, committed, committedWithTimeout)
+      }.compile.lastOrError.unsafeRunSync()
 
       val actuallyCommitted = withKafkaConsumer(defaultConsumerProperties) { consumer =>
         consumer
-          .committed(partitions.map { partition =>
-            new TopicPartition(topic, partition)
-          }.asJava)
+          .committed(topicPartitions.asJava)
           .asScala
           .toMap
       }
 
       assert {
-        committed.values.toList.foldMap(_.offset) == produced.size.toLong &&
-        committed == actuallyCommitted
+        committed.forall { offsets =>
+          offsets.values.toList.foldMap(_.offset) == produced.size.toLong &&
+          offsets == actuallyCommitted
+        }
       }
     }
 }


### PR DESCRIPTION
New methods added to `trait KafkaOffsets[F[_]]`:

```
def committed(partitions: Set[TopicPartition]): F[Map[TopicPartition, OffsetAndMetadata]]

def committed(partitions: Set[TopicPartition], timeout: FiniteDuration): F[Map[TopicPartition, OffsetAndMetadata]]
```


