### PR TITLE
Comitting records outside of kafka. Test to reproduce issue.

### DIFF
--- a/modules/core/src/test/resources/logback-test.xml
+++ b/modules/core/src/test/resources/logback-test.xml
@@ -6,7 +6,7 @@
     </encoder>
   </appender>
 
-  <root level="INFO" additivity="false">
+  <root level="ERROR" additivity="false">
     <appender-ref ref="STDOUT"/>
   </root>
 </configuration>

--- a/modules/core/src/test/scala/fs2/kafka/KafkaMultiSeekSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaMultiSeekSpec.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018-2024 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka
+
+import scala.concurrent.duration.*
+
+import cats.data.{NonEmptyList, NonEmptySet}
+import cats.effect.{Fiber, IO, Ref, Resource}
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import fs2.concurrent.SignallingRef
+import fs2.kafka.consumer.KafkaConsumeChunk.CommitNow
+import fs2.kafka.internal.converters.collection.*
+import fs2.Stream
+
+import org.apache.kafka.clients.consumer.{
+  ConsumerConfig,
+  CooperativeStickyAssignor,
+  NoOffsetForPartitionException
+}
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.errors.TimeoutException
+import org.apache.kafka.common.TopicPartition
+import org.scalatest.Assertion
+
+final class KafkaMultiSeekSpec extends BaseKafkaSpec {
+
+  type Consumer = KafkaConsumer[IO, String, String]
+
+  type ConsumerStream = Stream[IO, CommittableConsumerRecord[IO, String, String]]
+  val topic       = "topic-example"
+  val partitions  = 2
+  val replication = 1
+
+  val records =
+    for {
+      partition <- (0 until partitions).toList
+      recordX   <- (0 until 10).toList
+      key        = s"key-p-$partition-r-$recordX"
+      value      = s"value-p-$partition-r-$recordX"
+    } yield ProducerRecord(topic, key, value).withPartition(partition)
+
+  describe("seeking to an offset") {
+    it("should correctly reset the first fetched offset") {
+      val consumerSettings = ConsumerSettings[IO, String, String]
+      val producerSettings = Map[String, String](
+        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> container.bootstrapServers,
+        ProducerConfig.MAX_BLOCK_MS_CONFIG      -> 10000.toString,
+        ProducerConfig.RETRY_BACKOFF_MS_CONFIG  -> 1000.toString
+      )
+      val delay   = 5.seconds
+      val waitEnd = 10.seconds
+
+      (for {
+        _ <- Stream.eval(createTopic(topic, partitions, 1))
+        _ <- Stream.eval(pushData(records))
+        _ <- Stream.resource(consumer("consumer1").compile.drain.background)
+        _ <- Stream.eval(IO.sleep(delay) *> IO.println(s"\n\nSlept for $delay."))
+        _ <- Stream.resource(consumer("consumer2").compile.drain.background)
+        _ <- Stream.eval(IO.sleep(waitEnd) *> IO.println(s"\n\nWill terminate after $waitEnd."))
+      } yield assert(true)).compile.drain.unsafeRunSync()
+    }
+  }
+
+  private def consumer(name: String) = {
+    for {
+      _ <- Stream.eval(IO.println(s"[action: consumer-joining, consumer: $name]"))
+      settings = ConsumerSettings[IO, Unit, Unit]
+                   .withProperties(
+                     Map(
+                       "client.id"          -> s"pipeline.simple.test.$name",
+                       "enable.auto.commit" -> s"false",
+                       "group.id"           -> "group.test",
+                       "auto.offset.reset"  -> "earliest"
+                     )
+                   )
+                   .withBootstrapServers(container.bootstrapServers)
+      consumer <- KafkaConsumer.stream(settings)
+      _        <- Stream.eval(consumer.subscribe(NonEmptyList.one(topic)))
+      assignments <- consumer
+                       .assignmentStream
+                       .switchMap { assignments =>
+                         for {
+                           _ <- Stream.eval(NonEmptySet.fromSet(assignments).pure[IO]).unNone
+                           _ <-
+                             Stream.eval(
+                               IO.println(
+                                 s"[action: assigned, consumer: $name, partitions: ${assignments.toList}]"
+                               )
+                             )
+                           _ <-
+                             Stream.eval(
+                               assignments.traverse_ { tp =>
+                                 val seek = 9
+                                 IO.println(
+                                   s"[action: seek, to: $seek consumer: $name, partition: $tp]"
+                                 ) *> consumer.seek(tp, seek)
+                               }
+                             )
+                           _ <- Stream.eval(
+                                  IO.println(
+                                    s"[action: call 'records', consumer:$name, topic:$topic"
+                                  )
+                                )
+                           record   <- consumer.records
+                           topic     = record.offset.topicPartition.topic()
+                           partition = record.offset.topicPartition.partition()
+                           offset    = record.record.offset
+                           _ <-
+                             Stream.eval(
+                               IO.println(
+                                 s"[action: record, consumer:$name, topic:$topic, partition:$partition, offset:$offset]"
+                               )
+                             )
+                         } yield ()
+                       }
+    } yield ()
+  }
+
+  def createTopic(
+    topic: String,
+    partition: Int,
+    replication: Int
+  ): IO[Unit] =
+    IO.fromTry(createCustomTopic(topic, Map.empty, partition, replication))
+
+  def pushData(records: List[ProducerRecord[String, String]]): IO[Unit] = {
+    val settings = ProducerSettings[IO, String, String]
+      .withBootstrapServers(container.bootstrapServers)
+    KafkaProducer[IO]
+      .resource(settings)
+      .use(_.produce(ProducerRecords[List, String, String](records)))
+      .flatten
+      .void
+  }
+
+}

