### PR TITLE
Fix flaky `KafkaConsumer#assignmentStream` tests

### DIFF
--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -778,7 +778,6 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
                    .evalMap { consumer =>
                      consumer
                        .assignmentStream
-                       .concurrently(consumer.records)
                        .evalMap(as => queue.offer(Some(as)))
                        .compile
                        .drain
@@ -837,7 +836,6 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
                    .evalMap { consumer =>
                      consumer
                        .assignmentStream
-                       .concurrently(consumer.records)
                        .evalMap(as => queue.offer(Some(as)))
                        .compile
                        .drain


### PR DESCRIPTION
There's no need to consume a topic's records in order to test the partition assignments.

This causes a race condition where, if `consumer.records` occurs first, the initial expected empty assignment is not streamed 👇🏽 (see the missing first `TreeSet()`):

```
[info] - should stream assignment updates to listeners *** FAILED *** (10 seconds, 632 milliseconds)
[info]   List(TreeSet(topic-2b357246-81b5-460d-ba2e-822ed148e635-0, topic-2b357246-81b5-460d-ba2e-822ed148e635-1, topic-2b357246-81b5-460d-ba2e-822ed148e635-2), TreeSet(), TreeSet(topic-2b357246-81b5-460d-ba2e-822ed148e635-0, topic-2b357246-81b5-460d-ba2e-822ed148e635-1)) had length 3 instead of expected length 4 (KafkaConsumerSpec.scala:803)
```