### PR TITLE
chore: update copyright notices

### DIFF
--- a/modules/core/src/main/scala-2.12/fs2/kafka/internal/converters.scala
+++ b/modules/core/src/main/scala-2.12/fs2/kafka/internal/converters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala-2.13+/fs2/kafka/internal/converters.scala
+++ b/modules/core/src/main/scala-2.13+/fs2/kafka/internal/converters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/Acks.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Acks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/AdminClientSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/AdminClientSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/AutoOffsetReset.scala
+++ b/modules/core/src/main/scala/fs2/kafka/AutoOffsetReset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/CommitRecovery.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommitRecovery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/CommitRecoveryException.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommitRecoveryException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/CommitTimeoutException.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommitTimeoutException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/CommittableConsumerRecord.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommittableConsumerRecord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/CommittableOffset.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommittableOffset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/CommittableOffsetBatch.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommittableOffsetBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/CommittableProducerRecords.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommittableProducerRecords.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerGroupException.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerGroupException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerRecord.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerRecord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerShutdownException.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerShutdownException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/DeserializationException.scala
+++ b/modules/core/src/main/scala/fs2/kafka/DeserializationException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/Deserializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Deserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/Header.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Header.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/HeaderDeserializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/HeaderDeserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/HeaderSerializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/HeaderSerializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/Headers.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Headers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/IsolationLevel.scala
+++ b/modules/core/src/main/scala/fs2/kafka/IsolationLevel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/Jitter.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Jitter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducerConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/NotSubscribedException.scala
+++ b/modules/core/src/main/scala/fs2/kafka/NotSubscribedException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/ProducerRecord.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ProducerRecord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/SerializationException.scala
+++ b/modules/core/src/main/scala/fs2/kafka/SerializationException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/Serializer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Serializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/Timestamp.scala
+++ b/modules/core/src/main/scala/fs2/kafka/Timestamp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalProducerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalProducerSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/UnexpectedTopicException.scala
+++ b/modules/core/src/main/scala/fs2/kafka/UnexpectedTopicException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/admin/MkAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/admin/MkAdminClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaAssignment.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaAssignment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaCommit.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaCommit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsume.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumeChunk.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaConsumerLifecycle.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaMetrics.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsets.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsets.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsetsV2.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaOffsetsV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaSubscription.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaSubscription.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaTopics.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaTopics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/KafkaTopicsV2.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/KafkaTopicsV2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/consumer/MkConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/instances.scala
+++ b/modules/core/src/main/scala/fs2/kafka/instances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/internal/Blocking.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/Blocking.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/internal/LogLevel.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/LogLevel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/internal/Logging.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/Logging.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithAdminClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/internal/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/producer/MkProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/security/KafkaCredentialStore.scala
+++ b/modules/core/src/main/scala/fs2/kafka/security/KafkaCredentialStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/vulcan-testkit-munit/src/main/scala/fs2/kafka/vulcan/testkit/SchemaSuite.scala
+++ b/modules/vulcan-testkit-munit/src/main/scala/fs2/kafka/vulcan/testkit/SchemaSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/Auth.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/Auth.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroDeserializer.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroDeserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSerializer.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSerializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSettings.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/AvroSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/SchemaRegistryClientSettings.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/SchemaRegistryClientSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/vulcan/src/main/scala/fs2/kafka/vulcan/package.scala
+++ b/modules/vulcan/src/main/scala/fs2/kafka/vulcan/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 OVO Energy Limited
+ * Copyright 2018-2025 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
Executed command: `sbt headerCreate`

CI is failing for 2025 builds due to this.