### PR TITLE
feat: Implemented RebalanceRevokeMode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -299,7 +299,13 @@ ThisBuild / mimaBinaryIssueFilters ++= {
     ProblemFilters.exclude[DirectMissingMethodProblem](
       "fs2.kafka.ProducerSettings#ProducerSettingsImpl.apply"
     ),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaProducer.produceRecord")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaProducer.produceRecord"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.sessionTimeout"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.rebalanceRevokeMode"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withRebalanceRevokeMode"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.apply")
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -300,12 +300,24 @@ ThisBuild / mimaBinaryIssueFilters ++= {
       "fs2.kafka.ProducerSettings#ProducerSettingsImpl.apply"
     ),
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaProducer.produceRecord"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.sessionTimeout"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.rebalanceRevokeMode"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withRebalanceRevokeMode"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.apply")
+    ProblemFilters.exclude[ReversedMissingMethodProblem](
+      "fs2.kafka.ConsumerSettings.sessionTimeout"
+    ),
+    ProblemFilters.exclude[ReversedMissingMethodProblem](
+      "fs2.kafka.ConsumerSettings.rebalanceRevokeMode"
+    ),
+    ProblemFilters.exclude[ReversedMissingMethodProblem](
+      "fs2.kafka.ConsumerSettings.withRebalanceRevokeMode"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.apply"
+    )
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val scala213 = "2.13.16"
 
 val scala3 = "3.3.5"
 
-ThisBuild / tlBaseVersion := "3.8"
+ThisBuild / tlBaseVersion := "3.9"
 
 ThisBuild / tlCiReleaseBranches := Seq("series/3.x")
 

--- a/docs/src/main/mdoc/consumers.md
+++ b/docs/src/main/mdoc/consumers.md
@@ -551,9 +551,9 @@ Also note, that even if you implement a graceful shutdown your application may f
 
 In addition to graceful shutdown of the whole consumer there is an option to configure your consumer to wait for the streams
 to finish processing partition before "releasing" it. Behavior can be enabled via the following settings:
+
 ```scala mdoc:silent
 object WithGracefulPartitionRevoke extends IOApp.Simple {
-
   val run: IO[Unit] = {
     def processRecord(record: CommittableConsumerRecord[IO, String, String]): IO[Unit] =
       IO(println(s"Processing record: $record"))
@@ -568,23 +568,22 @@ object WithGracefulPartitionRevoke extends IOApp.Simple {
         .compile
         .drain
     }
-    
-    val consumerSettings = ConsumerSettings[IO, String, String] =
+
+    val consumerSettings =
       ConsumerSettings[IO, String, String]
         .withRebalanceRevokeMode(RebalanceRevokeMode.Graceful)
         .withSessionTimeout(2.seconds)
 
     KafkaConsumer
       .resource(consumerSettings)
-      .use { consumer => 
+      .use { consumer =>
         run(consumer)
       }
   }
-
 }
 ```
 
-Please note that this setting does not guarantee that all the commits will be performed before partition is revoked and 
+Please note that this setting does not guarantee that all the commits will be performed before partition is revoked and
 that `session.timeout.ms` setting is set to lower value. Be aware that awaiting too long for partition processor
 to finish will cause processing of the whole topic to be suspended.
 

--- a/docs/src/main/mdoc/consumers.md
+++ b/docs/src/main/mdoc/consumers.md
@@ -547,6 +547,49 @@ You may notice, that actual graceful shutdown implementation requires a decent a
 
 Also note, that even if you implement a graceful shutdown your application may fall with an error. And in this case, a graceful shutdown will not be invoked. It means that your application should be ready to an _at least once_ semantic even when a graceful shutdown is implemented. Or, if you need an _exactly once_ semantic, consider using [transactions](transactions.md).
 
