### PR TITLE
Preparatory changes for new CE cancelation semantics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val scala213 = "2.13.10"
 
 val scala3 = "3.2.2"
 
-ThisBuild / tlBaseVersion := "2.5"
+ThisBuild / tlBaseVersion := "2.6"
 
 ThisBuild / tlVersionIntroduced := Map("3" -> "2.1.0")
 

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -218,7 +218,17 @@ object KafkaProducer {
                 else promise.failure(exception)
               }
             )
-          }.as(F.fromFuture(F.delay(promise.future)))
+          }.as {
+            F.delay(promise.future).flatMap { fut =>
+              F.executionContext.flatMap { implicit ec =>
+                F.async[(ProducerRecord[K, V], RecordMetadata)] { cb =>
+                  F.delay(fut.onComplete(t => cb(t.toEither))).as(Some(F.unit))
+                }
+              }
+            }
+            // TODO: replace the above with the following once CE3.5.0 is out
+            // F.fromFutureCancelable(F.delay(promise.future))
+          }
         }
       }
 

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -113,7 +113,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
     k: (Either[Throwable, Unit] => Unit) => F[Unit]
   ): F[Unit] =
     F.async[Unit] { (cb: Either[Throwable, Unit] => Unit) =>
-        k(cb).as(None)
+        k(cb).as(Some(F.unit))
       }
       .timeoutTo(settings.commitTimeout, F.raiseError[Unit] {
         CommitTimeoutException(

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -102,7 +102,8 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
       }
 
   private[this] def manualCommitSync(request: Request.ManualCommitSync[F]): F[Unit] = {
-    val commit = withConsumer.blocking(_.commitSync(request.offsets.asJava))
+    val commit =
+      withConsumer.blocking(_.commitSync(request.offsets.asJava, settings.commitTimeout.asJava))
     commit.attempt >>= request.callback
   }
 

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithAdminClient.scala
@@ -28,7 +28,7 @@ private[kafka] object WithAdminClient {
         val withAdminClient =
           new WithAdminClient[G] {
             override def apply[A](f: AdminClient => KafkaFuture[A]): G[A] =
-              G.delay(f(adminClient)).cancelable
+              G.delay(f(adminClient)).cancelable_
           }
 
         val close =

--- a/modules/core/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -189,7 +189,7 @@ private[kafka] object syntax {
   ) extends AnyVal {
 
     // Inspired by Monix's `CancelableFuture#fromJavaCompletable`.
-    def cancelable(implicit F: Async[F]): F[A] =
+    def cancelable_(implicit F: Async[F]): F[A] =
       F.async { (cb: (Either[Throwable, A] => Unit)) =>
         futureF.flatMap { future =>
           F.blocking {

--- a/modules/core/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
@@ -83,7 +83,7 @@ final class SyntaxSpec extends BaseSpec {
             }
             future
           }
-          fiber <- futureIO.cancelable.start
+          fiber <- futureIO.cancelable_.start
           _ <- gate.get // wait for future to be created before canceling it
           _ <- IO(assert(!isFutureCancelled))
           _ <- fiber.cancel


### PR DESCRIPTION
Resolves #1181 by returning `Some(F.unit)` instead of `None` for the canceler of the uncancelable async commit operation.

Also uses configured timeout for sync commit, and renames some syntax to avoid clashing with a new method on `IO` in forthcoming CE3.5