### PR TITLE
SBT 1.9.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -267,7 +267,8 @@ ThisBuild / mimaBinaryIssueFilters ++= {
   import com.typesafe.tools.mima.core._
   // format: off
     Seq(
-      ProblemFilters.exclude[Problem]("fs2.kafka.internal.*")
+      ProblemFilters.exclude[Problem]("fs2.kafka.internal.*"),
+      ProblemFilters.exclude[MissingClassProblem]("kafka.utils.VerifiableProperties")
     )
     // format: on
 }

--- a/project/PackagingTypePlugin.scala
+++ b/project/PackagingTypePlugin.scala
@@ -1,9 +1,0 @@
-import sbt._
-
-// workaround from https://github.com/sbt/sbt/issues/3618#issuecomment-424924293
-object PackagingTypePlugin extends AutoPlugin {
-  override val buildSettings = {
-    sys.props += "packaging.type" -> "jar"
-    Nil
-  }
-}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.3
+sbt.version = 1.9.6


### PR DESCRIPTION
Just that, bumping to latest SBT version. 

Also did some tidying removing an old workaround that was fixed in SBT 1.3.x 🧹 

**NOTE:** Anyone knows why Scala Steward didn't create a PR for this? Maybe it bumps SBT versions one-by-one? 🤔 