### PR TITLE
Change transactional producer to await produce before ending transaction

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -144,7 +144,7 @@ object TransactionalKafkaProducer {
                     KafkaProducer
                       .produceRecord(keySerializer, valueSerializer, producer, blocking)
                   )
-                  .map(_.sequence)
+                  .flatMap(_.sequence)
 
                 sendOffsets.fold(produce)(f => produce.flatTap(_ => f(producer, blocking)))
               } {
@@ -153,7 +153,7 @@ object TransactionalKafkaProducer {
                 case (_, Outcome.Canceled() | Outcome.Errored(_)) =>
                   blocking(producer.abortTransaction())
               }
-          }.flatten
+          }
 
         override def metrics: F[Map[MetricName, Metric]] =
           withProducer.blocking { _.metrics().asScala.toMap }


### PR DESCRIPTION
This is an extremely minor change that should have no/minimal end-user impact, but is probably more "correct" and may avoid invalid states in the producer.

Currently, we do not wait for the underlying Kafka producer to have sent any records before attempting to close (commit or abort) the transaction. Instead, it only waits until the records have been buffered internally. This works because `commitTransaction` awaits outstanding records and rethrows in the case of failure; if any record fails to send `commitTransaction` will fail and the user will see that.

With this change we will only try to commit the transaction once all records have been received by Kafka. This should have no user-facing impact in most cases. But, it may mean we more correctly call `abortTransaction` if a record fails to send, rather than potentially reaching an invalid state. The docstring says that you can retry `commitTransaction` after transient failures (retry and timeout), but "if not retrying, the only option is to close the producer."

At the moment if a message fails to send after we have called `commitTransaction` we may leave a producer open when we shouldn't.