### PR TITLE
Add support for CooperativeStickyAssignor with KafkaConsumer on 1.x

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -223,16 +223,16 @@ object KafkaConsumer {
 
         def enqueueAssignment(
           streamId: StreamId,
-          assigned: SortedSet[TopicPartition],
-          partitionsMapQueue: PartitionsMapQueue,
-          assignmentRevoked: F[Unit]
+          assigned: Map[TopicPartition, Deferred[F, Unit]],
+          partitionsMapQueue: PartitionsMapQueue
         ): F[Unit] = {
           val assignment: F[PartitionsMap] = if (assigned.isEmpty) {
             F.pure(Map.empty)
           } else {
             assigned.toVector
-              .traverse { partition =>
-                createPartitionStream(streamId, partition, assignmentRevoked).map { stream =>
+            .traverse {
+              case (partition, finisher) =>
+                createPartitionStream(streamId, partition, finisher.get).map { stream =>
                   partition -> stream
                 }
               }
@@ -251,57 +251,80 @@ object KafkaConsumer {
 
         def onRebalance(
           streamId: StreamId,
-          prevAssignmentFinisherRef: Ref[F, Deferred[F, Unit]],
+          assignmentRef: Ref[F, Map[TopicPartition, Deferred[F, Unit]]],
           partitionsMapQueue: PartitionsMapQueue
         ): OnRebalance[F, K, V] =
           OnRebalance(
-            onRevoked = _ => {
+            onRevoked = revoked => {
               for {
-                newFinisher <- Deferred[F, Unit]
-                prevAssignmentFinisher <- prevAssignmentFinisherRef.getAndSet(newFinisher)
-                _ <- prevAssignmentFinisher.complete(())
+                finishers <- assignmentRef.modify(_.partition(entry => !revoked.contains(entry._1)))
+                _ <- finishers.toVector
+                  .traverse {
+                    case (_, finisher) =>
+                      finisher.complete(())
+                  }
               } yield ()
             },
-            onAssigned = assigned => {
-              prevAssignmentFinisherRef.get.flatMap { prevAssignmentFinisher =>
-                enqueueAssignment(
+            onAssigned = assignedPartitions => {
+              for {
+                assignment <- assignedPartitions.toVector
+                  .traverse { partition =>
+                    Deferred[F, Unit].map(partition -> _)
+                  }
+                  .map(_.toMap)
+                _ <- assignmentRef.update(_ ++ assignment)
+                _ <- enqueueAssignment(
                   streamId = streamId,
-                  assigned = assigned,
-                  partitionsMapQueue = partitionsMapQueue,
-                  assignmentRevoked = prevAssignmentFinisher.get
+                  assigned = assignment,
+                  partitionsMapQueue = partitionsMapQueue
                 )
-              }
+              } yield ()
             }
           )
 
         def requestAssignment(
           streamId: StreamId,
-          prevAssignmentFinisherRef: Ref[F, Deferred[F, Unit]],
+          assignmentRef: Ref[F, Map[TopicPartition, Deferred[F, Unit]]],
           partitionsMapQueue: PartitionsMapQueue
-        ): F[SortedSet[TopicPartition]] =
+        ): F[Map[TopicPartition, Deferred[F, Unit]]] =
           Deferred[F, Either[Throwable, SortedSet[TopicPartition]]].flatMap { deferred =>
             val request =
               Request.Assignment[F, K, V](
                 deferred.complete,
-                Some(onRebalance(streamId, prevAssignmentFinisherRef, partitionsMapQueue))
+                Some(
+                  onRebalance(
+                    streamId,
+                    assignmentRef,
+                    partitionsMapQueue
+                  )
+                )
               )
             val assignment = requests.enqueue1(request) >> deferred.get.rethrow
-            F.race(awaitTermination.attempt, assignment).map {
-              case Left(_)         => SortedSet.empty[TopicPartition]
-              case Right(assigned) => assigned
+            F.race(awaitTermination.attempt, assignment).flatMap {
+              case Left(_) =>
+                F.pure(Map.empty)
+
+              case Right(assigned) =>
+                assigned.toVector
+                  .traverse { partition =>
+                    Deferred[F, Unit].map(partition -> _)
+                  }
+                  .map(_.toMap)
             }
           }
 
         def initialEnqueue(
           streamId: StreamId,
-          partitionsMapQueue: PartitionsMapQueue,
-          prevAssignmentFinisherRef: Ref[F, Deferred[F, Unit]]
+          assignmentRef: Ref[F, Map[TopicPartition, Deferred[F, Unit]]],
+          partitionsMapQueue: PartitionsMapQueue
         ): F[Unit] =
           for {
-            prevAssignmentFinisher <- prevAssignmentFinisherRef.get
-            assigned <- requestAssignment(streamId, prevAssignmentFinisherRef, partitionsMapQueue)
-            assignmentRevoked = prevAssignmentFinisher.get
-            _ <- enqueueAssignment(streamId, assigned, partitionsMapQueue, assignmentRevoked)
+            assigned <- requestAssignment(
+              streamId,
+              assignmentRef,
+              partitionsMapQueue
+            )
+            _ <- enqueueAssignment(streamId, assigned, partitionsMapQueue)
           } yield ()
 
         Stream.eval(stopConsumingDeferred.tryGet).flatMap {
@@ -309,10 +332,15 @@ object KafkaConsumer {
             for {
               partitionsMapQueue <- Stream.eval(Queue.noneTerminated[F, PartitionsMap])
               streamId <- Stream.eval(streamIdRef.modify(n => (n + 1, n)))
-              prevAssignmentFinisher <- Stream.eval(Deferred[F, Unit])
-              prevAssignmentFinisherRef <- Stream.eval(Ref[F].of(prevAssignmentFinisher))
+              assignmentRef <- Stream.eval(Ref[F].of(Map.empty[TopicPartition, Deferred[F, Unit]]))
               _ <- Stream
-                .eval(initialEnqueue(streamId, partitionsMapQueue, prevAssignmentFinisherRef))
+                .eval(
+                  initialEnqueue(
+                    streamId,
+                    assignmentRef,
+                    partitionsMapQueue
+                  )
+                )
               out <- partitionsMapQueue.dequeue
                 .interruptWhen(awaitTermination.attempt)
                 .concurrently(

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -230,11 +230,11 @@ object KafkaConsumer {
             F.pure(Map.empty)
           } else {
             assigned.toVector
-            .traverse {
-              case (partition, finisher) =>
-                createPartitionStream(streamId, partition, finisher.get).map { stream =>
-                  partition -> stream
-                }
+              .traverse {
+                case (partition, finisher) =>
+                  createPartitionStream(streamId, partition, finisher.get).map { stream =>
+                    partition -> stream
+                  }
               }
               .map(_.toMap)
           }

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
@@ -58,17 +58,25 @@ trait KafkaConsume[F[_], K, V] {
     * assignment is `Map`, where keys are a `TopicPartition`s, and values are
     * record streams for the `TopicPartition`.<br>
     * <br>
-    * New assignments will be received on each rebalance. On rebalance,
-    * Kafka revoke all previously assigned partitions, and after that assigned
-    * new partitions all at once. `partitionsMapStream` reflects this process
-    * in a streaming manner.<br>
+    * With the default assignor, previous partition assignments are revoked at
+    * once, and a new set of partitions assigned to a consumer on each
+    * rebalance. In this case, each returned map contains the full partition
+    * assignment for the consumer. `partitionsMapStream` reflects the assignment
+    * process in a streaming manner.<br>
+    * <br>
+    * This may not be the case when a custom assignor is configured in the
+    * consumer. When using the `CooperativeStickyAssignor`, for instance,
+    * partition assignments may be revoked individually. In this case, each
+    * element in the stream will contain only streams for newly assigned
+    * partitions. Streams returned previously will remain active until the
+    * assignment is revoked.<br>
     * <br>
     * Note, that partition streams for revoked partitions will
     * be closed after the new assignment comes.<br>
     * <br>
     * This is the most generic `Stream` method. If you don't need such control,
-    * consider using `partitionedStream` or `stream` methods.
-    * They are both based on a `partitionsMapStream`.
+    * consider using `partitionedStream` or `stream` methods. They are both
+    * based on a `partitionsMapStream`.
     *
     * @note you have to first use `subscribe` to subscribe the consumer
     *       before using this `Stream`. If you forgot to subscribe, there

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
@@ -54,9 +54,9 @@ trait KafkaConsume[F[_], K, V] {
   def partitionedStream: Stream[F, Stream[F, CommittableConsumerRecord[F, K, V]]]
 
   /**
-    * `Stream` where each element contains a current assignment. The current
-    * assignment is the `Map`, where keys is a `TopicPartition`, and values are
-    * streams with records for a particular `TopicPartition`.<br>
+    * `Stream` where each element contains an assignment. Each assignment
+    * assignment is `Map`, where keys are a `TopicPartition`s, and values are
+    * record streams for the `TopicPartition`.<br>
     * <br>
     * New assignments will be received on each rebalance. On rebalance,
     * Kafka revoke all previously assigned partitions, and after that assigned

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -315,7 +315,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
         val records = withRebalancing.records.keySetStrict
 
         val revokedFetches = revoked intersect fetches
-        val revokedNonFetches = revoked diff fetches
+        val revokedNonFetches = revoked diff revokedFetches
 
         val withRecords = records intersect revokedFetches
         val withoutRecords = revokedFetches diff records


### PR DESCRIPTION
Add backport of CooperativeStickyAssignor support in KafkaConsumer from https://github.com/fd4s/fs2-kafka/pull/844 to `1.x`