### PR TITLE
fix: reset spillover after poll loop

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -450,30 +450,27 @@ private[kafka] object KafkaConsumerActor {
       */
     def resetSpilloverAfterPoll(
       spillover: Map[TopicPartition, Chunk[CommittableConsumerRecord[F, K, V]]]
-    ): State[F, K, V] =
-      if (spillover.isEmpty)
-        this
-      else {
-        require(spillover.forall(kv => partitionState.contains(kv._1)))
+    ): State[F, K, V] = {
+      require(spillover.forall(kv => partitionState.contains(kv._1)))
 
-        val newPartitionState: PartitionStateMap[F, K, V] = partitionState.map {
-          case (partition, partitionState) =>
-            (
-              partition,
-              spillover
-                .get(partition)
-                .map(spillover => partitionState.copy(spillover = spillover))
-                .getOrElse(
-                  if (partitionState.spillover.isEmpty)
-                    partitionState
-                  else
-                    partitionState.copy(spillover = Chunk.empty)
-                )
-            )
-        }
-
-        copy(partitionState = newPartitionState)
+      val newPartitionState: PartitionStateMap[F, K, V] = partitionState.map {
+        case (partition, partitionState) =>
+          (
+            partition,
+            spillover
+              .get(partition)
+              .map(spillover => partitionState.copy(spillover = spillover))
+              .getOrElse(
+                if (partitionState.spillover.isEmpty)
+                  partitionState
+                else
+                  partitionState.copy(spillover = Chunk.empty)
+              )
+          )
       }
+
+      copy(partitionState = newPartitionState)
+    }
 
     /**
       * Resets pending commits after a poll operation.


### PR DESCRIPTION
In the face of backpressure, spillover records that couldn't be offered to the queue would be registered, and wouldn't always be cleared afterwards, leading to duplicate records being offered. This is addressed by ensuring spillover records are always reset at the end of the poll loop.

In an earlier iteration of #1369 spillover records were reset early in the poll loop. At the end of the loop only remaining spillover records needed to be recorded. In the approach that ended up being submitted spillover records are reset only once at the end of the poll loop, but logic from the earlier iteration was inadvertently left behind that skipped this reset operation in the case there were no remaining spillover records to register.