### PR TITLE
Use common apache kafka client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,8 @@ lazy val vulcan = project
     dependencySettings ++ Seq(
       libraryDependencies ++= Seq(
         "com.github.fd4s" %% "vulcan"                % vulcanVersion,
-        "io.confluent"     % "kafka-avro-serializer" % confluentVersion
+        "io.confluent"     % "kafka-avro-serializer" % confluentVersion exclude("org.apache.kafka", "kafka-clients"),
+        "org.apache.kafka" % "kafka-clients"         % kafkaVersion
       )
     ),
     publishSettings,


### PR DESCRIPTION
... by excluding Confluent's version of the kafka client and adding an explicit version.
Without this, we'll get Confluent's version which is only available in their maven repository.