### PR TITLE
Remove deprecated methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -274,8 +274,8 @@ lazy val publishSettings =
 ThisBuild / mimaBinaryIssueFilters ++= {
   import com.typesafe.tools.mima.core.*
   Seq(
-    ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.internal.FakeFiber"),
-    ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.internal.FakeFiber$"),
+    ProblemFilters.exclude[Problem]("fs2.kafka.internal.*"),
+    ProblemFilters.exclude[MissingClassProblem]("kafka.utils.VerifiableProperties"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.AdminClientSettings.apply"),
     ProblemFilters
       .exclude[DirectMissingMethodProblem]("fs2.kafka.TransactionalProducerRecords.apply"),

--- a/build.sbt
+++ b/build.sbt
@@ -274,6 +274,8 @@ lazy val publishSettings =
 ThisBuild / mimaBinaryIssueFilters ++= {
   import com.typesafe.tools.mima.core.*
   Seq(
+    ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.internal.FakeFiber"),
+    ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.internal.FakeFiber$"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.AdminClientSettings.apply"),
     ProblemFilters
       .exclude[DirectMissingMethodProblem]("fs2.kafka.TransactionalProducerRecords.apply"),

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val scala213 = "2.13.12"
 
 val scala3 = "3.3.1"
 
-ThisBuild / tlBaseVersion := "3.2"
+ThisBuild / tlBaseVersion := "3.3"
 
 ThisBuild / tlCiReleaseBranches := Seq("series/3.x")
 
@@ -274,8 +274,13 @@ lazy val publishSettings =
 ThisBuild / mimaBinaryIssueFilters ++= {
   import com.typesafe.tools.mima.core.*
   Seq(
-    ProblemFilters.exclude[Problem]("fs2.kafka.internal.*"),
-    ProblemFilters.exclude[MissingClassProblem]("kafka.utils.VerifiableProperties")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.AdminClientSettings.apply"),
+    ProblemFilters
+      .exclude[DirectMissingMethodProblem]("fs2.kafka.TransactionalProducerRecords.apply"),
+    ProblemFilters
+      .exclude[DirectMissingMethodProblem]("fs2.kafka.vulcan.AvroSettings.createAvroSerializer"),
+    ProblemFilters
+      .exclude[DirectMissingMethodProblem]("fs2.kafka.vulcan.AvroSettings.withCreateAvroSerializer")
   )
 }
 

--- a/modules/core/src/main/scala/fs2/kafka/AdminClientSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/AdminClientSettings.scala
@@ -231,13 +231,6 @@ object AdminClientSettings {
 
   }
 
-  @deprecated("use the overload that takes an argument for BootstrapServers", "2.0.0")
-  def apply: AdminClientSettings =
-    AdminClientSettingsImpl(
-      properties = Map.empty,
-      closeTimeout = 20.seconds
-    )
-
   def apply(bootstrapServers: String): AdminClientSettings =
     AdminClientSettingsImpl(
       properties = Map.empty,

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -130,11 +130,6 @@ package kafka {
 
   object TransactionalProducerRecords {
 
-    @deprecated("this is now an identity operation", "3.0.0-M5")
-    def apply[F[_], K, V](
-      chunk: Chunk[CommittableProducerRecords[F, K, V]]
-    ): Chunk[CommittableProducerRecords[F, K, V]] = chunk
-
     /**
       * Creates a new [[TransactionalProducerRecords]] for producing exactly one
       * [[CommittableProducerRecords]]

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSettings.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSettings.scala
@@ -104,12 +104,6 @@ sealed abstract class AvroSettings[F[_]] {
     writerSchema: Option[Schema]
   ): F[(KafkaAvroSerializer, SchemaRegistryClient)]
 
-  @deprecated("use the overload that takes an optional writer schema", "2.5.0-M3")
-  final def createAvroSerializer(
-    isKey: Boolean
-  ): F[(KafkaAvroSerializer, SchemaRegistryClient)] =
-    createAvroSerializer(isKey, writerSchema = None)
-
   /**
     * Creates a new [[AvroSettings]] instance with the specified function for creating
     * `KafkaAvroDeserializer`s from settings. The arguments are [[schemaRegistryClient]], `isKey`,
@@ -131,16 +125,6 @@ sealed abstract class AvroSettings[F[_]] {
     createAvroSerializerWith: (F[SchemaRegistryClient], Boolean, Option[Schema], Map[String, String]) => F[(KafkaAvroSerializer, SchemaRegistryClient)]
     // format: on
   ): AvroSettings[F]
-
-  @deprecated("use the overload that has an `Option[Schema]` argument", "2.5.0-M3")
-  final def withCreateAvroSerializer(
-    // format: off
-    createAvroSerializerWith: (F[SchemaRegistryClient], Boolean, Map[String, String]) => F[(KafkaAvroSerializer, SchemaRegistryClient)]
-    // format: on
-  ): AvroSettings[F] =
-    withCreateAvroSerializer((client, isKey, _, properties) =>
-      createAvroSerializerWith(client, isKey, properties)
-    )
 
   /**
     * Creates a new [[AvroSettings]] instance with the specified function for registering schemas


### PR DESCRIPTION
It's been a long time since 3.x was published and users have had enough time to stop using these deprecated methods.