### PR TITLE
chore: tweaks to handling of pending commits

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -93,7 +93,7 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
   private[this] def commit(request: Request.Commit[F]): F[Unit] =
     ref.flatModify { state =>
       val commitF = commitAsync(request.offsets, request.callback)
-      if (state.rebalancing) {
+      if (state.rebalancing || state.pendingCommits.nonEmpty) {
         val newState =
           state.withPendingCommit(commitF >> logging.log(CommittedPendingCommit(request)))
         (newState, logging.log(StoredPendingCommit(request, newState)))

--- a/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
@@ -145,7 +145,7 @@ private[kafka] object LogEntry {
 
     override def level: LogLevel = Debug
 
-    override def message: String = s"Committed pending commits [$pendingCommit]."
+    override def message: String = s"Committed pending commit [$pendingCommit]."
 
   }
 


### PR DESCRIPTION
This is a combination of two related changes to the handling of pending commits during rebalance operations in `KafkaConsumerActor`.

### Single definition of pending commit effect

Whether immediately committing offsets, or queueing the request in `State.pendingCommits`, the necessary effect is built at once.

This avoids the need to repeat similar logic in disparate call sites, and makes visible in a single place how the request will be processed and logged.

### Ensure pending commits order

Commits would be added to the chain of pending commits based only on the rebalancing state. Given that the rebalancing state is updated (via `ConsumerRebalanceListener.onPartitionsAssigned`) separate from when pending commits are processed (after `poll`), it could happen that commits emitted later would be processed before earlier pending ones.

This updates the condition for queueing commits to take into account the prior existence of pending commits.

In addition, the condition for processing pending commits in `poll` is also updated to disregard whether a rebalance operation was ongoing at the start of the poll. Instead, the existence of pending commits along with a non-`rebalancing` state are a sufficient trigger.

This ensures that rebalance operations that might conclude within a single consumer poll do not leave behind any pending commits.

At the moment, these possibilities are theoretical as commit operations are serialized via `KafkaConsumerActor`'s request queue, and don't happen concurrently to polls. That said, the cost of the fixes is trivial and being explicit about the conditions may prevent future bugs, if the surrounding context changes.