+### Graceful partition revoke
+
+In addition to graceful shutdown of the whole consumer there is an option to configure your consumer to wait for the streams
+to finish processing partition before "releasing" it. Behavior can be enabled via the following settings:
+```scala mdoc:silent
+object WithGracefulPartitionRevoke extends IOApp.Simple {
+
+  val run: IO[Unit] = {
+    def processRecord(record: CommittableConsumerRecord[IO, String, String]): IO[Unit] =
+      IO(println(s"Processing record: $record"))
+
+    def run(consumer: KafkaConsumer[IO, String, String]): IO[Unit] = {
+      consumer.subscribeTo("topic") >> consumer
+        .stream
+        .evalMap { msg =>
+          processRecord(msg).as(msg.offset)
+        }
+        .through(commitBatchWithin(100, 15.seconds))
+        .compile
+        .drain
+    }
+    
+    val consumerSettings = ConsumerSettings[IO, String, String] =
+      ConsumerSettings[IO, String, String]
+        .withRebalanceRevokeMode(RebalanceRevokeMode.Graceful)
+        .withSessionTimeout(2.seconds)
+
+    KafkaConsumer
+      .resource(consumerSettings)
+      .use { consumer => 
+        run(consumer)
+      }
+  }
+
+}
+```
+
+Please note that this setting does not guarantee that all the commits will be performed before partition is revoked and 
+that `session.timeout.ms` setting is set to lower value. Be aware that awaiting too long for partition processor
+to finish will cause processing of the whole topic to be suspended.
+
+Awaiting for commits to complete might be implemented in the future.
+
 [commitrecovery-default]: @API_BASE_URL@/CommitRecovery$.html#Default:fs2.kafka.CommitRecovery
 [committableconsumerrecord]: @API_BASE_URL@/CommittableConsumerRecord.html
 [committableoffset]: @API_BASE_URL@/CommittableOffset.html

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -8,6 +8,7 @@ package fs2.kafka
 
 import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext
+import scala.util.Try
 
 import cats.effect.Resource
 import cats.Show
@@ -150,6 +151,17 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
     * }}}
     */
   def withMaxPollInterval(maxPollInterval: FiniteDuration): ConsumerSettings[F, K, V]
+
+  /**
+    * Returns value for property:
+    *
+    * {{{
+    * ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG
+    * }}}
+    *
+    * Returns a value as a [[FiniteDuration]] for convenience
+    */
+  def sessionTimeout: FiniteDuration
 
   /**
     * Returns a new [[ConsumerSettings]] instance with the specified session timeout. This is
@@ -373,6 +385,17 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
     */
   def withCredentials(credentialsStore: KafkaCredentialStore): ConsumerSettings[F, K, V]
 
