### PR TITLE
feat: drop use of FetchRequests

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -27,7 +27,6 @@ import fs2.kafka.internal.*
 import fs2.kafka.internal.converters.collection.*
 import fs2.kafka.internal.syntax.*
 import fs2.kafka.internal.KafkaConsumerActor.*
-import fs2.kafka.internal.LogEntry.{RevokedPreviousFetch, StoredFetch}
 
 import org.apache.kafka.clients.consumer.{OffsetAndMetadata, OffsetAndTimestamp}
 import org.apache.kafka.common.{Metric, MetricName, PartitionInfo, TopicPartition}
@@ -127,10 +126,8 @@ object KafkaConsumer {
 
   private def createKafkaConsumer[F[_], K, V](
     requests: QueueSink[F, Request[F, K, V]],
-    settings: ConsumerSettings[F, K, V],
     actor: KafkaConsumerActor[F, K, V],
     fiber: Fiber[F, Throwable, Unit],
-    streamIdRef: Ref[F, StreamId],
     id: Int,
     withConsumer: WithConsumer[F],
     stopConsumingDeferred: Deferred[F, Unit]
@@ -139,206 +136,74 @@ object KafkaConsumer {
 
       override def partitionsMapStream
         : Stream[F, Map[TopicPartition, Stream[F, CommittableConsumerRecord[F, K, V]]]] = {
-        val chunkQueue: F[Queue[F, Option[Chunk[CommittableConsumerRecord[F, K, V]]]]] =
-          Queue.bounded(settings.maxPrefetchBatches - 1)
-
-        type PartitionResult =
-          (Chunk[CommittableConsumerRecord[F, K, V]], FetchCompletedReason)
 
         type PartitionsMap      = Map[TopicPartition, Stream[F, CommittableConsumerRecord[F, K, V]]]
         type PartitionsMapQueue = Queue[F, Option[PartitionsMap]]
 
         def partitionStream(
-          streamId: StreamId,
-          partition: TopicPartition,
-          assignmentRevoked: F[Unit]
-        ): Stream[F, CommittableConsumerRecord[F, K, V]] = Stream.force {
-          for {
-            chunks      <- chunkQueue
-            dequeueDone <- Deferred[F, Unit]
-            shutdown = F.race(
-                           F.race(
-                             awaitTermination.attempt,
-                             dequeueDone.get
-                           ),
-                           F.race(
-                             stopConsumingDeferred.get,
-                             assignmentRevoked
-                           )
-                         )
-                         .void
-            stopReqs <- Deferred[F, Unit]
-          } yield Stream
-            .eval {
-              val fetchPartition: F[Unit] = F
-                .deferred[PartitionResult]
-                .flatMap { deferred =>
-                  val callback: PartitionResult => F[Unit] =
-                    deferred.complete(_).void
+          partition: TopicPartition
+        ): Stream[F, CommittableConsumerRecord[F, K, V]] =
+          Stream.force {
+            actor
+              .getQueueAndStopSignalFor(partition)
+              .map { case (chunksQueue, partitionStop) =>
+                val stopStream: F[Either[Throwable, Unit]] =
+                  F.race(
+                      partitionStop,
+                      F.race(awaitTermination.attempt, stopConsumingDeferred.get)
+                    )
+                    .void
+                    .attempt
 
-                  val fetch: F[PartitionResult] = withPermit {
-                    val assigned =
-                      withConsumer.blocking {
-                        _.assignment.contains(partition)
-                      }
-
-                    def storeFetch: F[Unit] =
-                      actor
-                        .ref
-                        .flatModify { state =>
-                          val (newState, oldFetches) =
-                            state.withFetch(partition, streamId, callback)
-                          newState ->
-                            (logging.log(StoredFetch(partition, callback, newState)) >>
-                              oldFetches.traverse_ { fetch =>
-                                fetch.completeRevoked(Chunk.empty) >>
-                                  logging.log(RevokedPreviousFetch(partition, streamId))
-                              })
-                        }
-
-                    def completeRevoked: F[Unit] =
-                      callback((Chunk.empty, FetchCompletedReason.TopicPartitionRevoked))
-
-                    assigned.ifM(storeFetch, completeRevoked)
-                  } >> deferred.get
-
-                  fetch.flatMap { case (chunk, reason) =>
-                    val enqueueChunk = chunks.offer(Some(chunk)).unlessA(chunk.isEmpty)
-
-                    val completeRevoked =
-                      stopReqs.complete(()).void.whenA(reason.topicPartitionRevoked)
-
-                    enqueueChunk >> completeRevoked
-                  }
-                }
-
-              Stream
-                .repeatEval {
-                  stopReqs
-                    .tryGet
-                    .flatMap {
-                      case None =>
-                        fetchPartition
-
-                      case Some(()) =>
-                        // Prevent issuing additional requests after partition is
-                        // revoked or shutdown happens, in case the stream isn't
-                        // interrupted fast enough
-                        F.unit
-                    }
-                }
-                .interruptWhen(F.race(shutdown, stopReqs.get).void.attempt)
-                .compile
-                .drain
-                .guarantee(F.race(dequeueDone.get, chunks.offer(None)).void)
-                .start
-                .as {
-                  Stream
-                    .fromQueueNoneTerminated(chunks)
-                    .flatMap(Stream.chunk)
-                    .covary[F]
-                    .onFinalize(dequeueDone.complete(()).void)
-                }
-            }
-            .flatten
-        }
+                Stream.fromQueueUnterminated(chunksQueue, 1).unchunks.interruptWhen(stopStream)
+              }
+          }
 
         def enqueueAssignment(
-          streamId: StreamId,
-          assigned: Map[TopicPartition, Deferred[F, Unit]],
+          assigned: Set[TopicPartition],
           partitionsMapQueue: PartitionsMapQueue
         ): F[Unit] =
           stopConsumingDeferred
             .tryGet
             .flatMap {
               case None =>
-                val assignment: PartitionsMap = assigned.map { case (partition, finisher) =>
-                  partition -> partitionStream(streamId, partition, finisher.get)
-                }
+                val assignment: PartitionsMap = assigned
+                  .view
+                  .map { partition =>
+                    partition -> partitionStream(partition)
+                  }
+                  .toMap
+
                 partitionsMapQueue.offer(Some(assignment))
+
               case Some(()) =>
                 F.unit
             }
 
-        def onRebalance(
-          streamId: StreamId,
-          assignmentRef: Ref[F, Map[TopicPartition, Deferred[F, Unit]]],
-          partitionsMapQueue: PartitionsMapQueue
-        ): OnRebalance[F] =
+        def onRebalance(partitionsMapQueue: PartitionsMapQueue): OnRebalance[F] =
           OnRebalance(
-            onRevoked = revoked => {
-              assignmentRef.flatModify { assignment =>
-                val (newAssignment, finishers) =
-                  assignment.partition(entry => !revoked.contains(entry._1))
-
-                (
-                  newAssignment,
-                  finishers.toVector.traverse_ { case (_, finisher) => finisher.complete(()) }
-                )
-              }
-            },
-            onAssigned = assignedPartitions => {
-              for {
-                newAssignment <- assignedPartitions
-                                   .toVector
-                                   .traverse { partition =>
-                                     Deferred[F, Unit].map(partition -> _)
-                                   }
-                                   .map(_.toMap)
-                _ <- assignmentRef.flatModify { assignment =>
-                       (assignment ++ newAssignment) ->
-                         enqueueAssignment(
-                           streamId = streamId,
-                           assigned = newAssignment,
-                           partitionsMapQueue = partitionsMapQueue
-                         )
-                     }
-              } yield ()
-            }
+            onRevoked = _ => F.unit,
+            onAssigned = assigned => enqueueAssignment(assigned, partitionsMapQueue)
           )
 
-        def requestAssignment(
-          streamId: StreamId,
-          assignmentRef: Ref[F, Map[TopicPartition, Deferred[F, Unit]]],
-          partitionsMapQueue: PartitionsMapQueue
-        ): F[Map[TopicPartition, Deferred[F, Unit]]] = {
+        def requestAssignment(partitionsMapQueue: PartitionsMapQueue): F[Set[TopicPartition]] = {
           val assignment = this.assignment(
             Some(
-              onRebalance(
-                streamId,
-                assignmentRef,
-                partitionsMapQueue
-              )
+              onRebalance(partitionsMapQueue)
             )
           )
 
           F.race(awaitTermination.attempt, assignment)
             .flatMap {
-              case Left(_) =>
-                F.pure(Map.empty)
-
-              case Right(assigned) =>
-                assigned
-                  .toVector
-                  .traverse { partition =>
-                    Deferred[F, Unit].map(partition -> _)
-                  }
-                  .map(_.toMap)
+              case Left(_)         => F.pure(Set.empty)
+              case Right(assigned) => F.pure(assigned)
             }
         }
 
-        def initialEnqueue(
-          streamId: StreamId,
-          assignmentRef: Ref[F, Map[TopicPartition, Deferred[F, Unit]]],
-          partitionsMapQueue: PartitionsMapQueue
-        ): F[Unit] =
+        def initialEnqueue(partitionsMapQueue: PartitionsMapQueue): F[Unit] =
           for {
-            assigned <- requestAssignment(
-                          streamId,
-                          assignmentRef,
-                          partitionsMapQueue
-                        )
-            _ <- enqueueAssignment(streamId, assigned, partitionsMapQueue)
+            assigned <- requestAssignment(partitionsMapQueue)
+            _        <- enqueueAssignment(assigned, partitionsMapQueue)
           } yield ()
 
         Stream
@@ -347,16 +212,7 @@ object KafkaConsumer {
             case None =>
               for {
                 partitionsMapQueue <- Stream.eval(Queue.unbounded[F, Option[PartitionsMap]])
-                streamId           <- Stream.eval(streamIdRef.modify(n => (n + 1, n)))
-                assignmentRef <-
-                  Stream.eval(Ref[F].of(Map.empty[TopicPartition, Deferred[F, Unit]]))
-                _ <- Stream.eval(
-                       initialEnqueue(
-                         streamId,
-                         assignmentRef,
-                         partitionsMapQueue
-                       )
-                     )
+                _                  <- Stream.eval(initialEnqueue(partitionsMapQueue))
                 out <- Stream
                          .fromQueueNoneTerminated(partitionsMapQueue)
                          .interruptWhen(awaitTermination.attempt)
@@ -698,7 +554,6 @@ object KafkaConsumer {
       requests              <- Resource.eval(Queue.unbounded[F, Request[F, K, V]])
       polls                 <- Resource.eval(Queue.bounded[F, Request.Poll[F]](1))
       ref                   <- Resource.eval(Ref.of[F, State[F, K, V]](State.empty))
-      streamId              <- Resource.eval(Ref.of[F, StreamId](0))
       dispatcher            <- Dispatcher.sequential[F]
       stopConsumingDeferred <- Resource.eval(Deferred[F, Unit])
       withConsumer          <- WithConsumer(mk, settings)
@@ -719,10 +574,8 @@ object KafkaConsumer {
       fiber <- startBackgroundConsumer(requests, polls, actor, settings.pollInterval)
     } yield createKafkaConsumer(
       requests,
-      settings,
       actor,
       fiber,
-      streamId,
       id,
       withConsumer,
       stopConsumingDeferred

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -11,10 +11,10 @@ import java.util
 
 import scala.collection.immutable.SortedSet
 
-import cats.data.{Chain, NonEmptyVector, StateT}
+import cats.data.Chain
 import cats.effect.*
+import cats.effect.implicits.*
 import cats.effect.std.*
-import cats.effect.syntax.all.*
 import cats.syntax.all.*
 import fs2.kafka.*
 import fs2.kafka.instances.*
@@ -59,7 +59,9 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
 ) {
 
   private[this] type ConsumerRecords =
-    Map[TopicPartition, NonEmptyVector[CommittableConsumerRecord[F, K, V]]]
+    Map[TopicPartition, Chunk[CommittableConsumerRecord[F, K, V]]]
+
+  private[this] type ConsumerQueue = Queue[F, Chunk[CommittableConsumerRecord[F, K, V]]]
 
   private[this] val consumerGroupId: Option[String] =
     settings.properties.get(ConsumerConfig.GROUP_ID_CONFIG)
@@ -90,11 +92,13 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
 
   private[this] def commit(request: Request.Commit[F]): F[Unit] =
     ref.flatModify { state =>
+      val commitF = commitAsync(request.offsets, request.callback)
       if (state.rebalancing) {
-        val newState = state.withPendingCommit(request)
+        val newState =
+          state.withPendingCommit(commitF >> logging.log(CommittedPendingCommit(request)))
         (newState, logging.log(StoredPendingCommit(request, newState)))
       } else
-        (state, commitAsync(request.offsets, request.callback))
+        (state, commitF)
     }
 
   private[this] def manualCommitSync(request: Request.ManualCommitSync[F]): F[Unit] = {
@@ -122,91 +126,10 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
       )
 
   private[this] def assigned(assigned: SortedSet[TopicPartition]): F[Unit] =
-    ref
-      .flatModify { state =>
-        val newState = state.withRebalancing(false)
-        (
-          newState,
-          logging.log(AssignedPartitions(assigned, state)).as(newState.onRebalances)
-        )
-      }
-      .flatMap(_.traverse_(_.onAssigned(assigned)))
+    ref.flatModify(_.withAssignedPartitions(assigned)).flatten
 
-  private[this] def revoked(revoked: SortedSet[TopicPartition]): F[Unit] = {
-    def withState[A] = StateT.apply[Id, State[F, K, V], A](_)
-
-    def completeWithRecords(withRecords: Set[TopicPartition]) = withState { st =>
-      if (withRecords.nonEmpty) {
-        val newState = st.withoutFetchesAndRecords(withRecords)
-
-        val action = st
-          .fetches
-          .filterKeysStrictList(withRecords)
-          .traverse { case (partition, partitionFetches) =>
-            val records = Chunk.from(st.records(partition).toVector)
-            partitionFetches.values.toList.traverse(_.completeRevoked(records))
-          } >> logging.log(
-          RevokedFetchesWithRecords(st.records.filterKeysStrict(withRecords), newState)
-        )
-
-        (newState, action)
-      } else (st, F.unit)
-    }
-
-    def completeWithoutRecords(withoutRecords: SortedSet[TopicPartition]) = withState { st =>
-      if (withoutRecords.nonEmpty) {
-        val newState = st.withoutFetches(withoutRecords)
-
-        val action = st
-          .fetches
-          .filterKeysStrictValuesList(withoutRecords)
-          .traverse(_.values.toList.traverse(_.completeRevoked(Chunk.empty))) >>
-          logging.log(RevokedFetchesWithoutRecords(withoutRecords, newState))
-
-        (newState, action)
-      } else (st, F.unit)
-    }
-
-    def removeRevokedRecords(revokedNonFetches: SortedSet[TopicPartition]) = withState { st =>
-      if (revokedNonFetches.nonEmpty) {
-        val revokedRecords = st.records.filterKeysStrict(revokedNonFetches)
-
-        if (revokedRecords.nonEmpty) {
-          val newState = st.withoutRecords(revokedRecords.keySet)
-
-          val action = logging.log(RemovedRevokedRecords(revokedRecords, newState))
-
-          (newState, action)
-        } else (st, F.unit)
-      } else (st, F.unit)
-    }
-
-    ref
-      .flatModify { state =>
-        val withRebalancing = state.withRebalancing(true)
-
-        val fetches = withRebalancing.fetches.keySetStrict
-        val records = withRebalancing.records.keySetStrict
-
-        val revokedFetches    = revoked.intersect(fetches)
-        val revokedNonFetches = revoked.diff(revokedFetches)
-
-        val withRecords    = records.intersect(revokedFetches)
-        val withoutRecords = revokedFetches.diff(records)
-
-        (for {
-          completeWithRecords    <- completeWithRecords(withRecords)
-          completeWithoutRecords <- completeWithoutRecords(withoutRecords)
-          removeRevokedRecords   <- removeRevokedRecords(revokedNonFetches)
-        } yield for {
-          _ <- logging.log(RevokedPartitions(revoked, withRebalancing))
-          _ <- completeWithRecords
-          _ <- completeWithoutRecords
-          _ <- removeRevokedRecords
-        } yield withRebalancing.onRebalances).run(withRebalancing)
-      }
-      .flatMap(_.traverse_(_.onRevoked(revoked)))
-  }
+  private[this] def revoked(revoked: SortedSet[TopicPartition]): F[Unit] =
+    ref.flatModify(_.withRevokedPartitions(revoked)).flatten
 
   def offsetCommitAsync(offsets: Map[TopicPartition, OffsetAndMetadata]): F[Unit] =
     runCommitAsync(offsets)(cb => requests.offer(Request.Commit(offsets, cb)))
@@ -240,14 +163,15 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
       .partitions
       .toVector
       .traverse { partition =>
-        NonEmptyVector
-          .fromVectorUnsafe(batch.records(partition).toVector)
+        batch
+          .records(partition)
+          .toVector
           .traverse { record =>
             ConsumerRecord
               .fromJava(record, keyDeserializer, valueDeserializer)
               .map(committableConsumerRecord(_, partition))
           }
-          .map((partition, _))
+          .map(records => (partition, Chunk.from(records)))
       }
       .map(_.toMap)
 
@@ -255,153 +179,133 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
     settings.pollTimeout.toJava
 
   private[this] val poll: F[Unit] = {
-    def pollConsumer(state: State[F, K, V]): F[ConsumerRecords] =
+
+    // Checks whether to poll Kafka, at all, and drops state and records for
+    // unassigned partitions.
+    //
+    // Returns a 3-tuple:
+    //  1. whether to poll, at all;
+    //  2. the current partition assignment;
+    //  3. partitions to pause in pollForRecords.
+    val updateStateBeforePoll =
+      withConsumer
+        .blocking(_.assignment.toSet)
+        .flatMap { assignment =>
+          ref.flatModify {
+            case state if state.subscribed && state.streaming =>
+              val isStreaming        = true
+              val (newState, result) = state.dropUnassignedPartitions(assignment)
+              (newState, result.map((isStreaming, assignment, _)))
+
+            case state =>
+              val isStreaming = false
+              (state, F.pure((isStreaming, assignment, List.empty[TopicPartition])))
+          }
+        }
+
+    // Polls for records, and deserialize.
+    val pollForRecords = { (assignment: Set[TopicPartition], queueIsFull: List[TopicPartition]) =>
       withConsumer
         .blocking { consumer =>
-          val assigned  = consumer.assignment.toSet
-          val requested = state.fetches.keySetStrict
-          val available = state.records.keySetStrict
+          val resumePartitions = assignment -- queueIsFull
 
-          val resume = requested.intersect(assigned).diff(available)
-          val pause  = assigned.diff(resume)
+          if (queueIsFull.nonEmpty)
+            consumer.pause(queueIsFull.asJava)
 
-          if (pause.nonEmpty)
-            consumer.pause(pause.asJava)
-
-          if (resume.nonEmpty)
-            consumer.resume(resume.asJava)
+          if (resumePartitions.nonEmpty)
+            consumer.resume(resumePartitions.asJava)
 
           consumer.poll(pollTimeout)
         }
         .flatMap(records)
-
-    def handlePoll(newRecords: ConsumerRecords, initialRebalancing: Boolean): F[Unit] = {
-      def handleBatch(
-        state: State[F, K, V],
-        pendingCommits: Option[HandlePollResult.PendingCommits]
-      ) =
-        if (state.fetches.isEmpty) {
-          if (newRecords.isEmpty) {
-            (state, HandlePollResult.StateNotChanged(pendingCommits))
-          } else {
-            val newState = state.withRecords(newRecords)
-            (newState, HandlePollResult.Stored(StoredRecords(newRecords, newState), pendingCommits))
-          }
-        } else {
-          val allRecords = state.records.combine(newRecords)
-
-          if (allRecords.nonEmpty) {
-            val requested = state.fetches.keySetStrict
-
-            val canBeCompleted = allRecords.keySetStrict.intersect(requested)
-            val canBeStored    = newRecords.keySetStrict.diff(canBeCompleted)
-
-            def completeFetches: F[Unit] =
-              state
-                .fetches
-                .filterKeysStrictList(canBeCompleted)
-                .traverse_ { case (partition, fetches) =>
-                  val records = Chunk.from(allRecords(partition).toVector)
-                  fetches.values.toList.traverse_(_.completeRecords(records))
-                }
-
-            (canBeCompleted.nonEmpty, canBeStored.nonEmpty) match {
-              case (true, true) =>
-                val storeRecords = newRecords.filterKeysStrict(canBeStored)
-                val newState =
-                  state.withoutFetchesAndRecords(canBeCompleted).withRecords(storeRecords)
-                (
-                  newState,
-                  HandlePollResult.CompletedAndStored(
-                    completeFetches = completeFetches,
-                    completedLog = CompletedFetchesWithRecords(
-                      allRecords.filterKeysStrict(canBeCompleted),
-                      newState
-                    ),
-                    storedLog = StoredRecords(storeRecords, newState),
-                    pendingCommits = pendingCommits
-                  )
-                )
-
-              case (true, false) =>
-                val newState = state.withoutFetchesAndRecords(canBeCompleted)
-                (
-                  newState,
-                  HandlePollResult.Completed(
-                    completeFetches = completeFetches,
-                    log = CompletedFetchesWithRecords(
-                      allRecords.filterKeysStrict(canBeCompleted),
-                      newState
-                    ),
-                    pendingCommits = pendingCommits
-                  )
-                )
-
-              case (false, true) =>
-                val storeRecords = newRecords.filterKeysStrict(canBeStored)
-                val newState     = state.withRecords(storeRecords)
-                (
-                  newState,
-                  HandlePollResult.Stored(StoredRecords(storeRecords, newState), pendingCommits)
-                )
-
-              case (false, false) =>
-                (state, HandlePollResult.StateNotChanged(pendingCommits))
-            }
-          } else {
-            (state, HandlePollResult.StateNotChanged(pendingCommits))
-          }
-        }
-
-      def handlePendingCommits(state: State[F, K, V]) = {
-        val currentRebalancing = state.rebalancing
-
-        if (initialRebalancing && !currentRebalancing && state.pendingCommits.nonEmpty) {
-          val newState = state.withoutPendingCommits
-          (
-            newState,
-            Some(
-              HandlePollResult.PendingCommits(
-                commits = state.pendingCommits,
-                log = CommittedPendingCommits(state.pendingCommits, newState)
-              )
-            )
-          )
-        } else (state, None)
-      }
-
-      ref
-        .modify { state =>
-          val (stateWithoutPendingCommits, pendingCommits) = handlePendingCommits(state)
-          handleBatch(stateWithoutPendingCommits, pendingCommits)
-        }
-        .flatMap { result =>
-          (result match {
-            case HandlePollResult.StateNotChanged(_) =>
-              F.unit
-            case HandlePollResult.Stored(log, _) =>
-              logging.log(log)
-            case HandlePollResult.Completed(completeFetches, log, _) =>
-              completeFetches >> logging.log(log)
-            case HandlePollResult.CompletedAndStored(completeFetches, completedLog, storedLog, _) =>
-              completeFetches >> logging.log(completedLog) >> logging.log(storedLog)
-          }) >> result.pendingCommits.traverse_(_.commit)
-        }
     }
 
+    // Attempts to enqueue existing spillover records and newly fetched records. Returns updated spillover.
+    val queueRecords = {
+      (partitionState: PartitionStateMap[F, K, V], newRecords: ConsumerRecords) =>
+        require(newRecords.forall(kv => partitionState.contains(kv._1)))
+
+        partitionState
+          .toList
+          .flatTraverse { case (partition, PartitionState(queue, spillover, _)) =>
+            val chunk = spillover ++ newRecords.getOrElse(partition, Chunk.empty)
+
+            F.pure(chunk.isEmpty)
+              .ifM[List[(TopicPartition, Chunk[CommittableConsumerRecord[F, K, V]])]](
+                F.pure(Nil),
+                queue.tryOffer(chunk).ifF(Nil, List(partition -> chunk))
+              )
+          }
+    }
+
+    // Resets spillover, resets pending commits.
+    val updateStateAfterPoll = { (spillover: ConsumerRecords) =>
+      ref.flatModify(_.resetSpilloverAfterPoll(spillover).resetPendingCommitsAfterPoll)
+    }
+
+    updateStateBeforePoll.flatMap {
+      case (isStreaming @ true, assignment, queueIsFull) =>
+        for {
+          newRecords     <- pollForRecords(assignment, queueIsFull) // Poll may change assignment
+          partitionState <- ensurePartitionStateFor(newRecords.keySet)
+          spillover      <- queueRecords(partitionState, newRecords)
+          _              <- updateStateAfterPoll(spillover.toMap)
+        } yield ()
+
+      case _ =>
+        // Not streaming
+        F.unit
+    }
+  }
+
+  /**
+    * Ensures the state holds a PartitionState for each requested partition, and returns the map of
+    * all partition states (including at least the requested partitions).
+    *
+    * At the cost of additional synchronization on the internal state `ref`, this method
+    * optimistically assumes there is already an entry for the requested partition. The intent is to
+    * avoid over-provisioning `PartitionState` instances. New instances are then created as
+    * necessary, and atomically added to the state.
+    *
+    * This may still create and discard duplicate `PartitionState` instances. Any previously added
+    * to the state will be returned and not overwritten.
+    *
+    * Called by `poll`, and `getQueueAndStopSignalFor` (for `KafkaConsumer`).
+    */
+  private[this] def ensurePartitionStateFor(
+    partitions: Set[TopicPartition]
+  ): F[PartitionStateMap[F, K, V]] =
     ref
       .get
       .flatMap { state =>
-        F.uncancelable { poll =>
-            val initialRebalancing = state.rebalancing
-            for {
-              records <- poll(pollConsumer(state))
-              _       <- handlePoll(records, initialRebalancing)
-            } yield ()
-          }
-          .whenA(state.subscribed && state.streaming)
+        (partitions -- state.partitionState.keys).toList match {
+          case Nil => F.pure(state.partitionState)
+          case missing =>
+            missing
+              .traverse { partition =>
+                (
+                  Queue.bounded[F, Chunk[CommittableConsumerRecord[F, K, V]]](
+                    settings.maxPrefetchBatches
+                  ),
+                  F.pure(Chunk.empty[CommittableConsumerRecord[F, K, V]]),
+                  F.deferred[Unit]
+                ).parMapN(partition -> PartitionState(_, _, _))
+              }
+              .flatMap { newPartitionState =>
+                val newPartitionStateMap = newPartitionState.toMap
+                ref.modify(_.addPartitionStates(newPartitionStateMap))
+              }
+        }
       }
-  }
+
+  def getQueueAndStopSignalFor(partition: TopicPartition): F[(ConsumerQueue, F[Unit])] =
+    ensurePartitionStateFor(Set(partition)).flatMap { partitionState =>
+      partitionState.get(partition) match {
+        case Some(ps) => F.pure((ps.queue, ps.closeSignal.get))
+        case None =>
+          F.raiseError(new IllegalStateException(s"PartitionState not added for $partition"))
+      }
+    }
 
   def handle(request: Request[F, K, V]): F[Unit] =
     request match {
@@ -411,134 +315,182 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
       case Request.WithPermit(fa, cb)               => fa.attempt >>= cb
     }
 
-  sealed private[this] trait HandlePollResult {
-    def pendingCommits: Option[HandlePollResult.PendingCommits]
-  }
-
-  private[this] object HandlePollResult {
-
-    case class PendingCommits(
-      commits: Chain[Request.Commit[F]],
-      log: CommittedPendingCommits[F]
-    ) {
-
-      def commit: F[Unit] =
-        commits.traverse { commitRequest =>
-          commitAsync(commitRequest.offsets, commitRequest.callback)
-        } >> logging.log(log)
-
-    }
-
-    case class StateNotChanged(pendingCommits: Option[PendingCommits]) extends HandlePollResult
-
-    case class Stored(
-      log: LogEntry.StoredRecords[F],
-      pendingCommits: Option[PendingCommits]
-    ) extends HandlePollResult
-
-    case class Completed(
-      completeFetches: F[Unit],
-      log: LogEntry.CompletedFetchesWithRecords[F],
-      pendingCommits: Option[PendingCommits]
-    ) extends HandlePollResult
-
-    case class CompletedAndStored(
-      completeFetches: F[Unit],
-      completedLog: LogEntry.CompletedFetchesWithRecords[F],
-      storedLog: LogEntry.StoredRecords[F],
-      pendingCommits: Option[PendingCommits]
-    ) extends HandlePollResult
-
-  }
-
 }
 
 private[kafka] object KafkaConsumerActor {
 
-  final case class FetchRequest[F[_], K, V](
-    callback: ((Chunk[CommittableConsumerRecord[F, K, V]], FetchCompletedReason)) => F[Unit]
+  final case class PartitionState[F[_]: Async, K, V](
+    queue: Queue[F, Chunk[CommittableConsumerRecord[F, K, V]]],
+    spillover: Chunk[CommittableConsumerRecord[F, K, V]],
+    closeSignal: Deferred[F, Unit]
   ) {
 
-    def completeRevoked(chunk: Chunk[CommittableConsumerRecord[F, K, V]]): F[Unit] =
-      callback((chunk, FetchCompletedReason.TopicPartitionRevoked))
+    def isQueueFull: Boolean = spillover.nonEmpty
 
-    def completeRecords(chunk: Chunk[CommittableConsumerRecord[F, K, V]]): F[Unit] =
-      callback((chunk, FetchCompletedReason.FetchedRecords))
+    def close: F[Unit] = closeSignal.complete(()).void
 
     override def toString: String =
-      "FetchRequest$" + System.identityHashCode(this)
+      spillover.head match {
+        case None         => "()"
+        case Some(record) => s"(offset = ${record.offset}, size = ${spillover.size})"
+      }
 
   }
 
-  type StreamId = Int
+  private type PartitionStateMap[F[_], K, V] = Map[TopicPartition, PartitionState[F, K, V]]
 
   final case class State[F[_], K, V](
-    fetches: Map[TopicPartition, Map[StreamId, FetchRequest[F, K, V]]],
-    records: Map[TopicPartition, NonEmptyVector[CommittableConsumerRecord[F, K, V]]],
-    pendingCommits: Chain[Request.Commit[F]],
+    partitionState: PartitionStateMap[F, K, V],
+    pendingCommits: Chain[F[Unit]],
     onRebalances: Chain[OnRebalance[F]],
     rebalancing: Boolean,
     subscribed: Boolean,
     streaming: Boolean
-  ) {
+  )(implicit F: Async[F]) {
+
+    /**
+      * State update function that updates `partitionState` to ensure it includes a state for all
+      * requested partitions.
+      *
+      * If no previous state exists for a given partition, the proposed `PartitionState` is added to
+      * the new state. Otherwise, the existing partition state is kept.
+      *
+      * Use with `Ref.modify`.
+      */
+    def addPartitionStates(
+      newPartitionState: PartitionStateMap[F, K, V]
+    ): (State[F, K, V], PartitionStateMap[F, K, V]) = {
+      // Own partitionState takes precedence over newPartitionState
+      val newState: State[F, K, V] = copy(partitionState = newPartitionState ++ partitionState)
+      (newState, newState.partitionState)
+    }
+
+    /**
+      * Updates the state based on a set of assigned partitions, received as part of a rebalance
+      * operation; concludes a previous rebalance operation.
+      *
+      * Partition state for newly assigned partitions will be lazily initialized when records are
+      * fetched, or a new stream created for the partition.
+      *
+      * Returns an effect with the registered `OnRebalance.onAssigned` callbacks, so that it may be
+      * invoked outside an uncancelable block.
+      *
+      * Use with `Ref.flatModify`, and then `.flatten` to invoke registered `OnRebalance.onAssigned`
+      * callbacks.
+      */
+    def withAssignedPartitions(
+      assigned: SortedSet[TopicPartition]
+    )(implicit logging: Logging[F]): (State[F, K, V], F[F[Unit]]) = {
+      val newState: State[F, K, V] = if (!rebalancing) this else copy(rebalancing = false)
+
+      (
+        newState,
+        logging
+          .log(AssignedPartitions(assigned, newState))
+          .as(onRebalances.traverse_(_.onAssigned(assigned)))
+      )
+    }
+
+    /**
+      * Updates the state based on a set of revoked partitions, received as part of a rebalance
+      * operation; initiates a rebalance operation.
+      *
+      * Partition state is dropped for any partitions that are not part of the assignment, and their
+      * `closeSignal` triggered in the returned effect.
+      *
+      * Returns an effect with the registered `OnRebalance.onRevoked` callbacks, so that it may be
+      * invoked outside an uncancelable block.
+      *
+      * Use with `Ref.flatModify`, and then `.flatten` to invoke registered `OnRebalance.onRevoked`
+      * callbacks.
+      */
+    def withRevokedPartitions(
+      revoked: SortedSet[TopicPartition]
+    )(implicit logging: Logging[F]): (State[F, K, V], F[F[Unit]]) = {
+      val (revokedToClose, stillAssigned) = partitionState.partition(e => revoked.contains(e._1))
+
+      val newState: State[F, K, V] = copy(partitionState = stillAssigned, rebalancing = true)
+
+      (
+        newState,
+        for {
+          _ <- logging.log(RevokedPartitions(revoked, revokedToClose, newState))
+          _ <- revokedToClose.values.toList.traverse_(_.close)
+        } yield onRebalances.traverse_(_.onRevoked(revoked))
+      )
+    }
+
+    /**
+      * Updates the state based on the current set of assigned partitions.
+      *
+      * Partition state is dropped for any partitions that are not a part of the assignment, and
+      * their `closeSignal` triggered in the returned effect.
+      *
+      * Use with `Ref.flatModify`.
+      */
+    def dropUnassignedPartitions(
+      assignment: Set[TopicPartition]
+    )(implicit logging: Logging[F]): (State[F, K, V], F[List[TopicPartition]]) = {
+      val (assigned, revoked) = partitionState.partition(e => assignment.contains(e._1))
+
+      val newState: State[F, K, V] = copy(partitionState = assigned)
+      val queueIsFull              = assigned.filter(_._2.isQueueFull).keys.toList
+
+      (
+        newState,
+        (for {
+          _ <- revoked.values.toList.traverse_(_.close)
+          _ <- logging.log(RevokedPartitions(revoked.keySet, revoked, newState))
+        } yield ()).whenA(revoked.nonEmpty).as(queueIsFull)
+      )
+    }
+
+    /**
+      * Resets partition states with a new set of spillover records after a poll operation.
+      */
+    def resetSpilloverAfterPoll(
+      spillover: Map[TopicPartition, Chunk[CommittableConsumerRecord[F, K, V]]]
+    ): State[F, K, V] =
+      if (spillover.isEmpty)
+        this
+      else {
+        require(spillover.forall(kv => partitionState.contains(kv._1)))
+
+        val newPartitionState: PartitionStateMap[F, K, V] = partitionState.map {
+          case (partition, partitionState) =>
+            (
+              partition,
+              spillover
+                .get(partition)
+                .map(spillover => partitionState.copy(spillover = spillover))
+                .getOrElse(
+                  if (partitionState.spillover.isEmpty)
+                    partitionState
+                  else
+                    partitionState.copy(spillover = Chunk.empty)
+                )
+            )
+        }
+
+        copy(partitionState = newPartitionState)
+      }
+
+    /**
+      * Resets pending commits after a poll operation.
+      *
+      * Pending commits are reset only if a rebalance operation is no longer underway.
+      *
+      * Use with `Ref.flatModify`.
+      */
+    def resetPendingCommitsAfterPoll: (State[F, K, V], F[Unit]) =
+      if (pendingCommits.isEmpty || rebalancing) (this, F.unit)
+      else (copy(pendingCommits = Chain.empty), pendingCommits.sequence_)
 
     def withOnRebalance(onRebalance: OnRebalance[F]): State[F, K, V] =
       copy(onRebalances = onRebalances.append(onRebalance))
 
-    /**
-      * @return
-      *   (new-state, old-fetches-to-revoke)
-      */
-    def withFetch(
-      partition: TopicPartition,
-      streamId: StreamId,
-      callback: ((Chunk[CommittableConsumerRecord[F, K, V]], FetchCompletedReason)) => F[Unit]
-    ): (State[F, K, V], List[FetchRequest[F, K, V]]) = {
-      val newFetchRequest =
-        FetchRequest(callback)
-
-      val oldPartitionFetches: Map[StreamId, FetchRequest[F, K, V]] =
-        fetches.getOrElse(partition, Map.empty)
-
-      val newFetches: Map[TopicPartition, Map[StreamId, FetchRequest[F, K, V]]] =
-        fetches.updated(partition, oldPartitionFetches.updated(streamId, newFetchRequest))
-
-      val fetchesToRevoke: List[FetchRequest[F, K, V]] =
-        oldPartitionFetches.get(streamId).toList
-
-      (
-        copy(fetches = newFetches),
-        fetchesToRevoke
-      )
-    }
-
-    def withoutFetches(partitions: Set[TopicPartition]): State[F, K, V] =
-      copy(
-        fetches = fetches.filterKeysStrict(!partitions.contains(_))
-      )
-
-    def withRecords(
-      records: Map[TopicPartition, NonEmptyVector[CommittableConsumerRecord[F, K, V]]]
-    ): State[F, K, V] =
-      copy(records = this.records.combine(records))
-
-    def withoutFetchesAndRecords(partitions: Set[TopicPartition]): State[F, K, V] =
-      copy(
-        fetches = fetches.filterKeysStrict(!partitions.contains(_)),
-        records = records.filterKeysStrict(!partitions.contains(_))
-      )
-
-    def withoutRecords(partitions: Set[TopicPartition]): State[F, K, V] =
-      copy(records = records.filterKeysStrict(!partitions.contains(_)))
-
-    def withPendingCommit(pendingCommit: Request.Commit[F]): State[F, K, V] =
+    def withPendingCommit(pendingCommit: F[Unit]): State[F, K, V] =
       copy(pendingCommits = pendingCommits.append(pendingCommit))
-
-    def withoutPendingCommits: State[F, K, V] =
-      if (pendingCommits.isEmpty) this else copy(pendingCommits = Chain.empty)
-
-    def withRebalancing(rebalancing: Boolean): State[F, K, V] =
-      if (this.rebalancing == rebalancing) this else copy(rebalancing = rebalancing)
 
     def asSubscribed: State[F, K, V] =
       if (subscribed) this else copy(subscribed = true)
@@ -549,51 +501,22 @@ private[kafka] object KafkaConsumerActor {
     def asStreaming: State[F, K, V] =
       if (streaming) this else copy(streaming = true)
 
-    override def toString: String = {
-      val fetchesString =
-        fetches
-          .toList
-          .sortBy { case (tp, _) => tp }
-          .mkStringAppend { case (append, (tp, fs)) =>
-            append(tp.toString)
-            append(" -> ")
-            append(fs.mkString("[", ", ", "]"))
-          }("", ", ", "")
-
-      s"State(fetches = Map($fetchesString), records = Map(${recordsString(records)}), pendingCommits = $pendingCommits, onRebalances = $onRebalances, rebalancing = $rebalancing, subscribed = $subscribed, streaming = $streaming)"
-    }
+    override def toString: String =
+      s"State(partitionState = $partitionState, pendingCommits = $pendingCommits, onRebalances = $onRebalances, rebalancing = $rebalancing, subscribed = $subscribed, streaming = $streaming)"
 
   }
 
   object State {
 
-    def empty[F[_], K, V]: State[F, K, V] =
+    def empty[F[_]: Async, K, V]: State[F, K, V] =
       State(
-        fetches = Map.empty,
-        records = Map.empty,
+        partitionState = Map.empty,
         pendingCommits = Chain.empty,
         onRebalances = Chain.empty,
         rebalancing = false,
         subscribed = false,
         streaming = false
       )
-
-  }
-
-  sealed abstract class FetchCompletedReason {
-
-    final def topicPartitionRevoked: Boolean = this match {
-      case FetchCompletedReason.TopicPartitionRevoked => true
-      case FetchCompletedReason.FetchedRecords        => false
-    }
-
-  }
-
-  object FetchCompletedReason {
-
-    case object TopicPartitionRevoked extends FetchCompletedReason
-
-    case object FetchedRecords extends FetchCompletedReason
 
   }
 


### PR DESCRIPTION
Record streams are streamlined by dropping the `FetchRequest` middleman. Instead, queues of records are lazily created by `KafkaConsumerActor`, one for each assigned partition.

Enqueueing records uses `Queue.tryOffer`, to avoid blocking the polling fiber. `KafkaConsumerActor` maintains a separate `spillover` map to hold records when queues are full. This acts as back-pressure and pauses polling for "slow" partitions.

`KafkaConsumerActor.poll` takes a more active role in managing assigned partitions. Namely, it signals the revocation of any partitions that are not assigned, and drops those from the internal state.

While the `ConsumerRebalanceListener` interface is meant to handle this state when the consumer faces rebalance operations, explicitly handling assignments in `poll` caters to manually assigned partitions. In addition, it ensures `KafkaConsumerActor`'s internal state stays consistent in the face of race conditions between rebalance operations and the setup of record streams in `KafkaConsumer`.

The newly introduced `partitionState` (maintaining per-partition queues and spillover records) bears some resemblance to the former `fetches` and `records` fields, but differs in some important ways:

- registration of fetch requests involved a query of the current consumer assignment, which forced synchronization with the polling thread via the use of `withConsumer.blocking`.
- fetch requests would follow the lifcycle of record chunks, and needed to be continuously re-added to the state, before new data would be polled from a partition. Now, the current assignment forms the basis to fetch data from a partition, with spillover records acting as a back-pressure signal;
- `records` acted as a holding area, but mainly supported a race condition between a new assignment, the start of a new stream, and the subsequent registration of fetch requests. `records` was not generally used as a spillover area for incoming data.

In the face of multiple streams hooked up to a single consumer, an inherent race in the old registration of fetch requests meant that each chunk of records could be added to all or only a subset of the listening streams. With the new approach, multiple streams will forcefully compete to take elements from the queue, ensuring each chunk of records goes to only one stream. (While I do not expect that such use of multiple streams was a feature, the potential behavior change is noted.)

An internal `StreamId` was previously used to match `FetchRequest`s to the owning stream. This is no longer used and the ID is dropped.

`KafkaConsumer` previously kept track of its partition assignment, along with a `Deferred` instances to interrupt partition streams. This is now handled by `KafkaConsumerActor`, which relies solely on the underlying consumer to keep track of its current assignment.

Overall, this change should reduce some overhead and latency between the polling thread and the record streams. It does this by removing layers through which records must pass, as well as reducing synchronization between polling and consuming fibers.