### PR TITLE
Merge 2.x into 3.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,9 @@ val fs2Version = "3.6.1"
 
 val kafkaVersion = "3.3.2"
 
-val testcontainersScalaVersion = "0.40.12"
+val testcontainersScalaVersion = "0.40.14"
 
-val vulcanVersion = "1.8.4"
+val vulcanVersion = "1.9.0"
 
 val munitVersion = "0.7.29"
 

--- a/modules/core/src/main/scala/fs2/kafka/RecordDeserializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/RecordDeserializer.scala
@@ -15,9 +15,21 @@ import cats.{Applicative, Functor}
   * a creation effect.
   */
 sealed abstract class RecordDeserializer[F[_], A] {
+
   def forKey: F[KeyDeserializer[F, A]]
 
   def forValue: F[ValueDeserializer[F, A]]
+
+  /**
+    * Returns a new [[RecordDeserializer]] instance applying the mapping function to key and value deserializers
+    */
+  final def transform[B](
+    f: Deserializer[F, A] => Deserializer[F, B]
+  )(implicit F: Functor[F]): RecordDeserializer[F, B] =
+    RecordDeserializer.instance(
+      forKey = forKey.map(des => f(des.asInstanceOf[Deserializer[F, A]])),
+      forValue = forValue.map(des => f(des.asInstanceOf[Deserializer[F, A]]))
+    )
 
   /**
     * Returns a new [[RecordDeserializer]] instance that will catch deserialization
@@ -25,7 +37,16 @@ sealed abstract class RecordDeserializer[F[_], A] {
     * causing the consumer to fail.
     */
   final def attempt(implicit F: Functor[F]): RecordDeserializer[F, Either[Throwable, A]] =
-    RecordDeserializer.instance(forKey.map(_.attempt), forValue.map(_.attempt))
+    transform(_.attempt)
+
+  /**
+    * Returns a new [[RecordDeserializer]] instance that will deserialize key and value returning `None` when the
+    * bytes are `null`, and otherwise returns the result wrapped in `Some`.
+    *
+    * See [[Deserializer.option]] for more details.
+    */
+  final def option(implicit F: Functor[F]): RecordDeserializer[F, Option[A]] =
+    transform(_.option)
 }
 
 object RecordDeserializer {
@@ -46,8 +67,8 @@ object RecordDeserializer {
     forKey: => F[KeyDeserializer[F, A]],
     forValue: => F[ValueDeserializer[F, A]]
   ): RecordDeserializer[F, A] = {
-    def _forKey = forKey
-    def _forValue = forValue
+    def _forKey: F[KeyDeserializer[F, A]] = forKey
+    def _forValue: F[ValueDeserializer[F, A]] = forValue
 
     new RecordDeserializer[F, A] {
       override def forKey: F[KeyDeserializer[F, A]] =

--- a/modules/core/src/test/scala/fs2/kafka/RecordDeserializerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/RecordDeserializerSpec.scala
@@ -1,0 +1,67 @@
+package fs2.kafka
+
+import cats.effect.IO
+
+class RecordDeserializerSpec extends BaseSpec {
+
+  import cats.effect.unsafe.implicits.global
+
+  describe("RecordDeserializer#transform") {
+    it("should transform the RecordDeserializer applying the function to inner Deserializers") {
+
+      val strRecordDes: RecordDeserializer[IO, String] =
+        RecordDeserializer
+          .const(IO.pure(Deserializer[IO, Int]))
+          .transform(_.map(_.toString))
+
+      strRecordDes.forKey
+        .flatMap(_.deserialize("T1", Headers.empty, serializeToBytes(1)))
+        .unsafeRunSync() shouldBe "1"
+    }
+  }
+
+  describe("RecordDeserializer#attempt") {
+    it(
+      "should transform the RecordDeserializer[F, T] to RecordDeserializer[F, Either[Throwable, T]]"
+    ) {
+
+      val attemptIntRecordDes: RecordDeserializer[IO, Either[Throwable, Int]] =
+        RecordDeserializer
+          .const(IO.pure(Deserializer[IO, Int].flatMap[Int] {
+            case 1 => Deserializer[IO, Int]
+            case _ => Deserializer.failWith("Unsupported value")
+          }))
+          .attempt
+
+      attemptIntRecordDes.forKey
+        .flatMap(_.deserialize("T1", Headers.empty, serializeToBytes(1)))
+        .unsafeRunSync() shouldBe Right(1)
+
+      attemptIntRecordDes.forKey
+        .flatMap(_.deserialize("T1", Headers.empty, null))
+        .unsafeRunSync()
+        .isLeft shouldBe true
+    }
+  }
+
+  describe("RecordDeserializer#option") {
+    it("should transform the RecordDeserializer[F, T] to RecordDeserializer[F, Option[T]]") {
+
+      val optIntRecordDes: RecordDeserializer[IO, Option[Int]] =
+        RecordDeserializer
+          .const(IO.pure(Deserializer[IO, Int]))
+          .option
+
+      optIntRecordDes.forKey
+        .flatMap(_.deserialize("T1", Headers.empty, serializeToBytes(1)))
+        .unsafeRunSync() shouldBe Some(1)
+
+      optIntRecordDes.forKey
+        .flatMap(_.deserialize("T1", Headers.empty, null))
+        .unsafeRunSync() shouldBe None
+    }
+  }
+
+  private def serializeToBytes[T: Serializer[IO, *]](value: T): Array[Byte] =
+    Serializer[IO, T].serialize("", Headers.empty, value).unsafeRunSync()
+}

--- a/modules/core/src/test/scala/fs2/kafka/RecordDeserializerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/RecordDeserializerSpec.scala
@@ -27,9 +27,9 @@ class RecordDeserializerSpec extends BaseSpec {
 
       val attemptIntRecordDes: RecordDeserializer[IO, Either[Throwable, Int]] =
         RecordDeserializer
-          .const(IO.pure(Deserializer[IO, Int].flatMap[Int] {
+          .const(IO.pure(Deserializer[IO, Int].flatMap {
             case 1 => Deserializer[IO, Int]
-            case _ => Deserializer.failWith("Unsupported value")
+            case _ => Deserializer.failWith[IO, Int]("Unsupported value")
           }))
           .attempt
 

--- a/modules/core/src/test/scala/fs2/kafka/RecordSerializerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/RecordSerializerSpec.scala
@@ -1,0 +1,40 @@
+package fs2.kafka
+
+import cats.effect.IO
+
+class RecordSerializerSpec extends BaseSpec {
+
+  import cats.effect.unsafe.implicits.global
+
+  describe("RecordSerializer#transform") {
+    it("should transform the RecordSerializer applying the function to inner Serializers") {
+
+      val intRecordSer: RecordSerializer[IO, Int] =
+        RecordSerializer
+          .const(IO.pure(Serializer[IO, String]))
+          .transform(_.contramap(_.toString))
+
+      intRecordSer.forKey
+        .flatMap(_.serialize("T1", Headers.empty, 1))
+        .unsafeRunSync() shouldBe "1".getBytes
+    }
+  }
+
+  describe("RecordSerializer#option") {
+    it("should transform the RecordSerializer[F, T] to RecordSerializer[F, Option[T]]") {
+
+      val optStrRecordSer: RecordSerializer[IO, Option[String]] =
+        RecordSerializer
+          .const(IO.pure(Serializer[IO, String]))
+          .option
+
+      optStrRecordSer.forKey
+        .flatMap(_.serialize("T1", Headers.empty, Some("1")))
+        .unsafeRunSync() shouldBe "1".getBytes
+
+      optStrRecordSer.forKey
+        .flatMap(_.serialize("T1", Headers.empty, None))
+        .unsafeRunSync() shouldBe null
+    }
+  }
+}


### PR DESCRIPTION
Unfortunately, porting the `transform` method on `RecordSerializer`/`RecordDeserializer` forward requires a cast now that serdes are typed for key vs value. I don't think this is going to break anything but I'm not terribly comfortable with it either - it could be an extra incentive to improve these abstractions, but for now I want to push forward towards a 3.0 release given the library has been neglected for many months.