--- a/modules/core/src/test/scala/fs2/kafka/KafkaMultiSeekSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaMultiSeekSpec.scala
@@ -32,29 +32,32 @@ final class KafkaMultiSeekSpec extends BaseKafkaSpec {
   type Consumer = KafkaConsumer[IO, String, String]
 
   type ConsumerStream = Stream[IO, CommittableConsumerRecord[IO, String, String]]
-  val topic       = "topic-example"
-  val partitions  = 2
-  val replication = 1
+  val topic               = "topic-example"
+  val partitions          = 3
+  val replication         = 1
+  val recordsPerPartition = 10
 
   val records =
     for {
       partition <- (0 until partitions).toList
-      recordX   <- (0 until 10).toList
+      recordX   <- (0 until recordsPerPartition).toList
       key        = s"key-p-$partition-r-$recordX"
       value      = s"value-p-$partition-r-$recordX"
     } yield ProducerRecord(topic, key, value).withPartition(partition)
 
+  val delay   = 5.seconds
+  val waitEnd = 10.seconds
+  val seekTo  = recordsPerPartition - 1
+
   describe("seeking to an offset") {
     it("should correctly reset the first fetched offset") {
       val consumerSettings = ConsumerSettings[IO, String, String]
+
       val producerSettings = Map[String, String](
         ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> container.bootstrapServers,
         ProducerConfig.MAX_BLOCK_MS_CONFIG      -> 10000.toString,
         ProducerConfig.RETRY_BACKOFF_MS_CONFIG  -> 1000.toString
       )
-      val delay   = 5.seconds
-      val waitEnd = 10.seconds
-
       (for {
         _ <- Stream.eval(createTopic(topic, partitions, 1))
         _ <- Stream.eval(pushData(records))
@@ -79,8 +82,8 @@ final class KafkaMultiSeekSpec extends BaseKafkaSpec {
                      )
                    )
                    .withBootstrapServers(container.bootstrapServers)
-      consumer <- KafkaConsumer.stream(settings)
-      _        <- Stream.eval(consumer.subscribe(NonEmptyList.one(topic)))
+      consumer      <- KafkaConsumer.stream(settings)
+      _             <- Stream.eval(consumer.subscribe(NonEmptyList.one(topic)))
       assignments <- consumer
                        .assignmentStream
                        .switchMap { assignments =>
@@ -95,10 +98,9 @@ final class KafkaMultiSeekSpec extends BaseKafkaSpec {
                            _ <-
                              Stream.eval(
                                assignments.traverse_ { tp =>
-                                 val seek = 9
                                  IO.println(
-                                   s"[action: seek, to: $seek consumer: $name, partition: $tp]"
-                                 ) *> consumer.seek(tp, seek)
+                                   s"[action: seek, to: $seekTo consumer: $name, partition: $tp]"
+                                 ) *> consumer.seek(tp, seekTo)
                                }
                              )
                            _ <- Stream.eval(


### PR DESCRIPTION
This PR demonstrates the following issue:

When a consumer joins an existing consumer group with other active consumers, if `seek` is used, it can happen that the consumer starts reading not from the offset that results from applying the `"auto.offset.reset"` strategy instead of the offset passed to "seek".

It might take a few attempts to observe, but the result should look something like this: 

```
[action: consumer-joining, consumer: consumer1]
[action: assigned, consumer: consumer1, partitions: List(topic-example-0, topic-example-1, topic-example-2)]
[action: seek, to: 9 consumer: consumer1, partition: topic-example-0]
[action: seek, to: 9 consumer: consumer1, partition: topic-example-1]
[action: seek, to: 9 consumer: consumer1, partition: topic-example-2]
[action: call 'records', consumer:consumer1, topic:topic-example
[action: record, consumer:consumer1, topic:topic-example, partition:1, offset:9]
[action: record, consumer:consumer1, topic:topic-example, partition:2, offset:9]
[action: record, consumer:consumer1, topic:topic-example, partition:0, offset:9]


Slept for 5 seconds.
[action: consumer-joining, consumer: consumer2]
[action: assigned, consumer: consumer2, partitions: List(topic-example-2)]
[action: seek, to: 9 consumer: consumer2, partition: topic-example-2]
[action: assigned, consumer: consumer1, partitions: List(topic-example-0, topic-example-1)]
[action: seek, to: 9 consumer: consumer1, partition: topic-example-0]
[action: call 'records', consumer:consumer2, topic:topic-example
[action: seek, to: 9 consumer: consumer1, partition: topic-example-1]
[action: call 'records', consumer:consumer1, topic:topic-example
[action: record, consumer:consumer2, topic:topic-example, partition:2, offset:0]
[action: record, consumer:consumer2, topic:topic-example, partition:2, offset:1]
[action: record, consumer:consumer2, topic:topic-example, partition:2, offset:2]
[action: record, consumer:consumer2, topic:topic-example, partition:2, offset:3]
[action: record, consumer:consumer2, topic:topic-example, partition:2, offset:4]
[action: record, consumer:consumer2, topic:topic-example, partition:2, offset:5]
[action: record, consumer:consumer2, topic:topic-example, partition:2, offset:6]
[action: record, consumer:consumer2, topic:topic-example, partition:2, offset:7]
[action: record, consumer:consumer2, topic:topic-example, partition:2, offset:8]
[action: record, consumer:consumer2, topic:topic-example, partition:2, offset:9]
[action: record, consumer:consumer1, topic:topic-example, partition:0, offset:9]
[action: record, consumer:consumer1, topic:topic-example, partition:1, offset:9]
[action: record, consumer:consumer2, topic:topic-example, partition:2, offset:9]


Will terminate after 10 seconds.
```

Notice that both consumer instances do a seek to offset 9. 
Despite this however consumer2 starts reading from the earliest offset.