### PR TITLE
Retry `RebalanceInProgressException` in `CommitRecovery.Default`

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/CommitRecovery.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommitRecovery.scala
@@ -15,6 +15,7 @@ import cats.syntax.functor.*
 import cats.Functor
 
 import org.apache.kafka.clients.consumer.{OffsetAndMetadata, RetriableCommitFailedException}
+import org.apache.kafka.common.errors.RebalanceInProgressException
 import org.apache.kafka.common.TopicPartition
 
 /**
@@ -51,9 +52,9 @@ object CommitRecovery {
 
   /**
     * The default [[CommitRecovery]] used in [[ConsumerSettings]] unless a different one has been
-    * specified. The default recovery strategy only retries `RetriableCommitFailedException`s. These
-    * exceptions are retried with a jittered exponential backoff, where the time in milliseconds
-    * before retrying is calculated using:
+    * specified. The default recovery strategy only retries `RetriableCommitFailedException`s and
+    * `RebalanceInProgressException`s. These exceptions are retried with a jittered exponential
+    * backoff, where the time in milliseconds before retrying is calculated using:
     *
     * {{{
     * Random.nextDouble() * Math.min(10000, 10 * Math.pow(2, n))
@@ -61,8 +62,9 @@ object CommitRecovery {
     *
     * where `n` is the retry attempt (first attempt is `n = 1`). This is done for up to 10 attempts,
     * after which we change to retry using a fixed time of 10 seconds, for up to another 5 attempts.
-    * If at that point we are still faced with `RetriableCommitFailedException`, we give up and
-    * raise a [[CommitRecoveryException]] with the last such error experienced.<br><br>
+    * If at that point we are still faced with `RetriableCommitFailedException` or
+    * `RebalanceInProgressException`, we give up and raise a [[CommitRecoveryException]] with the
+    * last such error experienced.<br><br>
     *
     * The sum of time spent waiting between retries will always be less than 70 220 milliseconds, or
     * ~70 seconds. Note that this does not include the time for attempting to commit offsets. Offset
@@ -87,7 +89,7 @@ object CommitRecovery {
         jitter: Jitter[F]
       ): Throwable => F[Unit] = {
         def retry(attempt: Int): Throwable => F[Unit] = {
-          case retriable: RetriableCommitFailedException =>
+          case retriable @ (_: RetriableCommitFailedException | _: RebalanceInProgressException) =>
             val commitWithRecovery = commit.handleErrorWith(retry(attempt + 1))
             if (attempt <= 10) backoff(attempt).flatMap(F.sleep) >> commitWithRecovery
             else if (attempt <= 15) F.sleep(10.seconds) >> commitWithRecovery


### PR DESCRIPTION
Fixes #1213 

After inspecting the internals of Kafka Client's `KafkaConsumer`, any time a `RebalanceInProgressException` is thrown, the message states it can be retried after a call to `poll()`. 

https://github.com/apache/kafka/blob/5e3c2b738d253ff51a7a61fe08713f564ab647fa/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java#L1347

https://github.com/apache/kafka/blob/5e3c2b738d253ff51a7a61fe08713f564ab647fa/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java#L1437

https://github.com/apache/kafka/blob/5e3c2b738d253ff51a7a61fe08713f564ab647fa/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java#L1457

https://github.com/apache/kafka/blob/5e3c2b738d253ff51a7a61fe08713f564ab647fa/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java#L1470

Given that we handle those `poll()` calls internally at intervals, it makes sense to follow the recommendation and also retry the commit requests. Eventually the rebalance will finish and the offsets will be committed successfully (or fail if the partitions are not assigned anymore to the consumer).