### PR TITLE
Add chunk-based consumer API

### DIFF
--- a/docs/src/main/mdoc/consumers.md
+++ b/docs/src/main/mdoc/consumers.md
@@ -12,6 +12,7 @@ import scala.concurrent.duration._
 
 import cats.effect._
 import cats.syntax.all._
+import fs2._
 import fs2.kafka._
 import fs2.kafka.consumer.KafkaConsumeChunk.CommitNow
 ```

--- a/docs/src/main/mdoc/consumers.md
+++ b/docs/src/main/mdoc/consumers.md
@@ -13,6 +13,7 @@ import scala.concurrent.duration._
 import cats.effect._
 import cats.syntax.all._
 import fs2.kafka._
+import fs2.kafka.consumer.KafkaConsumeChunk.CommitNow
 ```
 
 ## Deserializers

--- a/docs/src/main/mdoc/consumers.md
+++ b/docs/src/main/mdoc/consumers.md
@@ -275,9 +275,9 @@ Offsets commits are managed manually, which is important for ensuring at-least-o
 
 ### Working on `Chunk`
 
-Most use cases that require at-least-once delivery make it necessary to commit the offset of messages only after the message has been successfully processed. Implementing this correctly can be challenging, especially when the business logic requires advanced data manipulation with concurrency, batching, filtering and the like:
+Use cases that require at-least-once delivery make it necessary to commit the offset of messages only after the message has been successfully processed. Implementing this correctly can be challenging, especially when the business logic requires advanced data manipulation with concurrency, batching, filtering and the like:
 
-- When consuming multiple messages from the same partition concurrently, a consumer might lose messages if the commits happen out of order and one of the older messages can't be processed and has to be retried.
+- When consuming multiple messages from the same partition concurrently, a consumer might lose messages if the commits happen out of order and a message that is not the last one on its partition can't be processed and has to be retried.
 - When filtering messages, it's important to still commit the offset of the filtered message because if this message is the latest one on its partition, it will get re-sent infinitely.
 - For performance reasons, it makes sense to batch the offsets when committing them.
 
