### PR TITLE
Fix docs publishing

### DIFF
--- a/docs/src/main/mdoc/consumers.md
+++ b/docs/src/main/mdoc/consumers.md
@@ -332,7 +332,7 @@ We could combine `stopConsuming` with the custom resource handling and implement
 ```scala mdoc:silent
 import cats.effect.{Deferred, Ref}
 
-object WithGracefulShutdownExample extends IOApp.Simple {
+object WithGracefulShutdownExampleCE2 extends IOApp.Simple {
   val run: IO[Unit] = {
     def processRecord(record: CommittableConsumerRecord[IO, String, String]): IO[Unit] =
       IO(println(s"Processing record: $record"))
@@ -395,7 +395,7 @@ object WithGracefulShutdownExample extends IOApp.Simple {
 For cats-effect 3 the example above will not work as in cats-effect 2, because in cats-effect 3 cancelation semantics [was changed](https://typelevel.org/cats-effect/docs/typeclasses/monadcancel). Here is the example of graceful shutdown for cats-effect 3:
 
 ```scala mdoc:silent
-object WithGracefulShutdownExample extends IOApp.Simple {
+object WithGracefulShutdownExampleCE3 extends IOApp.Simple {
   val run: IO[Unit] = {
     def processRecord(record: CommittableConsumerRecord[IO, String, String]): IO[Unit] =
       IO(println(s"Processing record: $record"))

--- a/docs/src/main/scala/fs2/kafka/docs/Main.scala
+++ b/docs/src/main/scala/fs2/kafka/docs/Main.scala
@@ -2,20 +2,19 @@ package fs2.kafka.docs
 
 import fs2.kafka.build.info._
 import java.nio.file.{FileSystems, Path}
-import scala.collection.Seq
 
 object Main {
   def sourceDirectoryPath(rest: String*): Path =
     FileSystems.getDefault.getPath(sourceDirectory.getAbsolutePath, rest: _*)
 
-  def minorVersion(version: String): String = {
-    val Array(major, minor, _) = version.split('.')
-    s"$major.$minor"
+  def minorVersion(version: String): String = version.split('.') match {
+    case Array(major, minor, _) => s"$major.$minor"
+    case _                      => throw new IllegalArgumentException(s"Invalid major/minor: $version")
   }
 
-  def majorVersion(version: String): String = {
-    val Array(major, _, _) = version.split('.')
-    major
+  def majorVersion(version: String): String = version.split('.') match {
+    case Array(major, _, _) => major
+    case _                  => throw new IllegalArgumentException(s"Invalid major: $version")
   }
 
   def minorVersionsString(versions: Seq[String]): String = {


### PR DESCRIPTION
```
[error] /home/runner/work/fs2-kafka/fs2-kafka/docs/src/main/scala/fs2/kafka/docs/Main.scala:12:47: match may not be exhaustive.
[error]     val Array(major, minor, _) = version.split('.')
[error]                                               ^
[error] /home/runner/work/fs2-kafka/fs2-kafka/docs/src/main/scala/fs2/kafka/docs/Main.scala:17:43: match may not be exhaustive.
[error]     val Array(major, _, _) = version.split('.')
[error]                                           ^
[error] two errors found
[error] (docs / Compile / compileIncremental) Compilation failed
[error] Total time: 10 s, completed Oct 1, 2023 7:48:53 AM
```