### PR TITLE
Plugin dependencies under `sbt-typelevel` umbrella

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12, 2.13, 3]
-        java: [temurin@8, temurin@17]
+        java: [temurin@21, temurin@8]
         exclude:
           - scala: 2.12
-            java: temurin@17
+            java: temurin@8
           - scala: 3
-            java: temurin@17
+            java: temurin@8
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -42,6 +42,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Java (temurin@21)
+        id: setup-java-temurin-21
+        if: matrix.java == 'temurin@21'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@21' && steps.setup-java-temurin-21.outputs.cache-hit == 'false'
+        run: sbt +update
 
       - name: Setup Java (temurin@8)
         id: setup-java-temurin-8
@@ -54,19 +67,6 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt +update
-
-      - name: Setup Java (temurin@17)
-        id: setup-java-temurin-17
-        if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Check that workflows are up to date
@@ -84,13 +84,26 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [temurin@8]
+        java: [temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Java (temurin@21)
+        id: setup-java-temurin-21
+        if: matrix.java == 'temurin@21'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@21' && steps.setup-java-temurin-21.outputs.cache-hit == 'false'
+        run: sbt +update
 
       - name: Setup Java (temurin@8)
         id: setup-java-temurin-8
@@ -103,19 +116,6 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt +update
-
-      - name: Setup Java (temurin@17)
-        id: setup-java-temurin-17
-        if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Import signing key
@@ -149,13 +149,26 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [temurin@8]
+        java: [temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Java (temurin@21)
+        id: setup-java-temurin-21
+        if: matrix.java == 'temurin@21'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@21' && steps.setup-java-temurin-21.outputs.cache-hit == 'false'
+        run: sbt +update
 
       - name: Setup Java (temurin@8)
         id: setup-java-temurin-8
@@ -168,19 +181,6 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt +update
-
-      - name: Setup Java (temurin@17)
-        id: setup-java-temurin-17
-        if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: sbt
-
-      - name: sbt update
-        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Submit Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - run: sbt '++ ${{ matrix.scala }}' ci
 
-      - if: matrix.scala == '2.13.12'
+      - if: matrix.scala == '2.13'
         run: sbt '++ ${{ matrix.scala }}' docs/run
 
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - run: sbt '++ ${{ matrix.scala }}' ci
 
-      - if: matrix.scala == '2.13'
+      - if: matrix.scala == '2.13' && matrix.java == 'temurin@21'
         run: sbt '++ ${{ matrix.scala }}' docs/run
 
   publish:

--- a/build.sbt
+++ b/build.sbt
@@ -216,7 +216,10 @@ ThisBuild / githubWorkflowBuild := Seq(
 
 ThisBuild / githubWorkflowArtifactUpload := false
 
-ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8"), JavaSpec.temurin("17"))
+ThisBuild / githubWorkflowJavaVersions := Seq(
+  JavaSpec.temurin("21"),
+  JavaSpec.temurin("8")
+)
 
 ThisBuild / githubWorkflowPublish := Seq(
   WorkflowStep.Sbt(

--- a/build.sbt
+++ b/build.sbt
@@ -207,19 +207,22 @@ lazy val metadataSettings = Seq(
   organization := "com.github.fd4s"
 )
 
+val OldGuardJava = JavaSpec.temurin("8")
+val LTSJava      = JavaSpec.temurin("21")
+
 ThisBuild / githubWorkflowTargetBranches := Seq("series/*")
 
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(List("ci")),
-  WorkflowStep.Sbt(List("docs/run"), cond = Some(s"matrix.scala == '2.13'"))
+  WorkflowStep.Sbt(
+    List("docs/run"),
+    cond = Some(s"matrix.scala == '2.13' && matrix.java == '${LTSJava.render}'")
+  )
 )
 
 ThisBuild / githubWorkflowArtifactUpload := false
 
-ThisBuild / githubWorkflowJavaVersions := Seq(
-  JavaSpec.temurin("21"),
-  JavaSpec.temurin("8")
-)
+ThisBuild / githubWorkflowJavaVersions := Seq(LTSJava, OldGuardJava)
 
 ThisBuild / githubWorkflowPublish := Seq(
   WorkflowStep.Sbt(

--- a/build.sbt
+++ b/build.sbt
@@ -211,7 +211,7 @@ ThisBuild / githubWorkflowTargetBranches := Seq("series/*")
 
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(List("ci")),
-  WorkflowStep.Sbt(List("docs/run"), cond = Some(s"matrix.scala == '$scala213'"))
+  WorkflowStep.Sbt(List("docs/run"), cond = Some(s"matrix.scala == '2.13'"))
 )
 
 ThisBuild / githubWorkflowArtifactUpload := false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,4 @@
-addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"   % "0.11.0")
-addSbtPlugin("com.github.sbt"    % "sbt-unidoc"      % "0.5.0")
-addSbtPlugin("com.typesafe"      % "sbt-mima-plugin" % "1.1.3")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"      % "5.10.0")
-addSbtPlugin("org.scalameta"     % "sbt-mdoc"        % "2.4.0")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"    % "2.5.2")
-addSbtPlugin("org.typelevel"     % "sbt-typelevel"   % "0.6.5")
+val sbtTypelevelVersion = "0.6.5"
+addSbtPlugin("org.typelevel" % "sbt-typelevel"      % sbtTypelevelVersion)
+addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % sbtTypelevelVersion)
+addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo"      % "0.11.0")


### PR DESCRIPTION
## On `mdoc` execution issue

Latest `mdoc` is compiled with JDK 11 but our GHA publish job was configured to use JDK 8:

```
[info] running fs2.kafka.docs.Main 
Error: Exception in thread "sbt-bg-threads-1" java.lang.UnsupportedClassVersionError: mdoc/MainSettings$ has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

👆🏽 See [this run log](https://github.com/fd4s/fs2-kafka/actions/runs/7150982561/job/19474915886) for the full error.

By switching the order of `githubWorkflowJavaVersions` the issue should be fixed, because the first JDK defined (in the case of this PR, JDK 21) is the one used for the publish job. I'm pretty sure that this doesn't affect anything else because we're only using a newest JVM to run but the release flag is set to JDK 8, thus compiled bytecode will be compatible with old Java versions.

The build job still runs in JDK 8 and JDK 21, so we can be confident that we're compatible with old codebases and also with latest ones (by using the latest LTS).

## On `sbt-typelevel` usage

I've removed the redundant dependencies already defined by `sbt-typelevel`. 

Also, this is the first step to use `sbt-typelevel-site` for publishing the website. This first iteration only uses the transitive `mdoc` and everything else stays the same (Docusaurus), but we're now in a good position to use the standard typelevel way for websites.