@@ -298,13 +298,14 @@ object ConsumerChunkExample extends IOApp.Simple {
 
 Note that this method uses `partitionedStream`, which means that all the partitions assigned to the consumer will be processed concurrently.
 
-As a user, you don't have to care about the offset commits, all you have to do is implement a function that processes all records in the `Chunk`, and return a `IO[CommitNow]`. After this action finished, the offsets for all messages in the `Chunk` will be committed. `CommitNow` is basically the same as `Unit`, but helps in making it clear when the processing of messages has been finished.
+As a user, you don't have to care about the offset commits, all you have to do is implement a function that processes all records in the `Chunk`, and return a `IO[CommitNow]`. After this action finished, the offsets for all messages in the `Chunk` will be committed. `CommitNow` is basically the same as `Unit`, but helps in making it clear when the processing of messages has been finished and it's time to commit.
 
-This brings several benefits for the most use cases:
+This brings several benefits:
 
 - **Correctness:** You can focus on implementing your business logic, without having to worry about offset commits or propagating the correct offsets through your code. Offsets are committed correctly afterwards.
 - **Performance:** Typical performance improvements are bulk-writes to a database, or using concurrency to speed things up. These patterns can be used liberally when working on the records in a `Chunk`, without having to sacrifice correctness.
 - **Flexibility:** Besides using batching and concurrency, you might want to filter out messages, or process them in a different order than they appear on the partitions. As long as you work on a single `Chunk` and make sure that the processing is finished when you return `CommitNow`, you can do all that.
+- A concrete example that makes use of these ideas is to group all the messages in the `Chunk` by key and then only process the last message for each key (basically doing what Kafka's log compaction does). In many occasions, it's also possible to process the messages for different keys concurrently, which drastically increases the available concurrency.
 
 If the chunk size doesn't fit your needs, the first way to start tuning is the `max.poll.records` config property of your consumer.
 

--- a/docs/src/main/mdoc/quick-example.md
+++ b/docs/src/main/mdoc/quick-example.md
@@ -11,6 +11,7 @@ Following is an example showing how to:
 
 ```scala mdoc
 import cats.effect.{IO, IOApp}
+import fs2._
 import fs2.kafka._
 import fs2.kafka.consumer.KafkaConsumeChunk.CommitNow
 

--- a/docs/src/main/mdoc/quick-example.md
+++ b/docs/src/main/mdoc/quick-example.md
@@ -10,17 +10,12 @@ Following is an example showing how to:
 - use `commitBatchWithin` to commit consumed offsets in batches.
 
 ```scala mdoc
-import scala.concurrent.duration._
-
 import cats.effect.{IO, IOApp}
 import fs2.kafka._
+import fs2.kafka.consumer.KafkaConsumeChunk.CommitNow
 
 object Main extends IOApp.Simple {
-
   val run: IO[Unit] = {
-    def processRecord(record: ConsumerRecord[String, String]): IO[(String, String)] =
-      IO.pure(record.key -> record.value)
-
     val consumerSettings =
       ConsumerSettings[IO, String, String]
         .withAutoOffsetReset(AutoOffsetReset.Earliest)
@@ -28,34 +23,23 @@ object Main extends IOApp.Simple {
         .withGroupId("group")
 
     val producerSettings =
-      ProducerSettings[IO, String, String].withBootstrapServers("localhost:9092")
+      ProducerSettings[IO, String, String]
+        .withBootstrapServers("localhost:9092")
+
+    def processRecords(producer: KafkaProducer[IO, String, String])(records: Chunk[ConsumerRecord[String, String]]): IO[CommitNow] = {
+      val producerRecords = records.map(consumerRecord => ProducerRecord("topic", consumerRecord.key, consumerRecord.value))
+      producer.produce(producerRecords).flatten.as(CommitNow)
+    }
 
     val stream =
-      KafkaConsumer
-        .stream(consumerSettings)
-        .subscribeTo("topic")
-        .records
-        .mapAsync(25) { committable =>
-          processRecord(committable.record).map { case (key, value) =>
-            val record = ProducerRecord("topic", key, value)
-            committable.offset -> ProducerRecords.one(record)
-          }
-        }
-        .through { offsetsAndProducerRecords =>
-          KafkaProducer
-            .stream(producerSettings)
-            .flatMap { producer =>
-              offsetsAndProducerRecords
-                .evalMap { case (offset, producerRecord) =>
-                  producer.produce(producerRecord).map(_.as(offset))
-                }
-                .parEvalMap(Int.MaxValue)(identity)
-            }
-        }
-        .through(commitBatchWithin(500, 15.seconds))
+      KafkaProducer.stream(producerSettings).flatMap { producer =>
+        KafkaConsumer
+          .stream(consumerSettings)
+          .subscribeTo("topic")
+          .consumeChunk(chunk => processRecords(producer)(chunk))
+      }
 
     stream.compile.drain
   }
-
 }
 ```

--- a/docs/src/main/mdoc/quick-example.md
+++ b/docs/src/main/mdoc/quick-example.md
@@ -33,7 +33,7 @@ object Main extends IOApp.Simple {
     }
 
     val stream =
-      KafkaProducer.stream(producerSettings).flatMap { producer =>
+      KafkaProducer.stream(producerSettings).evalMap { producer =>
         KafkaConsumer
           .stream(consumerSettings)
           .subscribeTo("topic")

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -63,6 +63,7 @@ import org.apache.kafka.common.{Metric, MetricName, PartitionInfo, TopicPartitio
   */
 sealed abstract class KafkaConsumer[F[_], K, V]
     extends KafkaConsume[F, K, V]
+    with KafkaConsumeChunk[F, K, V]
     with KafkaAssignment[F]
     with KafkaOffsetsV2[F]
     with KafkaSubscription[F]

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
@@ -1,0 +1,23 @@
+package fs2.kafka.consumer
+
+import cats.syntax.flatMap.*
+import fs2.*
+import fs2.kafka.CommittableConsumerRecord
+import fs2.kafka.CommittableOffsetBatch
+import fs2.kafka.ConsumerRecord
+import cats.MonadThrow
+
+trait KafkaConsumeChunk[F[_], K, V] extends KafkaConsume[F, K, V] {
+
+  final def streamChunk(
+    processor: Chunk[ConsumerRecord[K, V]] => F[Unit]
+  )(implicit F: MonadThrow[F]): Stream[F, Unit] =
+    stream.chunks.evalMap(consumeChunk(processor))
+
+  private def consumeChunk(processor: Chunk[ConsumerRecord[K, V]] => F[Unit])(
+    chunk: Chunk[CommittableConsumerRecord[F, K, V]]
+  )(implicit F: MonadThrow[F]): F[Unit] =
+    processor(chunk.map(_.record)) >> CommittableOffsetBatch
+      .fromFoldable(chunk.map(_.offset))
+      .commit
+}

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
@@ -11,6 +11,44 @@ import fs2.kafka.ConsumerRecord
 
 trait KafkaConsumeChunk[F[_], K, V] extends KafkaConsume[F, K, V] {
 
+  /**
+    * Consume from all assigned partitions concurrently, processing the messages in `Chunk`s. For
+    * each `Chunk`, the provided `processor` is called, after that has finished the offsets for all
+    * messages in the chunks are committed.<br><br>
+    *
+    * This method is intended to be used in cases where messages have to be processed before offsets
+    * are committed. By relying on the methods like [[partitionedStream]], [[records]], and similar,
+    * you have to correctly implement not only your processing logic but also the correct mechanism
+    * for committing offsets. This can be tricky to do in a correct and efficient way
+    *
+    * This approach has several benefits:<br>
+    *   - As a user, you don't have to care about committing offsets correctly. You can focus on
+    *     implementing your business logic<br>
+    *   - It's very straightforward to batch several messages from a `Chunk` together, e.g. for
+    *     efficient writes to a persistent storage<br>
+    *   - You can liberally use logic that involves concurrency, filtering, and re-ordering of
+    *     messages without having to worry about incorrect offset commits<br>
+    *
+    * <br>
+    *
+    * The `processor` is a function that takes a `Chunk[ConsumerRecord[K, V]]` and returns a
+    * `F[CommitNow]`. [[CommitNow]] is isomorphic to `Unit`, but helps in transporting the intention
+    * that processing of a `Chunk` is done and offsets should be committed.<br><br>
+    *
+    * The returned value is `F[Nothing]`, because it's a never-ending process that doesn't
+    * terminate, and therefore doesn't return a result.
+    *
+    * @note
+    *   This method does not make any use of Kafka's auto-commit feature, it implements "manual"
+    *   commits in a way that suits most of the common use cases.
+    * @note
+    *   you have to first use `subscribe` or `assign` the consumer before using this `Stream`. If
+    *   you forgot to subscribe, there will be a [[NotSubscribedException]] raised in the `Stream`.
+    * @see
+    *   [[partitionedStream]]
+    * @see
+    *   [[CommitNow]]
+    */
   final def consumeChunk(
     processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow]
   )(implicit F: Concurrent[F]): F[Nothing] = partitionedStream
@@ -36,6 +74,13 @@ trait KafkaConsumeChunk[F[_], K, V] extends KafkaConsume[F, K, V] {
 object KafkaConsumeChunk {
 
   type CommitNow = CommitNow.type
+
+  /**
+    * Token to indicate that a `Chunk` has been processed and the corresponding offsets are ready to
+    * be committed.<br>
+    *
+    * Isomorphic to `Unit`, but more intention revealing.
+    */
   object CommitNow
 
 }

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2018-2024 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package fs2.kafka.consumer
 
 import cats.effect.Concurrent

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
@@ -1,23 +1,51 @@
 package fs2.kafka.consumer
 
 import cats.syntax.flatMap.*
+import cats.MonadThrow
 import fs2.*
+import fs2.kafka.consumer.KafkaConsumeChunk.CommitNow
 import fs2.kafka.CommittableConsumerRecord
 import fs2.kafka.CommittableOffsetBatch
 import fs2.kafka.ConsumerRecord
-import cats.MonadThrow
+
+import org.apache.kafka.common.TopicPartition
 
 trait KafkaConsumeChunk[F[_], K, V] extends KafkaConsume[F, K, V] {
 
+  final def recordsChunk(
+    processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type]
+  )(implicit F: MonadThrow[F]): Stream[F, Unit] = streamChunk(processor)
+
   final def streamChunk(
-    processor: Chunk[ConsumerRecord[K, V]] => F[Unit]
+    processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type]
   )(implicit F: MonadThrow[F]): Stream[F, Unit] =
     stream.chunks.evalMap(consumeChunk(processor))
 
-  private def consumeChunk(processor: Chunk[ConsumerRecord[K, V]] => F[Unit])(
+  final def partitionedRecordsChunk(
+    processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type]
+  )(implicit F: MonadThrow[F]): Stream[F, Stream[F, Unit]] =
+    partitionedStreamChunk(processor)
+
+  final def partitionedStreamChunk(
+    processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type]
+  )(implicit F: MonadThrow[F]): Stream[F, Stream[F, Unit]] =
+    partitionedStream.map(_.chunks.evalMap(consumeChunk(processor)))
+
+  final def partitionsMapStreamChunk(
+    processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type]
+  )(implicit F: MonadThrow[F]): Stream[F, Map[TopicPartition, Stream[F, Unit]]] =
+    partitionsMapStream
+      .map(m => m.map(kv => (kv._1, kv._2.chunks.evalMap(consumeChunk(processor)))))
+
+  private def consumeChunk(processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type])(
     chunk: Chunk[CommittableConsumerRecord[F, K, V]]
   )(implicit F: MonadThrow[F]): F[Unit] =
     processor(chunk.map(_.record)) >> CommittableOffsetBatch
       .fromFoldable(chunk.map(_.offset))
       .commit
+
+}
+
+object KafkaConsumeChunk {
+  object CommitNow
 }

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
@@ -1,51 +1,41 @@
 package fs2.kafka.consumer
 
+import cats.effect.Concurrent
 import cats.syntax.flatMap.*
-import cats.MonadThrow
+import cats.Monad
 import fs2.*
 import fs2.kafka.consumer.KafkaConsumeChunk.CommitNow
 import fs2.kafka.CommittableConsumerRecord
 import fs2.kafka.CommittableOffsetBatch
 import fs2.kafka.ConsumerRecord
 
-import org.apache.kafka.common.TopicPartition
-
 trait KafkaConsumeChunk[F[_], K, V] extends KafkaConsume[F, K, V] {
 
-  final def recordsChunk(
-    processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type]
-  )(implicit F: MonadThrow[F]): Stream[F, Unit] = streamChunk(processor)
+  final def consumeChunk(
+    processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow]
+  )(implicit F: Concurrent[F]): F[Nothing] = partitionedStream
+    .map(
+      _.chunks.evalMap(consumeChunk(processor))
+    )
+    .parJoinUnbounded
+    .compile
+    .drain >> F.never
 
-  final def streamChunk(
-    processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type]
-  )(implicit F: MonadThrow[F]): Stream[F, Unit] =
-    stream.chunks.evalMap(consumeChunk(processor))
-
-  final def partitionedRecordsChunk(
-    processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type]
-  )(implicit F: MonadThrow[F]): Stream[F, Stream[F, Unit]] =
-    partitionedStreamChunk(processor)
-
-  final def partitionedStreamChunk(
-    processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type]
-  )(implicit F: MonadThrow[F]): Stream[F, Stream[F, Unit]] =
-    partitionedStream.map(_.chunks.evalMap(consumeChunk(processor)))
-
-  final def partitionsMapStreamChunk(
-    processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type]
-  )(implicit F: MonadThrow[F]): Stream[F, Map[TopicPartition, Stream[F, Unit]]] =
-    partitionsMapStream
-      .map(m => m.map(kv => (kv._1, kv._2.chunks.evalMap(consumeChunk(processor)))))
-
-  private def consumeChunk(processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow.type])(
+  private def consumeChunk(processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow])(
     chunk: Chunk[CommittableConsumerRecord[F, K, V]]
-  )(implicit F: MonadThrow[F]): F[Unit] =
-    processor(chunk.map(_.record)) >> CommittableOffsetBatch
-      .fromFoldable(chunk.map(_.offset))
-      .commit
+  )(implicit F: Monad[F]): F[Unit] = {
+    val (offsets, records) = chunk.foldLeft(
+      (CommittableOffsetBatch.empty, Chunk.empty[ConsumerRecord[K, V]])
+    )((acc, record) => (acc._1.updated(record.offset), acc._2 ++ Chunk(record.record)))
+
+    processor(records) >> offsets.commit
+  }
 
 }
 
 object KafkaConsumeChunk {
+
+  type CommitNow = CommitNow.type
   object CommitNow
+
 }

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
@@ -64,9 +64,9 @@ trait KafkaConsumeChunk[F[_], K, V] extends KafkaConsume[F, K, V] {
       _.chunks.evalMap(consume(processor))
     )
     .parJoinUnbounded
-    .compile
     .drain
-    .flatMap[Nothing](_ => F.never)
+    .compile
+    .onlyOrError
 
   private def consume(processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow])(
     chunk: Chunk[CommittableConsumerRecord[F, K, V]]

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
@@ -12,16 +12,17 @@ import fs2.kafka.ConsumerRecord
 trait KafkaConsumeChunk[F[_], K, V] extends KafkaConsume[F, K, V] {
 
   /**
-    * Consume from all assigned partitions concurrently, processing the messages in `Chunk`s. For
+    * Consume from all assigned partitions concurrently, processing the records in `Chunk`s. For
     * each `Chunk`, the provided `processor` is called, after that has finished the offsets for all
-    * messages in the chunks are committed.<br><br>
+    * messages in the chunk are committed.<br><br>
     *
-    * This method is intended to be used in cases where messages have to be processed before offsets
-    * are committed. By relying on the methods like [[partitionedStream]], [[records]], and similar,
-    * you have to correctly implement not only your processing logic but also the correct mechanism
-    * for committing offsets. This can be tricky to do in a correct and efficient way
+    * This method is intended to be used in cases that require at-least-once-delivery, where
+    * messages have to be processed before offsets are committed. By relying on the methods like
+    * [[partitionedStream]], [[records]], and similar, you have to correctly implement not only your
+    * processing logic but also the correct mechanism for committing offsets. This can be tricky to
+    * do in a correct and efficient way.<br><br>
     *
-    * This approach has several benefits:<br>
+    * Working with `Chunk`s of records has several benefits:<br>
     *   - As a user, you don't have to care about committing offsets correctly. You can focus on
     *     implementing your business logic<br>
     *   - It's very straightforward to batch several messages from a `Chunk` together, e.g. for
@@ -33,7 +34,8 @@ trait KafkaConsumeChunk[F[_], K, V] extends KafkaConsume[F, K, V] {
     *
     * The `processor` is a function that takes a `Chunk[ConsumerRecord[K, V]]` and returns a
     * `F[CommitNow]`. [[CommitNow]] is isomorphic to `Unit`, but helps in transporting the intention
-    * that processing of a `Chunk` is done and offsets should be committed.<br><br>
+    * that processing of a `Chunk` is done, offsets should be committed, and no important processing
+    * should be done afterwards.<br><br>
     *
     * The returned value has the type `F[Nothing]`, because it's a never-ending process that doesn't
     * terminate, and therefore doesn't return a result.

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
@@ -35,7 +35,7 @@ trait KafkaConsumeChunk[F[_], K, V] extends KafkaConsume[F, K, V] {
     * `F[CommitNow]`. [[CommitNow]] is isomorphic to `Unit`, but helps in transporting the intention
     * that processing of a `Chunk` is done and offsets should be committed.<br><br>
     *
-    * The returned value is `F[Nothing]`, because it's a never-ending process that doesn't
+    * The returned value has the type `F[Nothing]`, because it's a never-ending process that doesn't
     * terminate, and therefore doesn't return a result.
     *
     * @note

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
@@ -65,7 +65,8 @@ trait KafkaConsumeChunk[F[_], K, V] extends KafkaConsume[F, K, V] {
     )
     .parJoinUnbounded
     .compile
-    .drain >> F.never
+    .drain
+    .flatMap[Nothing](_ => F.never)
 
   private def consume(processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow])(
     chunk: Chunk[CommittableConsumerRecord[F, K, V]]

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
@@ -55,13 +55,13 @@ trait KafkaConsumeChunk[F[_], K, V] extends KafkaConsume[F, K, V] {
     processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow]
   )(implicit F: Concurrent[F]): F[Nothing] = partitionedStream
     .map(
-      _.chunks.evalMap(consumeChunk(processor))
+      _.chunks.evalMap(consume(processor))
     )
     .parJoinUnbounded
     .compile
     .drain >> F.never
 
-  private def consumeChunk(processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow])(
+  private def consume(processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow])(
     chunk: Chunk[CommittableConsumerRecord[F, K, V]]
   )(implicit F: Monad[F]): F[Unit] = {
     val (offsets, records) = chunk.foldLeft(

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -1190,7 +1190,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
                  .evalMap(
                    _.consumeChunk(chunk =>
                      chunk
-                       .traverse(record => ref.getAndUpdate(_.appended(record.key -> record.value)))
+                       .traverse(record => ref.getAndUpdate(_ :+ (record.key -> record.value)))
                        .as(CommitNow)
                    )
                  ).interruptAfter(10.seconds).compile.drain
@@ -1205,7 +1205,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
 
         val actuallyCommitted = withKafkaConsumer(defaultConsumerProperties) { consumer =>
           consumer.committed(Set(topicPartition).asJava).asScala.toMap
-        }.view.mapValues(_.offset()).toMap
+        }.map { case (k, v) => k -> v.offset() }.toMap
 
         actuallyCommitted shouldBe Map(topicPartition -> 5L)
       }


### PR DESCRIPTION
This adds an API to make the pattern of chunk-based consumers a first-class concept. The idea keeps popping up in the typelevel discord, and we've been successfully using it at $WORK for a while now, so it makes sense to add it.

# General idea

The pattern aims at helping users to implement consumers without auto-commit to write their code without having to do too much work in order to achieve correct offset committing (no offsets must be lost, offsets should be committed only after messages have been processed, etc).
It achieves that by switching from processing messages in a `Stream[F, CommittableConsumerRecord[F, K, V]]` to processing them chunks: `Chunk[ConsumerRecord[K, V]] => F[Unit]`. After each chunk, the offsets of the chunk are committed.

This has a couple of advantages (summarizing [what Fabio said on the Discord](https://discord.com/channels/632277896739946517/632310980449402880/1179069659128008775)) :
* Consumers can write their business logic without having to care about offsets
* batching several messages is very straightforward, which is often practical (e.g. batch writes to the db)
* concurrency and filtering can be done liberally without having to worry about incorrect commits

# open questions

* Do we want to mirror all methods from the `KafkaConsume` trait in the new trait? I only added one of them so far to show the concept, the rest could be implemented in the same fashion.
* Instead of `Unit`, the processor for the chunks could use a return type of `F[CommitNow]`, where `CommitNow` is an intention revealing equivalent of `Unit` that also makes it more clear that afterwards no processing should be done on the records. Do we want that?
* Instead of only processing single chunks, the library could also offer (additional?) ways that take care of things like:
  * deduplicating messages in a chunk by key (I feel this may be too much for the library and might be confusing for some consumers, and it's also relatively easy to implement consumer side)
  * allowing to process messages concurrently, using concurrency per key (this is a bit more tricky to implement, so it might be a good idea to provide it in an opt-in way for those consumers who want it but don't want to implement it themselves). If we decide to allow both the "simple" chunk-based approach as well as the "concurrent-by-key" approach, I'd be happy to add that after this PR is done.

# todos

There's still a lot of work to do, but I wanted to get some early feedback on the general concept before doing the busy work.

- testing
- docs
- add the missing methods to make the API complete and consistent to the rest

I'm looking forward to receiving some feedbacks and thoughts on this idea!