### PR TITLE
Fix exeption of multiple promise completions (#1391)

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -219,7 +219,7 @@ object KafkaProducer {
                   if (exception == null) { promise.success((record, metadata)) }
                   else {
                     promise.failure(exception)
-                    produceRecordError.foreach(_.failure(exception))
+                    produceRecordError.foreach(_.tryFailure(exception))
                   }
                 }
               )


### PR DESCRIPTION
Using `tryFailure` instead of `failure` will not produce an `IllegalStateException` when the sending of multiple records is interrupted. The same promise is used for all records and all of them will complete that same promise, leading to the exception without this change.

This fixes issue #1391.