### PR TITLE
CVE-2024-47561 - Bump vulcan to bump avro dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val kafkaVersion = "2.8.2"
 
 val testcontainersScalaVersion = "0.40.17"
 
-val vulcanVersion = "1.9.0"
+val vulcanVersion = "1.11.1"
 
 val munitVersion = "0.7.29"
 
@@ -16,7 +16,7 @@ val scala212 = "2.12.17"
 
 val scala213 = "2.13.10"
 
-val scala3 = "3.2.2"
+val scala3 = "3.3.3"
 
 ThisBuild / tlBaseVersion := "2.6"
 


### PR DESCRIPTION
Fixes CVE-2024-47561

* Bump `com.github.fd4s:vulcan` to `1.11.1`
* This transitively bumps `org.apache.avro:avro` to `1.11.4`
* Necessary: Bump `scalaVersion` to `3.3.3` (vulcan is compiled using `3.3.x`

The vuln still exists in 1.11.0: https://mvnrepository.com/artifact/com.github.fd4s/vulcan_2.13/1.11.0
Fixed in 1.11.1: https://mvnrepository.com/artifact/com.github.fd4s/vulcan_2.13/1.11.1