### PR TITLE
Revert "Change to publish on series branches"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/heads/series/'))
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -211,7 +211,7 @@ ThisBuild / githubWorkflowArtifactUpload := false
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8"), JavaSpec.temurin("17"))
 
 ThisBuild / githubWorkflowPublishTargetBranches :=
-  Seq(RefPredicate.StartsWith(Ref.Branch("series/")))
+  Seq(RefPredicate.StartsWith(Ref.Tag("v")))
 
 ThisBuild / githubWorkflowPublish := Seq(
   WorkflowStep.Sbt(


### PR DESCRIPTION
This reverts commit 78fc4258c8df82919d8ae38f6221dc4b6318915c.

@vlovgr what was the purpose of this change? I'm reverting it now to publish v2.6 but we can change it again if needed.