### PR TITLE
Instantiate underlying Kafka Consumer inside blocking context

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
@@ -30,7 +30,7 @@ object MkConsumer {
   implicit def mkConsumerForSync[F[_]](implicit F: Sync[F]): MkConsumer[F] =
     new MkConsumer[F] {
 
-      def apply[G[_]](settings: ConsumerSettings[G, ?, ?]): F[KafkaByteConsumer] = F.delay {
+      def apply[G[_]](settings: ConsumerSettings[G, ?, ?]): F[KafkaByteConsumer] = F.blocking {
         val byteArrayDeserializer = new ByteArrayDeserializer
         new org.apache.kafka.clients.consumer.KafkaConsumer(
           (settings.properties: Map[String, AnyRef]).asJava,


### PR DESCRIPTION
I've got this warning by ce3 blocking detection 
```
[WARNING] A Cats Effect worker thread was detected to be in a blocked state (BLOCKED)                                                    │
│   at org.apache.kafka.common.metrics.JmxReporter.reconfigure(JmxReporter.java:109)                                                       │
│   at org.apache.kafka.common.metrics.JmxReporter.configure(JmxReporter.java:93)                                                          │
│   at org.apache.kafka.clients.CommonClientConfigs.metricsReporters(CommonClientConfigs.java:243)                                         │
│   at org.apache.kafka.clients.CommonClientConfigs.metricsReporters(CommonClientConfigs.java:234)                                         │
│   at org.apache.kafka.clients.consumer.internals.ConsumerUtils.createMetrics(ConsumerUtils.java:124)                                     │
│   at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:696)                                                      │
│   at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:671)                                                      │
│   at fs2.kafka.consumer.MkConsumer$.fs2$kafka$consumer$MkConsumer$$anon$1$$_$apply$$anonfun$1(MkConsumer.scala:38)                       │
│   at cats.effect.IOFiber.runLoop(IOFiber.scala:343)                                                                                      │
│   at cats.effect.IOFiber.execR(IOFiber.scala:1362)                                                                                       │
│   at cats.effect.IOFiber.run(IOFiber.scala:112)                                                                                          │
│   at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:743)                                                                         │
│ This is very likely to be due to suspending a blocking call in IO via                                                                    │
│ `IO.delay` or `IO.apply`. If this is the case then you should use                                                                        │
│ `IO.blocking` or `IO.interruptible` instead.
```

Looks like something inside `new org.apache.kafka.clients.consumer.KafkaConsumer` does network call.  