### PR TITLE
removed `retries` value override

### DIFF
--- a/docs/src/main/mdoc/producers.md
+++ b/docs/src/main/mdoc/producers.md
@@ -127,10 +127,6 @@ ProducerSettings(
 
 ### Default Settings
 
-The following Java Kafka producer properties are overridden by default.
-
-- `max.retries` is set to `0`, to avoid the risk of records being produced out-of-order. If we don't need to produce records in-order, then this can be set to some positive integer value. An alternative is to enable retries and use `withMaxInFlightRequestsPerConnection(1)` or `withEnableIdempotence(true)`. The blog post [Does Kafka really guarantee the order of messages?](https://blog.softwaremill.com/does-kafka-really-guarantee-the-order-of-messages-3ca849fd19d2) provides more detail on this topic.
-
 The following settings are specific to the library.
 
 - `withCloseTimeout` controls the timeout when waiting for producer shutdown. Default is 60 seconds.

--- a/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -332,9 +332,7 @@ object ProducerSettings {
       keySerializer = keySerializer,
       valueSerializer = valueSerializer,
       customBlockingContext = None,
-      properties = Map(
-        ProducerConfig.RETRIES_CONFIG -> "0"
-      ),
+      properties = Map.empty,
       closeTimeout = 60.seconds,
       failFastProduce = false
     )


### PR DESCRIPTION
This was introduced due to the default behavior of Kafka prior to version 3.0. However, it now causes more harm than good by preventing fail-safe behavior during rebalancing, as `NotLeaderOrFollowerException` is not retried.

Since Kafka 3.0, the default is `enable.idempotence=true`, which ensures safe behavior according to both the SoftwareMill blog (mentioned in producers.md) and the [Kafka docs](https://kafka.apache.org/documentation/#producerconfigs_retries).

> Allowing retries while setting enable.idempotence to false and max.in.flight.requests.per.connection to greater than 1 will potentially change the ordering of records because if two batches are sent to a single partition, and the first fails and is retried but the second succeeds, then the records in the second batch may appear first.