+  /**
+    * One of two possible modes of operation for [[KafkaConsumer.partitionsMapStream]]. See
+    * [[RebalanceRevokeMode]] for detailed explanation of differences between them.
+    */
+  def rebalanceRevokeMode: RebalanceRevokeMode
+
+  /**
+    * Creates a new [[ConsumerSettings]] with the specified [[rebalanceRevokeMode]].
+    */
+  def withRebalanceRevokeMode(rebalanceRevokeMode: RebalanceRevokeMode): ConsumerSettings[F, K, V]
+
 }
 
 object ConsumerSettings {
@@ -388,7 +411,8 @@ object ConsumerSettings {
     override val pollTimeout: FiniteDuration,
     override val commitRecovery: CommitRecovery,
     override val recordMetadata: ConsumerRecord[K, V] => String,
-    override val maxPrefetchBatches: Int
+    override val maxPrefetchBatches: Int,
+    override val rebalanceRevokeMode: RebalanceRevokeMode
   ) extends ConsumerSettings[F, K, V] {
 
     override def withCustomBlockingContext(ec: ExecutionContext): ConsumerSettings[F, K, V] =
@@ -421,6 +445,14 @@ object ConsumerSettings {
 
     override def withMaxPollInterval(maxPollInterval: FiniteDuration): ConsumerSettings[F, K, V] =
       withProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval.toMillis.toString)
+
+    // need to use Try, to avoid separate implementation for scala 2.12
+    override def sessionTimeout: FiniteDuration =
+      properties
+        .get(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG)
+        .flatMap(str => Try(str.toLong).toOption)
+        .map(_.millis)
+        .getOrElse(45000.millis)
 
     override def withSessionTimeout(sessionTimeout: FiniteDuration): ConsumerSettings[F, K, V] =
       withProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, sessionTimeout.toMillis.toString)
@@ -509,6 +541,11 @@ object ConsumerSettings {
     ): ConsumerSettings[F, K, V] =
       withProperties(credentialsStore.properties)
 
+    override def withRebalanceRevokeMode(
+      rebalanceRevokeMode: RebalanceRevokeMode
+    ): ConsumerSettings[F, K, V] =
+      copy(rebalanceRevokeMode = rebalanceRevokeMode)
+
     override def toString: String =
       s"ConsumerSettings(closeTimeout = $closeTimeout, commitTimeout = $commitTimeout, pollInterval = $pollInterval, pollTimeout = $pollTimeout, commitRecovery = $commitRecovery)"
 
@@ -542,7 +579,8 @@ object ConsumerSettings {
       pollTimeout = 50.millis,
       commitRecovery = CommitRecovery.Default,
       recordMetadata = _ => OffsetFetchResponse.NO_METADATA,
-      maxPrefetchBatches = 2
+      maxPrefetchBatches = 2,
+      rebalanceRevokeMode = RebalanceRevokeMode.Eager
     )
 
   def apply[F[_], K, V](

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -13,7 +13,7 @@ import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.FiniteDuration
 import scala.util.matching.Regex
 
-import cats.{Foldable, Functor, Reducible}
+import cats.{Applicative, Foldable, Functor, Reducible}
 import cats.data.{NonEmptySet, OptionT}
 import cats.effect.*
 import cats.effect.implicits.*
@@ -126,6 +126,7 @@ object KafkaConsumer {
 
   private def createKafkaConsumer[F[_], K, V](
     requests: QueueSink[F, Request[F, K, V]],
+    settings: ConsumerSettings[F, K, V],
     actor: KafkaConsumerActor[F, K, V],
     fiber: Fiber[F, Throwable, Unit],
     id: Int,
@@ -141,7 +142,8 @@ object KafkaConsumer {
         type PartitionsMapQueue = Queue[F, Option[PartitionsMap]]
 
         def partitionStream(
-          partition: TopicPartition
+          partition: TopicPartition,
+          signalCompletion: F[Unit]
         ): Stream[F, CommittableConsumerRecord[F, K, V]] =
           Stream.force {
             actor
@@ -155,24 +157,25 @@ object KafkaConsumer {
                     .void
                     .attempt
 
-                Stream.fromQueueUnterminated(chunksQueue, 1).unchunks.interruptWhen(stopStream)
+                Stream
+                  .fromQueueUnterminated(chunksQueue, 1)
+                  .unchunks
+                  .interruptWhen(stopStream)
+                  .onFinalize(signalCompletion)
               }
           }
 
         def enqueueAssignment(
-          assigned: Set[TopicPartition],
+          assigned: Map[TopicPartition, AssignmentSignals[F]],
           partitionsMapQueue: PartitionsMapQueue
         ): F[Unit] =
           stopConsumingDeferred
             .tryGet
             .flatMap {
               case None =>
-                val assignment: PartitionsMap = assigned
-                  .view
-                  .map { partition =>
-                    partition -> partitionStream(partition)
-                  }
-                  .toMap
+                val assignment: PartitionsMap = assigned.map { case (partition, signals) =>
+                  partition -> partitionStream(partition, signals.signalStreamFinished.void)
+                }
 
                 partitionsMapQueue.offer(Some(assignment))
 
@@ -180,29 +183,65 @@ object KafkaConsumer {
                 F.unit
             }
 
-        def onRebalance(partitionsMapQueue: PartitionsMapQueue): OnRebalance[F] =
+        def onRebalance(
+          assignmentRef: Ref[F, Map[TopicPartition, AssignmentSignals[F]]],
+          partitionsMapQueue: PartitionsMapQueue
+        ): OnRebalance[F] =
           OnRebalance(
-            onRevoked = _ => F.unit,
-            onAssigned = assigned => enqueueAssignment(assigned, partitionsMapQueue)
+            onRevoked = revoked =>
+              for {
+                assignment <- assignmentRef.get
+                _          <- revoked.toVector.flatMap(assignment.get).traverse_(_.awaitStreamFinishedSignal)
+              } yield (),
+            onAssigned = assigned =>
+              for {
+                assignment <- buildAssignment(assigned)
+                _          <- assignmentRef.update(_ ++ assignment)
+                _          <- enqueueAssignment(assignment, partitionsMapQueue)
+              } yield ()
           )
 
-        def requestAssignment(partitionsMapQueue: PartitionsMapQueue): F[Set[TopicPartition]] = {
+        def buildAssignment(
+          assignedPartitions: SortedSet[TopicPartition]
+        ): F[Map[TopicPartition, AssignmentSignals[F]]] = {
+          assignedPartitions
+            .toVector
+            .traverse { partition =>
+              settings.rebalanceRevokeMode match {
+                case RebalanceRevokeMode.EagerMode =>
+                  (partition -> AssignmentSignals.eager[F]).pure[F]
+                case RebalanceRevokeMode.GracefulMode =>
+                  Deferred[F, Unit].map(revokeFinisher =>
+                    partition -> AssignmentSignals.graceful(revokeFinisher)
+                  )
+              }
+            }
+            .map(_.toMap)
+        }
+
+        def requestAssignment(
+          assignmentRef: Ref[F, Map[TopicPartition, AssignmentSignals[F]]],
+          partitionsMapQueue: PartitionsMapQueue
+        ): F[Map[TopicPartition, AssignmentSignals[F]]] = {
           val assignment = this.assignment(
             Some(
-              onRebalance(partitionsMapQueue)
+              onRebalance(assignmentRef, partitionsMapQueue)
             )
           )
 
           F.race(awaitTermination.attempt, assignment)
             .flatMap {
-              case Left(_)         => F.pure(Set.empty)
-              case Right(assigned) => F.pure(assigned)
+              case Left(_)         => F.pure(Map.empty)
+              case Right(assigned) => buildAssignment(assigned).flatTap(assignmentRef.set)
             }
         }
 
-        def initialEnqueue(partitionsMapQueue: PartitionsMapQueue): F[Unit] =
+        def initialEnqueue(
+          assignmentRef: Ref[F, Map[TopicPartition, AssignmentSignals[F]]],
+          partitionsMapQueue: PartitionsMapQueue
+        ): F[Unit] =
           for {
-            assigned <- requestAssignment(partitionsMapQueue)
+            assigned <- requestAssignment(assignmentRef, partitionsMapQueue)
             _        <- enqueueAssignment(assigned, partitionsMapQueue)
           } yield ()
 
@@ -212,7 +251,9 @@ object KafkaConsumer {
             case None =>
               for {
                 partitionsMapQueue <- Stream.eval(Queue.unbounded[F, Option[PartitionsMap]])
-                _                  <- Stream.eval(initialEnqueue(partitionsMapQueue))
+                assignmentRef <-
+                  Stream.eval(Ref[F].of(Map.empty[TopicPartition, AssignmentSignals[F]]))
+                _ <- Stream.eval(initialEnqueue(assignmentRef, partitionsMapQueue))
                 out <- Stream
                          .fromQueueNoneTerminated(partitionsMapQueue)
                          .interruptWhen(awaitTermination.attempt)
@@ -574,6 +615,7 @@ object KafkaConsumer {
       fiber <- startBackgroundConsumer(requests, polls, actor, settings.pollInterval)
     } yield createKafkaConsumer(
       requests,
+      settings,
       actor,
       fiber,
       id,
@@ -692,6 +734,47 @@ object KafkaConsumer {
     def consumeChunk(processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow])(implicit
       F: Concurrent[F]
     ): F[Nothing] = self.evalMap(_.consumeChunk(processor)).compile.onlyOrError
+
+  }
+
+  /**
+    * Utility class to provide clarity for internals. Goal is to make [[RebalanceRevokeMode]]
+    * transparent to the rest of implementation internals.
+    * @tparam F
+    *   effect used
+    */
+  sealed abstract private class AssignmentSignals[F[_]] {
+
+    def signalStreamFinished: F[Boolean]
+    def awaitStreamFinishedSignal: F[Unit]
+
+  }
+
+  private object AssignmentSignals {
+
+    def eager[F[_]: Applicative]: AssignmentSignals[F] =
+      EagerSignals()
+
+    def graceful[F[_]](
+      revokeFinisher: Deferred[F, Unit]
+    ): AssignmentSignals[F] =
+      GracefulSignals[F](revokeFinisher)
+
+    final private case class EagerSignals[F[_]: Applicative]() extends AssignmentSignals[F] {
+
+      override def signalStreamFinished: F[Boolean]   = true.pure[F]
+      override def awaitStreamFinishedSignal: F[Unit] = ().pure[F]
+
+    }
+
+    final private case class GracefulSignals[F[_]](
+      revokeFinisher: Deferred[F, Unit]
+    ) extends AssignmentSignals[F] {
+
+      override def signalStreamFinished: F[Boolean]   = revokeFinisher.complete(())
+      override def awaitStreamFinishedSignal: F[Unit] = revokeFinisher.get
+
+    }
 
   }
 

--- a/modules/core/src/main/scala/fs2/kafka/RebalanceRevokeMode.scala
+++ b/modules/core/src/main/scala/fs2/kafka/RebalanceRevokeMode.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2018-2025 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package fs2.kafka
 
 /**

--- a/modules/core/src/main/scala/fs2/kafka/RebalanceRevokeMode.scala
+++ b/modules/core/src/main/scala/fs2/kafka/RebalanceRevokeMode.scala
@@ -1,0 +1,44 @@
+package fs2.kafka
+
+/**
+  * The available options for [[ConsumerSettings#rebalanceRevokeMode]].<br><br>
+  *
+  * Available options include:<br>
+  *   - [[RebalanceRevokeMode.Eager]] old behaviour, to release assigned partition as soon as
+  *     possible,<br>
+  *   - [[RebalanceRevokeMode.Graceful]] modified behavior, waiting for configured amount of time:
+  *     {{{org.apache.kafka.clients.consumer.ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG}}} It is
+  *     guaranteed by kafka protocol that after that timeout old consumer will be marked as dead.
+  *
+  * Default mode is [[RebalanceRevokeMode.Eager]] which is exactly the same as old behavior and can
+  * be preferred if rebalance need to happen as quickly as possible and having multiple consumers
+  * working on a partition for a moment is not a problem.
+  *
+  * On the other hand if you want stricter guarantees about processing and attempt to wait for
+  * existing streams to finish processing messages before releasing partition choose
+  * [[RebalanceRevokeMode.Graceful]]. Because stream is signalled to be shutdown in-flight commits
+  * might be lost and some messages might be processed again after new assignment.
+  */
+sealed abstract class RebalanceRevokeMode
+
+object RebalanceRevokeMode {
+
+  private[kafka] case object EagerMode extends RebalanceRevokeMode
+
+  private[kafka] case object GracefulMode extends RebalanceRevokeMode
+
+  /**
+    * Old behavior releasing partition as soon as all streams have messages dispatched and signalled
+    * termination
+    */
+  val Eager: RebalanceRevokeMode = EagerMode
+
+  /**
+    * Waiting for configured amount of time:<br>
+    * {{{org.apache.kafka.clients.consumer.ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG}}} or until all
+    * the partition streams finish processing (but not waiting for commits to conclude for that
+    * partition)
+    */
+  val Graceful: RebalanceRevokeMode = GracefulMode
+
+}

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -10,6 +10,7 @@ import java.time.Duration
 import java.util
 
 import scala.collection.immutable.SortedSet
+import scala.concurrent.duration.FiniteDuration
 
 import cats.data.Chain
 import cats.effect.*
@@ -129,7 +130,7 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
     ref.flatModify(_.withAssignedPartitions(assigned)).flatten
 
   private[this] def revoked(revoked: SortedSet[TopicPartition]): F[Unit] =
-    ref.flatModify(_.withRevokedPartitions(revoked)).flatten
+    ref.flatModify(_.withRevokedPartitions(settings.sessionTimeout, revoked)).flatten
 
   def offsetCommitAsync(offsets: Map[TopicPartition, OffsetAndMetadata]): F[Unit] =
     runCommitAsync(offsets)(cb => requests.offer(Request.Commit(offsets, cb)))
@@ -405,6 +406,7 @@ private[kafka] object KafkaConsumerActor {
       * callbacks.
       */
     def withRevokedPartitions(
+      sessionTimeout: FiniteDuration,
       revoked: SortedSet[TopicPartition]
     )(implicit logging: Logging[F]): (State[F, K, V], F[F[Unit]]) = {
       val (revokedToClose, stillAssigned) = partitionState.partition(e => revoked.contains(e._1))
@@ -416,7 +418,9 @@ private[kafka] object KafkaConsumerActor {
         for {
           _ <- logging.log(RevokedPartitions(revoked, revokedToClose, newState))
           _ <- revokedToClose.values.toList.traverse_(_.close)
-        } yield onRebalances.traverse_(_.onRevoked(revoked))
+        } yield onRebalances
+          .traverse_(_.onRevoked(revoked))
+          .timeoutTo(sessionTimeout, logging.log(LogEntry.RevokeTimeoutOccurred(revoked, newState)))
       )
     }
 

--- a/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
@@ -149,6 +149,18 @@ private[kafka] object LogEntry {
 
   }
 
+  final case class RevokeTimeoutOccurred[F[_]](
+    revoked: Set[TopicPartition],
+    state: State[F, ?, ?]
+  ) extends LogEntry {
+
+    override def level: LogLevel = Info
+
+    override def message: String =
+      s"Consuming streams did not signal processing completion of [$revoked]. Current state [$state]."
+
+  }
+
   def recordsString[F[_]](
     records: Map[TopicPartition, Chunk[CommittableConsumerRecord[F, ?, ?]]]
   ): String =

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -16,7 +16,7 @@ import cats.syntax.all.*
 import fs2.concurrent.SignallingRef
 import fs2.kafka.consumer.KafkaConsumeChunk.CommitNow
 import fs2.kafka.internal.converters.collection.*
-import fs2.{Chunk, Stream}
+import fs2.Stream
 import org.apache.kafka.clients.consumer.{ConsumerConfig, CooperativeStickyAssignor, NoOffsetForPartitionException}
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.TopicPartition

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -8,23 +8,16 @@ package fs2.kafka
 
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.*
-
 import cats.data.NonEmptySet
-import cats.effect.{Fiber, IO}
-import cats.effect.std.Queue
+import cats.effect.{Fiber, IO, Ref}
+import cats.effect.std.{Queue, Semaphore}
 import cats.effect.unsafe.implicits.global
-import cats.effect.Ref
 import cats.syntax.all.*
 import fs2.concurrent.SignallingRef
 import fs2.kafka.consumer.KafkaConsumeChunk.CommitNow
 import fs2.kafka.internal.converters.collection.*
-import fs2.Stream
-
-import org.apache.kafka.clients.consumer.{
-  ConsumerConfig,
-  CooperativeStickyAssignor,
-  NoOffsetForPartitionException
-}
+import fs2.{Chunk, Stream}
+import org.apache.kafka.clients.consumer.{ConsumerConfig, CooperativeStickyAssignor, NoOffsetForPartitionException}
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.TopicPartition
 import org.scalatest.Assertion
@@ -74,7 +67,13 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
       }
     }
 
-    it("should consume all records at least once with subscribing for several consumers") {
+    def testMultipleConsumersCorrectConsumption(
+      customizeSettings: ConsumerSettings[IO, String, String] => ConsumerSettings[
+        IO,
+        String,
+        String
+      ]
+    ) = {
       withTopic { topic =>
         createCustomTopic(topic, partitions = 3)
         val produced = (0 until 5).map(n => s"key-$n" -> s"value->$n")
@@ -82,7 +81,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
 
         val consumed =
           KafkaConsumer
-            .stream(consumerSettings[IO].withGroupId("test"))
+            .stream(customizeSettings(consumerSettings[IO].withGroupId("test")))
             .subscribeTo(topic)
             .evalMap(IO.sleep(3.seconds).as(_)) // sleep a bit to trigger potential race condition with _.stream
             .records
@@ -102,6 +101,16 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
         // duplication is currently possible.
         res.distinct should contain theSameElementsAs produced
       }
+    }
+
+    it("should consume all records at least once with subscribing for several consumers") {
+      testMultipleConsumersCorrectConsumption(identity)
+    }
+
+    it("should consume all records at least once with subscribing for several consumers in graceful mode") {
+      testMultipleConsumersCorrectConsumption(
+        _.withRebalanceRevokeMode(RebalanceRevokeMode.Graceful)
+      )
     }
 
     it("should consume records with assign by partitions") {
@@ -1217,6 +1226,90 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
         }.map { case (k, v) => k -> v.offset() }.toMap
 
         actuallyCommitted shouldBe Map(topicPartition -> 5L)
+      }
+    }
+  }
+
+  describe("KafkaConsumer#stream") {
+    it("should wait for previous generation of streams to finish before starting consuming messages with RebalanceRevokeMode#Graceful") {
+      withTopic { topic =>
+        case class RecordedMessage(consumer: String, key: String, value: String)
+        createCustomTopic(topic, partitions = 2) // minimal amount of partitions for two consumers
+        def recordRange(from: Int, _until: Int) =
+          (from until _until).map(n => s"key-$n" -> s"value-$n")
+
+        def produceRange(from: Int, until: Int): IO[Unit] = IO {
+          val produced = recordRange(from, until)
+          publishToKafka(topic, produced)
+        }
+
+        val settings = consumerSettings[IO]
+          .withGroupId("rebalance-test-group")
+          .withRebalanceRevokeMode(RebalanceRevokeMode.Graceful)
+          .withAutoOffsetReset(AutoOffsetReset.EarliestOffsetReset)
+          .withSessionTimeout(7.seconds)
+
+        val consumed = for {
+          secondStreamSubscribed <- Semaphore[IO](0)
+          longOperation          <- Semaphore[IO](0)
+          processingUniqueness   <- Ref.of[IO, Map[String, Semaphore[IO]]](Map.empty)
+          semaphoreForKey = (key: String) =>
+            processingUniqueness
+              .modify { map =>
+                map.get(key) match {
+                  case Some(sem) => (map, sem)
+                  case None =>
+                    val sem = Semaphore[IO](1).unsafeRunSync()
+                    (map.updated(key, sem), sem)
+                }
+              }
+          _                      <- produceRange(0, 10)
+          concurrentProcessingDetected <-
+            KafkaConsumer
+              .stream(settings)
+              .evalTap(_.subscribeTo(topic))
+              .flatMap(
+                _.stream
+                  .evalMap { r =>
+                    semaphoreForKey(r.record.key).flatMap(_.permit.use {_ =>
+                      if (r.record.key == "key-4") {
+                        secondStreamSubscribed.release *> longOperation.acquire *> r.offset.commit.as(
+                          RecordedMessage("1", r.record.key, r.record.value)
+                        )
+                      } else {
+                        r.offset.commit
+                      }
+                    })
+                  }
+                  .interruptAfter(5.seconds)
+              )
+              .compile
+              .drain
+              .both {
+                KafkaConsumer
+                  .stream(settings)
+                  .evalTap(_ => secondStreamSubscribed.acquire)
+                  .evalTap(_.subscribeTo(topic))
+                  .evalTap(_ => longOperation.release)
+                  .flatMap(c =>
+                    // infinite stream
+                    c.stream
+                      .evalMap { record =>
+                        semaphoreForKey(record.record.key).flatMap(_.tryAcquire)
+                      }
+                      .collectFirst { case false => true }
+                  )
+                  .compile
+                  .lastOrError
+                  .timeoutTo(5.seconds, IO.pure(false))
+              }
+              .map(_._2)
+        } yield concurrentProcessingDetected
+
+        val concurrentProcessingDetected = consumed.unsafeRunSync()
+
+        // no single key should be processed concurrently
+        concurrentProcessingDetected shouldBe false
       }
     }
   }

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -8,6 +8,7 @@ package fs2.kafka
 
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.*
+
 import cats.data.NonEmptySet
 import cats.effect.{Fiber, IO, Ref}
 import cats.effect.std.{Queue, Semaphore}
@@ -17,7 +18,12 @@ import fs2.concurrent.SignallingRef
 import fs2.kafka.consumer.KafkaConsumeChunk.CommitNow
 import fs2.kafka.internal.converters.collection.*
 import fs2.Stream
-import org.apache.kafka.clients.consumer.{ConsumerConfig, CooperativeStickyAssignor, NoOffsetForPartitionException}
+
+import org.apache.kafka.clients.consumer.{
+  ConsumerConfig,
+  CooperativeStickyAssignor,
+  NoOffsetForPartitionException
+}
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.TopicPartition
 import org.scalatest.Assertion
@@ -1254,16 +1260,15 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
           longOperation          <- Semaphore[IO](0)
           processingUniqueness   <- Ref.of[IO, Map[String, Semaphore[IO]]](Map.empty)
           semaphoreForKey = (key: String) =>
-            processingUniqueness
-              .modify { map =>
-                map.get(key) match {
-                  case Some(sem) => (map, sem)
-                  case None =>
-                    val sem = Semaphore[IO](1).unsafeRunSync()
-                    (map.updated(key, sem), sem)
-                }
-              }
-          _                      <- produceRange(0, 10)
+                              processingUniqueness.modify { map =>
+                                map.get(key) match {
+                                  case Some(sem) => (map, sem)
+                                  case None =>
+                                    val sem = Semaphore[IO](1).unsafeRunSync()
+                                    (map.updated(key, sem), sem)
+                                }
+                              }
+          _ <- produceRange(0, 10)
           concurrentProcessingDetected <-
             KafkaConsumer
               .stream(settings)
@@ -1271,15 +1276,21 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
               .flatMap(
                 _.stream
                   .evalMap { r =>
-                    semaphoreForKey(r.record.key).flatMap(_.permit.use {_ =>
-                      if (r.record.key == "key-4") {
-                        secondStreamSubscribed.release *> longOperation.acquire *> r.offset.commit.as(
-                          RecordedMessage("1", r.record.key, r.record.value)
-                        )
-                      } else {
-                        r.offset.commit
-                      }
-                    })
+                    semaphoreForKey(r.record.key).flatMap(
+                      _.permit
+                        .use { _ =>
+                          if (r.record.key == "key-4") {
+                            secondStreamSubscribed.release *> longOperation.acquire *> r
+                              .offset
+                              .commit
+                              .as(
+                                RecordedMessage("1", r.record.key, r.record.value)
+                              )
+                          } else {
+                            r.offset.commit
+                          }
+                        }
+                    )
                   }
                   .interruptAfter(5.seconds)
               )


### PR DESCRIPTION
This is potential solution for https://github.com/fd4s/fs2-kafka/issues/1200. Allowing for opting-in for graceful revoke handling (waiting for all the streams to finish, which should imply all the commits as well)