### PR TITLE
Refactor future cancellation test to avoid dependence on KakfaFuture internals

### DIFF
--- a/modules/core/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
@@ -6,11 +6,13 @@ import fs2.kafka._
 import fs2.kafka.BaseSpec
 import fs2.kafka.internal.syntax._
 import org.apache.kafka.common.KafkaFuture
+import org.apache.kafka.common.KafkaFuture.BiConsumer
 
 import java.time.temporal.ChronoUnit.MICROS
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.apache.kafka.common.internals.KafkaFutureImpl
 
+import java.util.concurrent.CancellationException
 import scala.concurrent.duration._
 
 final class SyntaxSpec extends BaseSpec {
@@ -67,16 +69,18 @@ final class SyntaxSpec extends BaseSpec {
         for {
           gate <- IO.deferred[Unit]
           futureIO: IO[KafkaFuture[Unit]] = gate.complete(()) >> IO {
-            new KafkaFutureImpl[Unit] {
-              override def cancel(mayInterruptIfRunning: Boolean): Boolean = {
-                isFutureCancelled = true
-                true
-              }
+            // We need to return the original future after calling `whenComplete`, because the future returned by
+            // `whenComplete` doesn't propagate cancellation back to the original future.
+            val future = new KafkaFutureImpl[Unit]
+            future.whenComplete {
+              case (_, _: CancellationException) => isFutureCancelled = true
+              case _                             => ()
             }
+            future
           }
           fiber <- futureIO.cancelable.start
-          _ <- IO(assert(!isFutureCancelled))
           _ <- gate.get // wait for future to be created before canceling it
+          _ <- IO(assert(!isFutureCancelled))
           _ <- fiber.cancel
           _ <- IO(assert(isFutureCancelled))
         } yield ()

--- a/modules/core/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
@@ -6,7 +6,6 @@ import fs2.kafka._
 import fs2.kafka.BaseSpec
 import fs2.kafka.internal.syntax._
 import org.apache.kafka.common.KafkaFuture
-import org.apache.kafka.common.KafkaFuture.BiConsumer
 
 import java.time.temporal.ChronoUnit.MICROS
 import org.apache.kafka.common.header.internals.RecordHeaders


### PR DESCRIPTION
This fixes the test failure on the 3.x branch.