### PR TITLE
KafkaProducer.produce fails fast

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
@@ -131,7 +131,8 @@ object KafkaProducerConnection {
             withProducer,
             keySerializer,
             valueSerializer,
-            records
+            records,
+            settings.failFastProduce
           )
 
         override def metrics: G[Map[MetricName, Metric]] =

--- a/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -242,7 +242,7 @@ object ProducerSettings {
     override val customBlockingContext: Option[ExecutionContext],
     override val properties: Map[String, String],
     override val closeTimeout: FiniteDuration,
-    override val failFastProduce: Boolean = false
+    override val failFastProduce: Boolean
   ) extends ProducerSettings[F, K, V] {
 
     override def withCustomBlockingContext(ec: ExecutionContext): ProducerSettings[F, K, V] =
@@ -335,7 +335,8 @@ object ProducerSettings {
       properties = Map(
         ProducerConfig.RETRIES_CONFIG -> "0"
       ),
-      closeTimeout = 60.seconds
+      closeTimeout = 60.seconds,
+      failFastProduce = false
     )
 
   def apply[F[_], K, V](

--- a/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
@@ -17,8 +17,8 @@ import org.apache.kafka.common.serialization.ByteArraySerializer
   * the fs2-kafka `KafkaProducer`. This is needed in order to instantiate
   * [[fs2.kafka.KafkaProducer]] and [[fs2.kafka.TransactionalKafkaProducer]].<br><br>
   *
-  * By default, the instance provided by [[MkProducer.mkProducerForSync]] will be used. However this
-  * behaviour can be overridden, e.g. for testing purposes, by placing an alternative implicit
+  * By default, the instance provided by [[MkProducer.mkProducerForSync]] will be used. However,
+  * this behaviour can be overridden, e.g. for testing purposes, by placing an alternative implicit
   * instance in lexical scope.
   */
 trait MkProducer[F[_]] {

--- a/modules/core/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
@@ -61,6 +61,7 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with ForAllTestContainer {
         .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
         .withEnv("KAFKA_AUTHORIZER_CLASS_NAME", "kafka.security.authorizer.AclAuthorizer")
         .withEnv("KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND", "true")
+        .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
 
       ()
     }

--- a/modules/core/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
@@ -61,7 +61,6 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with ForAllTestContainer {
         .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
         .withEnv("KAFKA_AUTHORIZER_CLASS_NAME", "kafka.security.authorizer.AclAuthorizer")
         .withEnv("KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND", "true")
-        .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
 
       ()
     }

--- a/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -267,7 +267,9 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
   it("should fail fast to produce records with multiple") {
     val nonExistentTopic = s"non-existent-topic-${UUID.randomUUID()}"
     val toProduce        = (0 until 1000).map(n => s"key-$n" -> s"value->$n").toList
-    val settings         = producerSettings[IO].withProperty(ProducerConfig.MAX_BLOCK_MS_CONFIG, "1000")
+    val settings = producerSettings[IO]
+      .withProperty(ProducerConfig.MAX_BLOCK_MS_CONFIG, "500")
+      .withFailFastProduce(true)
 
     val error = intercept[TimeoutException] {
       (for {
@@ -279,7 +281,7 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
       } yield result).compile.lastOrError.unsafeRunSync()
     }
 
-    error.getMessage shouldBe s"Topic $nonExistentTopic not present in metadata after 1000 ms."
+    error.getMessage shouldBe s"Topic $nonExistentTopic not present in metadata after 500 ms."
   }
 
   it("should get metrics") {

--- a/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -6,8 +6,6 @@
 
 package fs2.kafka
 
-import java.util.UUID
-
 import cats.effect.unsafe.implicits.global
 import cats.effect.IO
 import cats.syntax.all.*

--- a/modules/core/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
@@ -168,8 +168,16 @@ final class ProducerSettingsSpec extends BaseSpec {
         )
       }
     }
+
+    it("should provide failFastProduce default value") {
+      assert(settings.failFastProduce == false)
+    }
+
+    it("should be able to set failFastProduce") {
+      assert(settings.withFailFastProduce(true).failFastProduce == true)
+    }
   }
 
-  val settings = ProducerSettings[IO, String, String]
+  private val settings = ProducerSettings[IO, String, String]
 
 }

--- a/modules/core/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
@@ -406,11 +406,11 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with EitherValues {
   }
 
   it("should fail fast to produce records with multiple") {
-    val (key0, value0)     = "key-0" -> "value-0"
-    val (key1, value1)     = "key-1" -> "value-1"
-    val (key2, value2)     = "key-2" -> "value-2"
-    var transactionAborted = false
-    val expectedErrorOnSecondRecord = new RuntimeException("~Failed to produce second record~") 
+    val (key0, value0)              = "key-0" -> "value-0"
+    val (key1, value1)              = "key-1" -> "value-1"
+    val (key2, value2)              = "key-2" -> "value-2"
+    var transactionAborted          = false
+    val expectedErrorOnSecondRecord = new RuntimeException("~Failed to produce second record~")
 
     withTopic { topic =>
       createCustomTopic(topic)


### PR DESCRIPTION
## Description
Introduce `KafkaProducer.failFastProduce` producer configuration:

https://github.com/fd4s/fs2-kafka/blob/aed7ab3aeda58ac3b32438c5c22fb91c86ee2426/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala#L218-L228

## Proposed solution
When `failFastProduce` is set to true, each `fs2.kafka.producer.produce` call of `ProducerRecords` creates a `scala.concurrent.Promise[Throwable]`. This Promise resolution is raced against calling `org.apache.kafka.clients.producer.KafkaProducer.send` per record. Any failing callback will complete the promise with the failure, canceling the rest of the pending `org.apache.kafka.clients.producer.KafkaProducer.send` and in-flight callbacks.

https://github.com/fd4s/fs2-kafka/blob/2559d96ce326f9f2ffc2936c1b9b5f3086a7829c/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala#L186-L198

## Explanation
`fs2.kafka.KafkaProducer.produce` returns F[F[...]], where the first effect invokes the underlying `org.apache.kafka.clients.producer.KafkaProducer.send` and attaches promises to the corresponding callbacks. The second effect is waiting for the callbacks’ resolution. In use cases where all the records in the batch need to be confirmed, any callback failure will cause the final effect resolution to fail, achieving the same outcome sooner.

In non-transient errors such as invalid username, password, or non-existent topics, `org.apache.kafka.clients.producer.KafkaProducer.send` is blocked for max.block.ms, default to 60 seconds. For example, a `fs2.kafka.producer` attempting to produce N `ProducerRecords` will take at least N * 60 seconds to fail. In other words, faulty Kafka producers will take considerable time to fail by repeatedly calling brokers for metadata synchronization.


See: 
- [max.block.ms default ](https://github.com/apache/kafka/blob/736bd3cd093cd418b4fec5b583359884f23265ff/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java#L423)
- [KafkaProducer.doSend waitOnMetadata ](https://github.com/apache/kafka/blob/736bd3cd093cd418b4fec5b583359884f23265ff/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java#L1027 )