### PR TITLE
Feat/expose underlying kafka methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -314,11 +314,7 @@ def minorVersion(version: String): String = {
 }
 
 val latestVersion = settingKey[String]("Latest stable released version")
-ThisBuild / latestVersion := tlLatestVersion
-  .value
-  .getOrElse(
-    throw new IllegalStateException("No tagged version found")
-  )
+ThisBuild / latestVersion := "3.0.1"
 
 val updateSiteVariables = taskKey[Unit]("Update site variables")
 ThisBuild / updateSiteVariables := {

--- a/build.sbt
+++ b/build.sbt
@@ -314,7 +314,11 @@ def minorVersion(version: String): String = {
 }
 
 val latestVersion = settingKey[String]("Latest stable released version")
-ThisBuild / latestVersion := "3.0.1"
+ThisBuild / latestVersion := tlLatestVersion
+  .value
+  .getOrElse(
+    throw new IllegalStateException("No tagged version found")
+  )
 
 val updateSiteVariables = taskKey[Unit]("Update site variables")
 ThisBuild / updateSiteVariables := {

--- a/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
@@ -7,12 +7,10 @@
 package fs2.kafka
 
 import java.util
-import java.util.{Optional, UUID}
 
 import scala.annotation.nowarn
-import scala.collection.mutable
 
-import cats.{Applicative, Foldable, Functor}
+import cats.{Foldable, Functor}
 import cats.data.NonEmptySet
 import cats.effect.*
 import cats.syntax.all.*
@@ -42,9 +40,6 @@ import org.apache.kafka.common.{
 }
 import org.apache.kafka.common.acl.{AclBinding, AclBindingFilter}
 import org.apache.kafka.common.config.ConfigResource
-import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity
-import org.apache.kafka.common.message.ListClientMetricsResourcesResponseData.ClientMetricsResource
-import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, ClientQuotaFilter}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.security.token.delegation.DelegationToken
@@ -313,7 +308,7 @@ sealed abstract class KafkaAdminClient[F[_]] {
     groupId: String,
     members: NonEmptySet[MemberToRemove],
     reason: Option[String]
-  ): F[Map[MemberIdentity, Errors]]
+  ): F[Unit]
 
   /**
     * List offset for the specified partitions and isolation level.
@@ -377,12 +372,12 @@ sealed abstract class KafkaAdminClient[F[_]] {
   /**
     * Forcefully abort a transaction which is open on a topic partition.
     */
-  def abortTransaction[G[_]: Foldable](
+  def abortTransaction(
     topicPartition: TopicPartition,
     producerId: Long,
     producerEpoch: Short,
     coordinationEpoch: Int
-  ): F[Map[String, TransactionDescription]]
+  ): F[Unit]
 
   /**
     * List active transactions in the cluster.
@@ -452,22 +447,22 @@ object KafkaAdminClient {
     brokers: G[Int]
   ): F[Map[Int, Map[String, LogDirDescription]]] =
     withAdminClient(_.describeLogDirs(brokers.map(Integer.valueOf).asJava).allDescriptions()).map(
-      _.asScala.view.mapValues(_.asScala).toMap
+      _.asScala.view.map { case (k, v) => k.toInt -> v.asScala.toMap }.toMap
     )
 
   def describeReplicaLogDirsWith[F[_]: Functor, G[_]: Foldable](
     withAdminClient: WithAdminClient[F],
     replicas: G[TopicPartitionReplica]
   ): F[Map[TopicPartitionReplica, ReplicaLogDirInfo]] =
-    withAdminClient(_.describeReplicaLogDirs(replicas.asJava).all).map(_.asScala)
+    withAdminClient(_.describeReplicaLogDirs(replicas.asJava).all).map(_.asScala.toMap)
 
-  def deleteRecordsWith[F[_]](
+  def deleteRecordsWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F],
     recordsToDelete: Map[TopicPartition, RecordsToDelete]
   ): F[Unit] =
-    withAdminClient(_.deleteRecords(recordsToDelete.asJava).all)
+    withAdminClient(_.deleteRecords(recordsToDelete.asJava).all).void
 
-  def expireDelegationTokenWith[F[_]](
+  def expireDelegationTokenWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F],
     hmac: Array[Byte],
     options: Option[Long]
@@ -475,17 +470,17 @@ object KafkaAdminClient {
     val opt = options.foldLeft(new ExpireDelegationTokenOptions())((opt, expiry) =>
       opt.expiryTimePeriodMs(expiry)
     )
-    withAdminClient(_.expireDelegationToken(hmac, opt).expiryTimestamp())
+    withAdminClient(_.expireDelegationToken(hmac, opt).expiryTimestamp()).map(_.toLong)
   }
 
-  def renewDelegationTokenWith[F[_]](
+  def renewDelegationTokenWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F],
     hmac: Array[Byte],
     renewTimePeriodMs: Option[Long]
   ): F[Long] = {
     val options = new RenewDelegationTokenOptions()
     renewTimePeriodMs.foreach(options.renewTimePeriodMs)
-    withAdminClient(_.renewDelegationToken(hmac, options).expiryTimestamp())
+    withAdminClient(_.renewDelegationToken(hmac, options).expiryTimestamp()).map(_.toLong)
   }
 
   def describeDelegationTokenWith[F[_]: Functor, G[_]: Foldable](
@@ -494,7 +489,7 @@ object KafkaAdminClient {
   ): F[List[DelegationToken]] = {
     val options = new DescribeDelegationTokenOptions()
     owners.map(_.asJava).foreach(options.owners)
-    withAdminClient(_.describeDelegationToken(options).delegationTokens()).map(_.asScala)
+    withAdminClient(_.describeDelegationToken(options).delegationTokens()).map(_.asScala.toList)
   }
 
   def electLeadersWith[F[_]: Functor](
@@ -502,7 +497,7 @@ object KafkaAdminClient {
     electionType: ElectionType,
     partitions: Set[TopicPartition]
   ): F[Unit] =
-    withAdminClient(_.electLeaders(electionType, partitions.asJava).all)
+    withAdminClient(_.electLeaders(electionType, partitions.asJava).all).void
 
   def alterPartitionReassignmentsWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F],
@@ -522,17 +517,17 @@ object KafkaAdminClient {
           client.listPartitionReassignments(partitions.asJava)
         )
         .reassignments()
-    }.map(_.asScala)
+    }.map(_.asScala.toMap)
 
   def removeMembersFromConsumerGroupWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F],
     groupId: String,
     members: NonEmptySet[MemberToRemove],
     reason: Option[String]
-  ): F[Map[MemberIdentity, Errors]] = {
+  ): F[Unit] = {
     val options = new RemoveMembersFromConsumerGroupOptions(members.toSortedSet.asJava)
     reason.foreach(options.reason)
-    withAdminClient(_.removeMembersFromConsumerGroup(groupId, options).all)
+    withAdminClient(_.removeMembersFromConsumerGroup(groupId, options).all).void
   }
 
   def listOffsetsWith[F[_]: Functor](
@@ -541,14 +536,23 @@ object KafkaAdminClient {
     isolationLevel: org.apache.kafka.common.IsolationLevel
   ): F[Map[TopicPartition, ListOffsetsResultInfo]] = {
     val opts = new ListOffsetsOptions(isolationLevel)
-    withAdminClient(_.listOffsets(topicPartitionOffsets.asJava, opts).all)
+    withAdminClient(_.listOffsets(topicPartitionOffsets.asJava, opts).all).map(_.asScala.toMap)
   }
 
   def describeClientQuotasWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F],
     filter: ClientQuotaFilter
   ): F[Map[ClientQuotaEntity, Map[String, Double]]] =
-    withAdminClient(_.describeClientQuotas(filter).entities()).map(_.asScala)
+    withAdminClient(_.describeClientQuotas(filter).entities()).map { entities =>
+      Map.from(
+        entities
+          .asScala
+          .view
+          .map { case (k, v) =>
+            k -> Map.from(v.asScala.view.map { case (qk, qv) => qk -> qv.doubleValue })
+          }
+      )
+    }
 
   def alterClientQuotasWith[F[_]: Functor, G[_]: Foldable](
     withAdminClient: WithAdminClient[F],
@@ -561,7 +565,9 @@ object KafkaAdminClient {
     users: Option[List[String]]
   ): F[Map[String, UserScramCredentialsDescription]] =
     // underlying api uses null to distinguish between no user filter and an empty user filter
-    withAdminClient(_.describeUserScramCredentials(users.map(_.asJava).orNull).all)
+    withAdminClient(_.describeUserScramCredentials(users.map(_.asJava).orNull).all).map(
+      _.asScala.toMap
+    )
 
   def describeFeaturesWith[F[_]: Functor](withAdminClient: WithAdminClient[F]): F[FeatureMetadata] =
     withAdminClient(_.describeFeatures().featureMetadata())
@@ -572,7 +578,7 @@ object KafkaAdminClient {
     validateOnly: Boolean
   ): F[Unit] = {
     val opts = new UpdateFeaturesOptions().validateOnly(validateOnly)
-    withAdminClient(_.updateFeatures(features.asJava, opts).all)
+    withAdminClient(_.updateFeatures(features.asJava, opts).all).void
   }
 
   def describeMetadataQuorumWith[F[_]: Functor](
@@ -586,25 +592,25 @@ object KafkaAdminClient {
     brokerId: Option[Int]
   ): F[Map[TopicPartition, PartitionProducerState]] = {
     val opts = brokerId.foldLeft(new DescribeProducersOptions())((opt, id) => opt.brokerId(id))
-    withAdminClient(_.describeProducers(partitions.asJava, opts).all).map(_.asScala)
+    withAdminClient(_.describeProducers(partitions.asJava, opts).all).map(_.asScala.toMap)
   }
 
   def describeTransactionsWith[F[_]: Functor, G[_]: Foldable](
     withAdminClient: WithAdminClient[F],
     transactionalIds: G[String]
   ): F[Map[String, TransactionDescription]] =
-    withAdminClient(_.describeTransactions(transactionalIds.asJava).all)
+    withAdminClient(_.describeTransactions(transactionalIds.asJava).all).map(_.asScala.toMap)
 
-  def abortTransactionWith[F[_]: Functor, G[_]: Foldable](
+  def abortTransactionWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F],
     topicPartition: TopicPartition,
     producerId: Long,
     producerEpoch: Short,
     coordinationEpoch: Int
-  ): F[Map[String, TransactionDescription]] = {
+  ): F[Unit] = {
     val spec =
       new AbortTransactionSpec(topicPartition, producerId, producerEpoch, coordinationEpoch)
-    withAdminClient(_.abortTransaction(spec).all)
+    withAdminClient(_.abortTransaction(spec).all).void
   }
 
   def listTransactionsWith[F[_]: Functor](
@@ -613,23 +619,25 @@ object KafkaAdminClient {
     producerIds: Option[Set[Long]],
     duration: Option[Long]
   ): F[List[TransactionListing]] = {
-    val options   = new ListTransactionsOptions()
-    val wState    = states.map(_.asJava).fold(options)(options.filterStates)
-    val wProd     = producerIds.map(_.asJava).fold(wState)(wState.filterProducerIds)
+    val options = new ListTransactionsOptions()
+    val wState  = states.map(_.asJava).fold(options)(options.filterStates)
+    val wProd   = producerIds
+      .map(_.map(java.lang.Long.valueOf).asJava)
+      .fold(wState)(wState.filterProducerIds)
     val wDuration = duration.fold(wProd)(wProd.filterOnDuration)
-    withAdminClient(_.listTransactions(wDuration).all)
+    withAdminClient(_.listTransactions(wDuration).all).map(_.asScala.toList)
   }
 
   def fenceProducersWith[F[_]: Functor, G[_]: Foldable](
     withAdminClient: WithAdminClient[F],
     transactionalIds: G[String]
   ): F[Unit] =
-    withAdminClient(_.fenceProducers(transactionalIds.asJava).all)
+    withAdminClient(_.fenceProducers(transactionalIds.asJava).all).map(_ => ())
 
   def listClientMetricsResourcesWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F]
   ): F[List[ClientMetricsResourceListing]] =
-    withAdminClient(_.listClientMetricsResources().all)
+    withAdminClient(_.listClientMetricsResources().all).map(_.asScala.toList)
 
   def addRaftVoterWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F],
@@ -662,12 +670,14 @@ object KafkaAdminClient {
           new RemoveRaftVoterOptions().setClusterId(clusterId.toJava)
         )
         .all
-    )
+    ).map(_ => ())
 
-  def metricsWith[F[_]](
+  def metricsWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F]
   ): F[Map[MetricName, Metric]] =
-    withAdminClient(client => KafkaFuture.completedFuture(client.metrics()))
+    withAdminClient { client =>
+      KafkaFuture.completedFuture[Map[MetricName, Metric]](client.metrics().asScala.toMap)
+    }
 
   private[this] def alterConfigsWith[F[_]: Functor, G[_]: Foldable](
     withAdminClient: WithAdminClient[F],
@@ -1193,7 +1203,7 @@ object KafkaAdminClient {
         groupId: String,
         members: NonEmptySet[MemberToRemove],
         reason: Option[String]
-      ): F[Map[MemberIdentity, Errors]] =
+      ): F[Unit] =
         removeMembersFromConsumerGroupWith(client, groupId, members, reason)
 
       /**
@@ -1269,12 +1279,12 @@ object KafkaAdminClient {
       /**
         * Forcefully abort a transaction which is open on a topic partition.
         */
-      override def abortTransaction[G[_]: Foldable](
+      override def abortTransaction(
         topicPartition: TopicPartition,
         producerId: Long,
         producerEpoch: Short,
         coordinationEpoch: Int
-      ): F[Map[String, TransactionDescription]] =
+      ): F[Unit] =
         abortTransactionWith(client, topicPartition, producerId, producerEpoch, coordinationEpoch)
 
       /**

--- a/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
@@ -6,23 +6,48 @@
 
 package fs2.kafka
 
-import scala.annotation.nowarn
+import java.util
+import java.util.{Optional, UUID}
 
-import cats.{Foldable, Functor}
+import scala.annotation.nowarn
+import scala.collection.mutable
+
+import cats.{Applicative, Foldable, Functor}
+import cats.data.NonEmptySet
 import cats.effect.*
 import cats.syntax.all.*
 import fs2.kafka.admin.MkAdminClient
 import fs2.kafka.internal.converters.collection.*
+import fs2.kafka.internal.converters.option.*
 import fs2.kafka.internal.syntax.*
 import fs2.kafka.internal.WithAdminClient
 import fs2.kafka.KafkaAdminClient.*
 import fs2.Stream
 
 import org.apache.kafka.clients.admin.*
+import org.apache.kafka.clients.admin.DescribeProducersResult.PartitionProducerState
+import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult.ReplicaLogDirInfo
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
-import org.apache.kafka.common.{Node, TopicPartition}
+import org.apache.kafka.common
+import org.apache.kafka.common.{
+  ElectionType,
+  KafkaFuture,
+  Metric,
+  MetricName,
+  Node,
+  TopicPartition,
+  TopicPartitionReplica,
+  Uuid
+}
 import org.apache.kafka.common.acl.{AclBinding, AclBindingFilter}
 import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity
+import org.apache.kafka.common.message.ListClientMetricsResourcesResponseData.ClientMetricsResource
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, ClientQuotaFilter}
+import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.apache.kafka.common.security.token.delegation.DelegationToken
 
 /**
   * [[KafkaAdminClient]] represents an admin client for Kafka, which is able to describe queries
@@ -213,9 +238,436 @@ sealed abstract class KafkaAdminClient[F[_]] {
     */
   def deleteConsumerGroupOffsets(groupId: String, partitions: Set[TopicPartition]): F[Unit]
 
+  /**
+    * Incrementally update the configuration for the specified resources
+    */
+  def alterConfigs[G[_]: Foldable](
+    configs: Map[ConfigResource, G[AlterConfigOp]],
+    validateOnly: Boolean
+  ): F[Unit]
+
+  /**
+    * Change the log directory for the specified replicas.
+    */
+  def alterReplicaLogDirs(replicaAssignment: Map[TopicPartitionReplica, String]): F[Unit]
+
+  /**
+    * Query the information of all log directories on the given set of brokers.
+    */
+  def describeLogDirs[G[_]: Foldable: Functor](
+    brokers: G[Int]
+  ): F[Map[Int, Map[String, LogDirDescription]]]
+
+  /**
+    * Query the replica log directory information for the specified replicas.
+    */
+  def describeReplicaLogDirs[G[_]: Foldable](
+    replicas: G[TopicPartitionReplica]
+  ): F[Map[TopicPartitionReplica, ReplicaLogDirInfo]]
+
+  /**
+    * Delete records whose offset is smaller than the given offset of the corresponding partition.
+    */
+  def deleteRecords(recordsToDelete: Map[TopicPartition, RecordsToDelete]): F[Unit]
+
+  /**
+    * Expire a Delegation Token.
+    */
+  def expireDelegationToken(hmac: Array[Byte], expiryTimePeriodMs: Option[Long]): F[Long]
+
+  /**
+    * Renew a Delegation Token. Returns the expiryTimestamp.
+    */
+  def renewDelegationToken(hmac: Array[Byte], renewTimePeriodMs: Option[Long]): F[Long]
+
+  /**
+    * Describe the Delegation Tokens.
+    */
+  def describeDelegationToken[G[_]: Foldable](
+    owners: Option[List[KafkaPrincipal]]
+  ): F[List[DelegationToken]]
+
+  /**
+    * Elect a replica as leader for topic partitions.
+    */
+  def electLeaders(electionType: ElectionType, partitions: Set[TopicPartition]): F[Unit]
+
+  /**
+    * Change the reassignments for one or more partitions.
+    */
+  def alterPartitionReassignments(
+    reassignments: Map[TopicPartition, Option[NewPartitionReassignment]]
+  ): F[Unit]
+
+  /**
+    * List the current reassignments for the given partitions.
+    */
+  def listPartitionReassignments(
+    partitionsFilter: Option[Set[TopicPartition]]
+  ): F[Map[TopicPartition, PartitionReassignment]]
+
+  /**
+    * Remove members from the consumer group by given member identities.
+    */
+  def removeMembersFromConsumerGroup(
+    groupId: String,
+    members: NonEmptySet[MemberToRemove],
+    reason: Option[String]
+  ): F[Map[MemberIdentity, Errors]]
+
+  /**
+    * List offset for the specified partitions and isolation level.
+    */
+  def listOffsets(
+    topicPartitionOffsets: Map[TopicPartition, OffsetSpec],
+    isolationLevel: org.apache.kafka.common.IsolationLevel
+  ): F[Map[TopicPartition, ListOffsetsResultInfo]]
+
+  /**
+    * Describes all entities matching the provided filter that have at least one client quota
+    * configuration value defined.
+    */
+  def describeClientQuotas(
+    filter: ClientQuotaFilter
+  ): F[Map[ClientQuotaEntity, Map[String, Double]]]
+
+  /**
+    * Alters client quota configurations with the specified alterations.
+    */
+  def alterClientQuotas[G[_]: Foldable](entries: G[ClientQuotaAlteration]): F[Unit]
+
+  /**
+    * Describe all SASL/SCRAM credentials.
+    */
+  def describeUserScramCredentials(
+    users: Option[List[String]] = None
+  ): F[Map[String, UserScramCredentialsDescription]]
+
+  /**
+    * Describes finalized as well as supported features.
+    */
+  def describeFeatures(): F[FeatureMetadata]
+
+  /**
+    * Applies specified updates to finalized features.
+    */
+  def updateFeatures(features: Map[String, FeatureUpdate], validateOnly: Boolean): F[Unit]
+
+  /**
+    * Describes the state of the metadata quorum.
+    */
+  def describeMetadataQuorum(): F[QuorumInfo]
+
+  /**
+    * Describe producer state on a set of topic partitions.
+    */
+  def describeProducers[G[_]: Foldable](
+    partitions: G[TopicPartition],
+    brokerId: Option[Int]
+  ): F[Map[TopicPartition, PartitionProducerState]]
+
+  /**
+    * Describe the state of a set of transactional IDs from the respective transaction coordinators,
+    * which are dynamically discovered.
+    */
+  def describeTransactions[G[_]: Foldable](
+    transactionalIds: G[String]
+  ): F[Map[String, TransactionDescription]]
+
+  /**
+    * Forcefully abort a transaction which is open on a topic partition.
+    */
+  def abortTransaction[G[_]: Foldable](
+    topicPartition: TopicPartition,
+    producerId: Long,
+    producerEpoch: Short,
+    coordinationEpoch: Int
+  ): F[Map[String, TransactionDescription]]
+
+  /**
+    * List active transactions in the cluster.
+    */
+  def listTransactions(
+    states: Option[Set[TransactionState]],
+    producerIds: Option[Set[Long]],
+    duration: Option[Long]
+  ): F[List[TransactionListing]]
+
+  /**
+    * Fence out all active producers that use any of the provided transactional IDs.
+    */
+  def fenceProducers[G[_]: Foldable](transactionalIds: G[String]): F[Unit]
+
+  /**
+    * List the client metrics configuration resources available in the cluster.
+    */
+  def listClientMetricsResources(): F[List[ClientMetricsResourceListing]]
+
+  /**
+    * Add a new voter node to the KRaft metadata quorum.
+    */
+  def addRaftVoter(
+    voterId: Int,
+    voterDirectoryId: org.apache.kafka.common.Uuid,
+    endpoints: Set[RaftVoterEndpoint],
+    clusterId: Option[String]
+  ): F[Unit]
+
+  /**
+    * Remove a voter node from the KRaft metadata quorum.
+    */
+  def removeRaftVoter(
+    voterId: Int,
+    voterDirectoryId: org.apache.kafka.common.Uuid,
+    clusterId: Option[String]
+  ): F[Unit]
+
+  /**
+    * Get the metrics kept by the adminClient
+    */
+  def metrics(): F[Map[MetricName, Metric]]
+
 }
 
 object KafkaAdminClient {
+
+  def alterConfigsWith[F[_]: Functor, G[_]: Foldable](
+    withAdminClient: WithAdminClient[F],
+    configs: Map[ConfigResource, G[AlterConfigOp]],
+    validateOnly: Boolean
+  ): F[Unit] =
+    withAdminClient { client =>
+      val options: AlterConfigsOptions = new AlterConfigsOptions().validateOnly(validateOnly)
+      client.incrementalAlterConfigs(configs.asJavaMap, options).all
+    }.void
+
+  def alterReplicaLogDirsWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    replicaAssignment: Map[TopicPartitionReplica, String]
+  ): F[Unit] =
+    withAdminClient(_.alterReplicaLogDirs(replicaAssignment.asJava).all).void
+
+  def describeLogDirsWith[F[_]: Functor, G[_]: Foldable: Functor](
+    withAdminClient: WithAdminClient[F],
+    brokers: G[Int]
+  ): F[Map[Int, Map[String, LogDirDescription]]] =
+    withAdminClient(_.describeLogDirs(brokers.map(Integer.valueOf).asJava).allDescriptions()).map(
+      _.asScala.view.mapValues(_.asScala).toMap
+    )
+
+  def describeReplicaLogDirsWith[F[_]: Functor, G[_]: Foldable](
+    withAdminClient: WithAdminClient[F],
+    replicas: G[TopicPartitionReplica]
+  ): F[Map[TopicPartitionReplica, ReplicaLogDirInfo]] =
+    withAdminClient(_.describeReplicaLogDirs(replicas.asJava).all).map(_.asScala)
+
+  def deleteRecordsWith[F[_]](
+    withAdminClient: WithAdminClient[F],
+    recordsToDelete: Map[TopicPartition, RecordsToDelete]
+  ): F[Unit] =
+    withAdminClient(_.deleteRecords(recordsToDelete.asJava).all)
+
+  def expireDelegationTokenWith[F[_]](
+    withAdminClient: WithAdminClient[F],
+    hmac: Array[Byte],
+    options: Option[Long]
+  ): F[Long] = {
+    val opt = options.foldLeft(new ExpireDelegationTokenOptions())((opt, expiry) =>
+      opt.expiryTimePeriodMs(expiry)
+    )
+    withAdminClient(_.expireDelegationToken(hmac, opt).expiryTimestamp())
+  }
+
+  def renewDelegationTokenWith[F[_]](
+    withAdminClient: WithAdminClient[F],
+    hmac: Array[Byte],
+    renewTimePeriodMs: Option[Long]
+  ): F[Long] = {
+    val options = new RenewDelegationTokenOptions()
+    renewTimePeriodMs.foreach(options.renewTimePeriodMs)
+    withAdminClient(_.renewDelegationToken(hmac, options).expiryTimestamp())
+  }
+
+  def describeDelegationTokenWith[F[_]: Functor, G[_]: Foldable](
+    withAdminClient: WithAdminClient[F],
+    owners: Option[List[KafkaPrincipal]]
+  ): F[List[DelegationToken]] = {
+    val options = new DescribeDelegationTokenOptions()
+    owners.map(_.asJava).foreach(options.owners)
+    withAdminClient(_.describeDelegationToken(options).delegationTokens()).map(_.asScala)
+  }
+
+  def electLeadersWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    electionType: ElectionType,
+    partitions: Set[TopicPartition]
+  ): F[Unit] =
+    withAdminClient(_.electLeaders(electionType, partitions.asJava).all)
+
+  def alterPartitionReassignmentsWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    reassignments: Map[TopicPartition, Option[NewPartitionReassignment]]
+  ): F[Unit] = {
+    val javaOpts = reassignments.view.mapValues(_.toJava).toMap.asJava
+    withAdminClient(_.alterPartitionReassignments(javaOpts).all).void
+  }
+
+  def listPartitionReassignmentsWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    partitions: Option[Set[TopicPartition]]
+  ): F[Map[TopicPartition, PartitionReassignment]] =
+    withAdminClient { client =>
+      partitions
+        .fold(client.listPartitionReassignments())(partitions =>
+          client.listPartitionReassignments(partitions.asJava)
+        )
+        .reassignments()
+    }.map(_.asScala)
+
+  def removeMembersFromConsumerGroupWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    groupId: String,
+    members: NonEmptySet[MemberToRemove],
+    reason: Option[String]
+  ): F[Map[MemberIdentity, Errors]] = {
+    val options = new RemoveMembersFromConsumerGroupOptions(members.toSortedSet.asJava)
+    reason.foreach(options.reason)
+    withAdminClient(_.removeMembersFromConsumerGroup(groupId, options).all)
+  }
+
+  def listOffsetsWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    topicPartitionOffsets: Map[TopicPartition, OffsetSpec],
+    isolationLevel: org.apache.kafka.common.IsolationLevel
+  ): F[Map[TopicPartition, ListOffsetsResultInfo]] = {
+    val opts = new ListOffsetsOptions(isolationLevel)
+    withAdminClient(_.listOffsets(topicPartitionOffsets.asJava, opts).all)
+  }
+
+  def describeClientQuotasWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    filter: ClientQuotaFilter
+  ): F[Map[ClientQuotaEntity, Map[String, Double]]] =
+    withAdminClient(_.describeClientQuotas(filter).entities()).map(_.asScala)
+
+  def alterClientQuotasWith[F[_]: Functor, G[_]: Foldable](
+    withAdminClient: WithAdminClient[F],
+    entries: G[ClientQuotaAlteration]
+  ): F[Unit] =
+    withAdminClient(_.alterClientQuotas(entries.asJava).all).void
+
+  def describeUserScramCredentialsWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    users: Option[List[String]]
+  ): F[Map[String, UserScramCredentialsDescription]] =
+    // underlying api uses null to distinguish between no user filter and an empty user filter
+    withAdminClient(_.describeUserScramCredentials(users.map(_.asJava).orNull).all)
+
+  def describeFeaturesWith[F[_]: Functor](withAdminClient: WithAdminClient[F]): F[FeatureMetadata] =
+    withAdminClient(_.describeFeatures().featureMetadata())
+
+  def updateFeaturesWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    features: Map[String, FeatureUpdate],
+    validateOnly: Boolean
+  ): F[Unit] = {
+    val opts = new UpdateFeaturesOptions().validateOnly(validateOnly)
+    withAdminClient(_.updateFeatures(features.asJava, opts).all)
+  }
+
+  def describeMetadataQuorumWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F]
+  ): F[QuorumInfo] =
+    withAdminClient(_.describeMetadataQuorum().quorumInfo())
+
+  def describeProducersWith[F[_]: Functor, G[_]: Foldable](
+    withAdminClient: WithAdminClient[F],
+    partitions: G[TopicPartition],
+    brokerId: Option[Int]
+  ): F[Map[TopicPartition, PartitionProducerState]] = {
+    val opts = brokerId.foldLeft(new DescribeProducersOptions())((opt, id) => opt.brokerId(id))
+    withAdminClient(_.describeProducers(partitions.asJava, opts).all).map(_.asScala)
+  }
+
+  def describeTransactionsWith[F[_]: Functor, G[_]: Foldable](
+    withAdminClient: WithAdminClient[F],
+    transactionalIds: G[String]
+  ): F[Map[String, TransactionDescription]] =
+    withAdminClient(_.describeTransactions(transactionalIds.asJava).all)
+
+  def abortTransactionWith[F[_]: Functor, G[_]: Foldable](
+    withAdminClient: WithAdminClient[F],
+    topicPartition: TopicPartition,
+    producerId: Long,
+    producerEpoch: Short,
+    coordinationEpoch: Int
+  ): F[Map[String, TransactionDescription]] = {
+    val spec =
+      new AbortTransactionSpec(topicPartition, producerId, producerEpoch, coordinationEpoch)
+    withAdminClient(_.abortTransaction(spec).all)
+  }
+
+  def listTransactionsWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    states: Option[Set[TransactionState]],
+    producerIds: Option[Set[Long]],
+    duration: Option[Long]
+  ): F[List[TransactionListing]] = {
+    val options   = new ListTransactionsOptions()
+    val wState    = states.map(_.asJava).fold(options)(options.filterStates)
+    val wProd     = producerIds.map(_.asJava).fold(wState)(wState.filterProducerIds)
+    val wDuration = duration.fold(wProd)(wProd.filterOnDuration)
+    withAdminClient(_.listTransactions(wDuration).all)
+  }
+
+  def fenceProducersWith[F[_]: Functor, G[_]: Foldable](
+    withAdminClient: WithAdminClient[F],
+    transactionalIds: G[String]
+  ): F[Unit] =
+    withAdminClient(_.fenceProducers(transactionalIds.asJava).all)
+
+  def listClientMetricsResourcesWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F]
+  ): F[List[ClientMetricsResourceListing]] =
+    withAdminClient(_.listClientMetricsResources().all)
+
+  def addRaftVoterWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    voterId: Int,
+    voterDirectoryId: org.apache.kafka.common.Uuid,
+    endpoints: Set[RaftVoterEndpoint],
+    clusterId: Option[String]
+  ): F[Unit] = {
+    withAdminClient(
+      _.addRaftVoter(
+          voterId,
+          voterDirectoryId,
+          endpoints.asJava,
+          new AddRaftVoterOptions().setClusterId(clusterId.toJava)
+        )
+        .all
+    ).void
+  }
+
+  def removeRaftVoterWith[F[_]: Functor](
+    withAdminClient: WithAdminClient[F],
+    voterId: Int,
+    voterDirectoryId: org.apache.kafka.common.Uuid,
+    clusterId: Option[String]
+  ): F[Unit] =
+    withAdminClient(
+      _.removeRaftVoter(
+          voterId,
+          voterDirectoryId,
+          new RemoveRaftVoterOptions().setClusterId(clusterId.toJava)
+        )
+        .all
+    )
+
+  def metricsWith[F[_]](
+    withAdminClient: WithAdminClient[F]
+  ): F[Map[MetricName, Metric]] =
+    withAdminClient(client => KafkaFuture.completedFuture(client.metrics()))
 
   private[this] def alterConfigsWith[F[_]: Functor, G[_]: Foldable](
     withAdminClient: WithAdminClient[F],
@@ -648,6 +1100,227 @@ object KafkaAdminClient {
       override def toString: String =
         "KafkaAdminClient$" + System.identityHashCode(this)
 
+      /**
+        * Incrementally update the configuration for the specified resources
+        */
+      override def alterConfigs[G[_]: Foldable](
+        configs: Map[ConfigResource, G[AlterConfigOp]],
+        validateOnly: Boolean
+      ): F[Unit] =
+        alterConfigsWith[F, G](client, configs, validateOnly)
+
+      /**
+        * Change the log directory for the specified replicas.
+        */
+      override def alterReplicaLogDirs(
+        replicaAssignment: Map[TopicPartitionReplica, String]
+      ): F[Unit] =
+        alterReplicaLogDirsWith[F](client, replicaAssignment)
+
+      /**
+        * Query the information of all log directories on the given set of brokers.
+        */
+      override def describeLogDirs[G[_]: Foldable: Functor](
+        brokers: G[Int]
+      ): F[Map[Int, Map[String, LogDirDescription]]] =
+        describeLogDirsWith[F, G](client, brokers)
+
+      /**
+        * Query the replica log directory information for the specified replicas.
+        */
+      override def describeReplicaLogDirs[G[_]: Foldable](
+        replicas: G[TopicPartitionReplica]
+      ): F[Map[TopicPartitionReplica, ReplicaLogDirInfo]] =
+        describeReplicaLogDirsWith[F, G](client, replicas)
+
+      /**
+        * Delete records whose offset is smaller than the given offset of the corresponding
+        * partition.
+        */
+      override def deleteRecords(recordsToDelete: Map[TopicPartition, RecordsToDelete]): F[Unit] =
+        deleteRecordsWith[F](client, recordsToDelete)
+
+      /**
+        * Expire a Delegation Token.
+        */
+      override def expireDelegationToken(
+        hmac: Array[Byte],
+        expiryTimePeriodMs: Option[Long]
+      ): F[Long] = expireDelegationTokenWith(client, hmac, expiryTimePeriodMs)
+
+      /**
+        * Renew a Delegation Token. Returns the expiryTimestamp.
+        */
+      override def renewDelegationToken(
+        hmac: Array[Byte],
+        renewTimePeriodMs: Option[Long]
+      ): F[Long] = renewDelegationTokenWith(client, hmac, renewTimePeriodMs)
+
+      /**
+        * Describe the Delegation Tokens.
+        */
+      override def describeDelegationToken[G[_]: Foldable](
+        owners: Option[List[KafkaPrincipal]]
+      ): F[List[DelegationToken]] = describeDelegationTokenWith[F, G](client, owners)
+
+      /**
+        * Elect a replica as leader for topic partitions.
+        */
+      override def electLeaders(
+        electionType: ElectionType,
+        partitions: Set[TopicPartition]
+      ): F[Unit] = electLeadersWith[F](client, electionType, partitions)
+
+      /**
+        * Change the reassignments for one or more partitions.
+        */
+      override def alterPartitionReassignments(
+        reassignments: Map[TopicPartition, Option[NewPartitionReassignment]]
+      ): F[Unit] = alterPartitionReassignmentsWith[F](client, reassignments)
+
+      /**
+        * List the current reassignments for the given partitions.
+        */
+      override def listPartitionReassignments(
+        partitionsFilter: Option[Set[TopicPartition]]
+      ): F[Map[TopicPartition, PartitionReassignment]] =
+        listPartitionReassignmentsWith(client, partitionsFilter)
+
+      /**
+        * Remove members from the consumer group by given member identities.
+        */
+      override def removeMembersFromConsumerGroup(
+        groupId: String,
+        members: NonEmptySet[MemberToRemove],
+        reason: Option[String]
+      ): F[Map[MemberIdentity, Errors]] =
+        removeMembersFromConsumerGroupWith(client, groupId, members, reason)
+
+      /**
+        * List offset for the specified partitions and isolation level.
+        */
+      override def listOffsets(
+        topicPartitionOffsets: Map[TopicPartition, OffsetSpec],
+        isolationLevel: common.IsolationLevel
+      ): F[Map[TopicPartition, ListOffsetsResultInfo]] =
+        listOffsetsWith(client, topicPartitionOffsets, isolationLevel)
+
+      /**
+        * Describes all entities matching the provided filter that have at least one client quota
+        * configuration value defined.
+        */
+      override def describeClientQuotas(
+        filter: ClientQuotaFilter
+      ): F[Map[ClientQuotaEntity, Map[String, Double]]] =
+        describeClientQuotasWith(client, filter)
+
+      /**
+        * Alters client quota configurations with the specified alterations.
+        */
+      override def alterClientQuotas[G[_]: Foldable](entries: G[ClientQuotaAlteration]): F[Unit] =
+        alterClientQuotasWith[F, G](client, entries)
+
+      /**
+        * Describe all SASL/SCRAM credentials.
+        */
+      override def describeUserScramCredentials(
+        users: Option[List[String]]
+      ): F[Map[String, UserScramCredentialsDescription]] =
+        describeUserScramCredentialsWith(client, users)
+
+      /**
+        * Describes finalized as well as supported features.
+        */
+      override def describeFeatures(): F[FeatureMetadata] =
+        describeFeaturesWith(client)
+
+      /**
+        * Applies specified updates to finalized features.
+        */
+      override def updateFeatures(
+        features: Map[String, FeatureUpdate],
+        validateOnly: Boolean
+      ): F[Unit] = updateFeaturesWith(client, features, validateOnly)
+
+      /**
+        * Describes the state of the metadata quorum.
+        */
+      override def describeMetadataQuorum(): F[QuorumInfo] =
+        describeMetadataQuorumWith(client)
+
+      /**
+        * Describe producer state on a set of topic partitions.
+        */
+      override def describeProducers[G[_]: Foldable](
+        partitions: G[TopicPartition],
+        brokerId: Option[Int]
+      ): F[Map[TopicPartition, PartitionProducerState]] =
+        describeProducersWith(client, partitions, brokerId)
+
+      /**
+        * Describe the state of a set of transactional IDs from the respective transaction
+        * coordinators, which are dynamically discovered.
+        */
+      override def describeTransactions[G[_]: Foldable](
+        transactionalIds: G[String]
+      ): F[Map[String, TransactionDescription]] =
+        describeTransactionsWith(client, transactionalIds)
+
+      /**
+        * Forcefully abort a transaction which is open on a topic partition.
+        */
+      override def abortTransaction[G[_]: Foldable](
+        topicPartition: TopicPartition,
+        producerId: Long,
+        producerEpoch: Short,
+        coordinationEpoch: Int
+      ): F[Map[String, TransactionDescription]] =
+        abortTransactionWith(client, topicPartition, producerId, producerEpoch, coordinationEpoch)
+
+      /**
+        * List active transactions in the cluster.
+        */
+      override def listTransactions(
+        states: Option[Set[TransactionState]],
+        producerIds: Option[Set[Long]],
+        duration: Option[Long]
+      ): F[List[TransactionListing]] = listTransactionsWith(client, states, producerIds, duration)
+
+      /**
+        * Fence out all active producers that use any of the provided transactional IDs.
+        */
+      override def fenceProducers[G[_]: Foldable](transactionalIds: G[String]): F[Unit] =
+        fenceProducersWith(client, transactionalIds)
+
+      /**
+        * List the client metrics configuration resources available in the cluster.
+        */
+      override def listClientMetricsResources(): F[List[ClientMetricsResourceListing]] =
+        listClientMetricsResourcesWith(client)
+
+      /**
+        * Add a new voter node to the KRaft metadata quorum.
+        */
+      override def addRaftVoter(
+        voterId: Int,
+        voterDirectoryId: Uuid,
+        endpoints: Set[RaftVoterEndpoint],
+        clusterId: Option[String]
+      ): F[Unit] = addRaftVoterWith(client, voterId, voterDirectoryId, endpoints, clusterId)
+
+      /**
+        * Remove a voter node from the KRaft metadata quorum.
+        */
+      override def removeRaftVoter(
+        voterId: Int,
+        voterDirectoryId: Uuid,
+        clusterId: Option[String]
+      ): F[Unit] = removeRaftVoterWith(client, voterId, voterDirectoryId, clusterId)
+
+      /**
+        * Get the metrics kept by the adminClient
+        */
+      override def metrics(): F[Map[MetricName, Metric]] = metricsWith(client)
     }
 
   /**

--- a/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
@@ -7,9 +7,9 @@
 package fs2.kafka
 
 import scala.annotation.nowarn
+import scala.concurrent.duration.FiniteDuration
 
 import cats.{Foldable, Functor}
-import cats.data.NonEmptySet
 import cats.effect.*
 import cats.syntax.all.*
 import fs2.kafka.admin.MkAdminClient
@@ -103,21 +103,15 @@ sealed abstract class KafkaAdminClient[F[_]] {
   /**
     * Describes the cluster. Returns nodes using:
     *
-    * {{{
-    * describeCluster.nodes
-    * }}}
+    * {{{describeCluster.nodes}}}
     *
     * or the controller node using:
     *
-    * {{{
-    * describeCluster.controller
-    * }}}
+    * {{{describeCluster.controller}}}
     *
     * or the cluster ID using the following.
     *
-    * {{{
-    * describeCluster.clusterId
-    * }}}
+    * {{{describeCluster.clusterId}}}
     */
   def describeCluster: DescribeCluster[F]
 
@@ -264,6 +258,15 @@ sealed abstract class KafkaAdminClient[F[_]] {
   def deleteRecords(recordsToDelete: Map[TopicPartition, RecordsToDelete]): F[Unit]
 
   /**
+    * Creates a delegation token
+    */
+  def createDelegationToken(
+    renewers: List[KafkaPrincipal],
+    owner: Option[KafkaPrincipal],
+    maxLifeTime: Option[FiniteDuration]
+  ): F[DelegationToken]
+
+  /**
     * Expire a Delegation Token.
     */
   def expireDelegationToken(hmac: Array[Byte], expiryTimePeriodMs: Option[Long]): F[Long]
@@ -302,9 +305,9 @@ sealed abstract class KafkaAdminClient[F[_]] {
   /**
     * Remove members from the consumer group by given member identities.
     */
-  def removeMembersFromConsumerGroup(
+  def removeMembersFromConsumerGroup[G[_]: Foldable](
     groupId: String,
-    members: NonEmptySet[MemberToRemove],
+    members: G[MemberToRemove],
     reason: Option[String]
   ): F[Unit]
 
@@ -460,6 +463,19 @@ object KafkaAdminClient {
   ): F[Unit] =
     withAdminClient(_.deleteRecords(recordsToDelete.asJava).all).void
 
+  def createDelegationTokenWith[F[_]](
+    withAdminClient: WithAdminClient[F],
+    renewers: List[KafkaPrincipal],
+    owner: Option[KafkaPrincipal],
+    maxLifeTime: Option[FiniteDuration]
+  ): F[DelegationToken] = {
+    val options = new CreateDelegationTokenOptions()
+    options.renewers(renewers.asJava)
+    maxLifeTime.map(_.toMillis).foreach(options.maxLifetimeMs)
+    owner.foreach(options.owner)
+    withAdminClient(_.createDelegationToken(options).delegationToken())
+  }
+
   def expireDelegationTokenWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F],
     hmac: Array[Byte],
@@ -517,13 +533,13 @@ object KafkaAdminClient {
         .reassignments()
     }.map(_.asScala.toMap)
 
-  def removeMembersFromConsumerGroupWith[F[_]: Functor](
+  def removeMembersFromConsumerGroupWith[F[_]: Functor, G[_]: Foldable](
     withAdminClient: WithAdminClient[F],
     groupId: String,
-    members: NonEmptySet[MemberToRemove],
+    members: G[MemberToRemove],
     reason: Option[String]
   ): F[Unit] = {
-    val options = new RemoveMembersFromConsumerGroupOptions(members.toSortedSet.asJava)
+    val options = new RemoveMembersFromConsumerGroupOptions(members.toList.asJava)
     reason.foreach(options.reason)
     withAdminClient(_.removeMembersFromConsumerGroup(groupId, options).all).void
   }
@@ -675,12 +691,6 @@ object KafkaAdminClient {
     withAdminClient { client =>
       KafkaFuture.completedFuture[Map[MetricName, Metric]](client.metrics().asScala.toMap)
     }
-
-  private[this] def alterConfigsWith[F[_]: Functor, G[_]: Foldable](
-    withAdminClient: WithAdminClient[F],
-    configs: Map[ConfigResource, G[AlterConfigOp]]
-  ): F[Unit] =
-    withAdminClient(_.incrementalAlterConfigs(configs.asJavaMap).all).void
 
   private[this] def createPartitionsWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F],
@@ -1027,7 +1037,7 @@ object KafkaAdminClient {
     override def alterConfigs[G[_]](configs: Map[ConfigResource, G[AlterConfigOp]])(implicit
       G: Foldable[G]
     ): F[Unit] =
-      alterConfigsWith(client, configs)
+      alterConfigsWith(client, configs, validateOnly = false)
 
     override def createPartitions(newPartitions: Map[String, NewPartitions]): F[Unit] =
       createPartitionsWith(client, newPartitions)
@@ -1145,6 +1155,13 @@ object KafkaAdminClient {
     override def deleteRecords(recordsToDelete: Map[TopicPartition, RecordsToDelete]): F[Unit] =
       deleteRecordsWith[F](client, recordsToDelete)
 
+    override def createDelegationToken(
+      renewers: List[KafkaPrincipal],
+      owner: Option[KafkaPrincipal],
+      maxLifeTime: Option[FiniteDuration]
+    ): F[DelegationToken] =
+      createDelegationTokenWith[F](client, renewers, owner, maxLifeTime)
+
     /**
       * Expire a Delegation Token.
       */
@@ -1194,9 +1211,9 @@ object KafkaAdminClient {
     /**
       * Remove members from the consumer group by given member identities.
       */
-    override def removeMembersFromConsumerGroup(
+    override def removeMembersFromConsumerGroup[G[_]: Foldable](
       groupId: String,
-      members: NonEmptySet[MemberToRemove],
+      members: G[MemberToRemove],
       reason: Option[String]
     ): F[Unit] =
       removeMembersFromConsumerGroupWith(client, groupId, members, reason)

--- a/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaAdminClient.scala
@@ -6,8 +6,6 @@
 
 package fs2.kafka
 
-import java.util
-
 import scala.annotation.nowarn
 
 import cats.{Foldable, Functor}
@@ -279,7 +277,7 @@ sealed abstract class KafkaAdminClient[F[_]] {
     * Describe the Delegation Tokens.
     */
   def describeDelegationToken[G[_]: Foldable](
-    owners: Option[List[KafkaPrincipal]]
+    owners: Option[G[KafkaPrincipal]]
   ): F[List[DelegationToken]]
 
   /**
@@ -394,9 +392,9 @@ sealed abstract class KafkaAdminClient[F[_]] {
   def fenceProducers[G[_]: Foldable](transactionalIds: G[String]): F[Unit]
 
   /**
-    * List the client metrics configuration resources available in the cluster.
+    * @return
     */
-  def listClientMetricsResources(): F[List[ClientMetricsResourceListing]]
+  def listConfigResources(): F[List[ConfigResource]]
 
   /**
     * Add a new voter node to the KRaft metadata quorum.
@@ -485,10 +483,10 @@ object KafkaAdminClient {
 
   def describeDelegationTokenWith[F[_]: Functor, G[_]: Foldable](
     withAdminClient: WithAdminClient[F],
-    owners: Option[List[KafkaPrincipal]]
+    owners: Option[G[KafkaPrincipal]]
   ): F[List[DelegationToken]] = {
     val options = new DescribeDelegationTokenOptions()
-    owners.map(_.asJava).foreach(options.owners)
+    owners.map(_.toList.asJava).foreach(options.owners)
     withAdminClient(_.describeDelegationToken(options).delegationTokens()).map(_.asScala.toList)
   }
 
@@ -503,7 +501,7 @@ object KafkaAdminClient {
     withAdminClient: WithAdminClient[F],
     reassignments: Map[TopicPartition, Option[NewPartitionReassignment]]
   ): F[Unit] = {
-    val javaOpts = reassignments.view.mapValues(_.toJava).toMap.asJava
+    val javaOpts = reassignments.view.map { case (k, v) => k -> v.toJava }.toMap.asJava
     withAdminClient(_.alterPartitionReassignments(javaOpts).all).void
   }
 
@@ -544,14 +542,13 @@ object KafkaAdminClient {
     filter: ClientQuotaFilter
   ): F[Map[ClientQuotaEntity, Map[String, Double]]] =
     withAdminClient(_.describeClientQuotas(filter).entities()).map { entities =>
-      Map.from(
-        entities
-          .asScala
-          .view
-          .map { case (k, v) =>
-            k -> Map.from(v.asScala.view.map { case (qk, qv) => qk -> qv.doubleValue })
-          }
-      )
+      entities
+        .asScala
+        .view
+        .map { case (k, v) =>
+          k -> v.asScala.view.map { case (qk, qv) => qk -> qv.doubleValue }.toMap
+        }
+        .toMap
     }
 
   def alterClientQuotasWith[F[_]: Functor, G[_]: Foldable](
@@ -569,7 +566,7 @@ object KafkaAdminClient {
       _.asScala.toMap
     )
 
-  def describeFeaturesWith[F[_]: Functor](withAdminClient: WithAdminClient[F]): F[FeatureMetadata] =
+  def describeFeaturesWith[F[_]](withAdminClient: WithAdminClient[F]): F[FeatureMetadata] =
     withAdminClient(_.describeFeatures().featureMetadata())
 
   def updateFeaturesWith[F[_]: Functor](
@@ -581,7 +578,7 @@ object KafkaAdminClient {
     withAdminClient(_.updateFeatures(features.asJava, opts).all).void
   }
 
-  def describeMetadataQuorumWith[F[_]: Functor](
+  def describeMetadataQuorumWith[F[_]](
     withAdminClient: WithAdminClient[F]
   ): F[QuorumInfo] =
     withAdminClient(_.describeMetadataQuorum().quorumInfo())
@@ -634,10 +631,9 @@ object KafkaAdminClient {
   ): F[Unit] =
     withAdminClient(_.fenceProducers(transactionalIds.asJava).all).map(_ => ())
 
-  def listClientMetricsResourcesWith[F[_]: Functor](
+  def listConfigResourcesWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F]
-  ): F[List[ClientMetricsResourceListing]] =
-    withAdminClient(_.listClientMetricsResources().all).map(_.asScala.toList)
+  ): F[List[ConfigResource]] = withAdminClient(_.listConfigResources().all()).map(_.asScala.toList)
 
   def addRaftVoterWith[F[_]: Functor](
     withAdminClient: WithAdminClient[F],
@@ -646,6 +642,7 @@ object KafkaAdminClient {
     endpoints: Set[RaftVoterEndpoint],
     clusterId: Option[String]
   ): F[Unit] = {
+
     withAdminClient(
       _.addRaftVoter(
           voterId,
@@ -672,7 +669,7 @@ object KafkaAdminClient {
         .all
     ).map(_ => ())
 
-  def metricsWith[F[_]: Functor](
+  def metricsWith[F[_]](
     withAdminClient: WithAdminClient[F]
   ): F[Map[MetricName, Metric]] =
     withAdminClient { client =>
@@ -1025,313 +1022,311 @@ object KafkaAdminClient {
   ): Resource[F, KafkaAdminClient[G]] =
     WithAdminClient[F, G](mk, settings).map(create[G])
 
-  private def create[F[_]: Functor](client: WithAdminClient[F]) =
-    new KafkaAdminClient[F] {
+  private def create[F[_]: Functor](client: WithAdminClient[F]) = new KafkaAdminClient[F] {
 
-      override def alterConfigs[G[_]](configs: Map[ConfigResource, G[AlterConfigOp]])(implicit
-        G: Foldable[G]
-      ): F[Unit] =
-        alterConfigsWith(client, configs)
+    override def alterConfigs[G[_]](configs: Map[ConfigResource, G[AlterConfigOp]])(implicit
+      G: Foldable[G]
+    ): F[Unit] =
+      alterConfigsWith(client, configs)
 
-      override def createPartitions(newPartitions: Map[String, NewPartitions]): F[Unit] =
-        createPartitionsWith(client, newPartitions)
+    override def createPartitions(newPartitions: Map[String, NewPartitions]): F[Unit] =
+      createPartitionsWith(client, newPartitions)
 
-      override def createTopic(topic: NewTopic): F[Unit] =
-        createTopicWith(client, topic)
+    override def createTopic(topic: NewTopic): F[Unit] =
+      createTopicWith(client, topic)
 
-      override def createTopics[G[_]](topics: G[NewTopic])(implicit
-        G: Foldable[G]
-      ): F[Unit] =
-        createTopicsWith(client, topics)
+    override def createTopics[G[_]](topics: G[NewTopic])(implicit
+      G: Foldable[G]
+    ): F[Unit] =
+      createTopicsWith(client, topics)
 
-      override def createAcls[G[_]](acls: G[AclBinding])(implicit
-        G: Foldable[G]
-      ): F[Unit] =
-        createAclsWith(client, acls)
+    override def createAcls[G[_]](acls: G[AclBinding])(implicit
+      G: Foldable[G]
+    ): F[Unit] =
+      createAclsWith(client, acls)
 
-      override def deleteTopic(topic: String): F[Unit] =
-        deleteTopicWith(client, topic)
+    override def deleteTopic(topic: String): F[Unit] =
+      deleteTopicWith(client, topic)
 
-      override def deleteTopics[G[_]](topics: G[String])(implicit G: Foldable[G]): F[Unit] =
-        deleteTopicsWith(client, topics)
+    override def deleteTopics[G[_]](topics: G[String])(implicit G: Foldable[G]): F[Unit] =
+      deleteTopicsWith(client, topics)
 
-      override def deleteAcls[G[_]](filters: G[AclBindingFilter])(implicit
-        G: Foldable[G]
-      ): F[Unit] =
-        deleteAclsWith(client, filters)
+    override def deleteAcls[G[_]](filters: G[AclBindingFilter])(implicit
+      G: Foldable[G]
+    ): F[Unit] =
+      deleteAclsWith(client, filters)
 
-      override def describeCluster: DescribeCluster[F] =
-        describeClusterWith(client)
+    override def describeCluster: DescribeCluster[F] =
+      describeClusterWith(client)
 
-      override def describeConfigs[G[_]](resources: G[ConfigResource])(implicit
-        G: Foldable[G]
-      ): F[Map[ConfigResource, List[ConfigEntry]]] =
-        describeConfigsWith(client, resources)
+    override def describeConfigs[G[_]](resources: G[ConfigResource])(implicit
+      G: Foldable[G]
+    ): F[Map[ConfigResource, List[ConfigEntry]]] =
+      describeConfigsWith(client, resources)
 
-      override def describeConsumerGroups[G[_]](groupIds: G[String])(implicit
-        G: Foldable[G]
-      ): F[Map[String, ConsumerGroupDescription]] =
-        describeConsumerGroupsWith(client, groupIds)
+    override def describeConsumerGroups[G[_]](groupIds: G[String])(implicit
+      G: Foldable[G]
+    ): F[Map[String, ConsumerGroupDescription]] =
+      describeConsumerGroupsWith(client, groupIds)
 
-      override def describeTopics[G[_]](topics: G[String])(implicit
-        G: Foldable[G]
-      ): F[Map[String, TopicDescription]] =
-        describeTopicsWith(client, topics)
+    override def describeTopics[G[_]](topics: G[String])(implicit
+      G: Foldable[G]
+    ): F[Map[String, TopicDescription]] =
+      describeTopicsWith(client, topics)
 
-      override def listConsumerGroupOffsets(groupId: String): ListConsumerGroupOffsets[F] =
-        listConsumerGroupOffsetsWith(client, groupId)
+    override def listConsumerGroupOffsets(groupId: String): ListConsumerGroupOffsets[F] =
+      listConsumerGroupOffsetsWith(client, groupId)
 
-      override def listConsumerGroups: ListConsumerGroups[F] =
-        listConsumerGroupsWith(client)
+    override def listConsumerGroups: ListConsumerGroups[F] =
+      listConsumerGroupsWith(client)
 
-      override def listTopics: ListTopics[F] =
-        listTopicsWith(client)
+    override def listTopics: ListTopics[F] =
+      listTopicsWith(client)
 
-      override def describeAcls(filter: AclBindingFilter): F[List[AclBinding]] =
-        describeAclsWith(client, filter)
+    override def describeAcls(filter: AclBindingFilter): F[List[AclBinding]] =
+      describeAclsWith(client, filter)
 
-      override def alterConsumerGroupOffsets(
-        groupId: String,
-        offsets: Map[TopicPartition, OffsetAndMetadata]
-      ): F[Unit] =
-        alterConsumerGroupOffsetsWith(client, groupId, offsets)
+    override def alterConsumerGroupOffsets(
+      groupId: String,
+      offsets: Map[TopicPartition, OffsetAndMetadata]
+    ): F[Unit] =
+      alterConsumerGroupOffsetsWith(client, groupId, offsets)
 
-      override def deleteConsumerGroupOffsets(
-        groupId: String,
-        partitions: Set[TopicPartition]
-      ): F[Unit] =
-        deleteConsumerGroupOffsetsWith(client, groupId, partitions)
+    override def deleteConsumerGroupOffsets(
+      groupId: String,
+      partitions: Set[TopicPartition]
+    ): F[Unit] =
+      deleteConsumerGroupOffsetsWith(client, groupId, partitions)
 
-      override def deleteConsumerGroups[G[_]](
-        groupIds: G[String]
-      )(implicit G: Foldable[G]): F[Unit] =
-        deleteConsumerGroupsWith(client, groupIds)
+    override def deleteConsumerGroups[G[_]](
+      groupIds: G[String]
+    )(implicit G: Foldable[G]): F[Unit] =
+      deleteConsumerGroupsWith(client, groupIds)
 
-      override def toString: String =
-        "KafkaAdminClient$" + System.identityHashCode(this)
+    override def toString: String =
+      "KafkaAdminClient$" + System.identityHashCode(this)
 
-      /**
-        * Incrementally update the configuration for the specified resources
-        */
-      override def alterConfigs[G[_]: Foldable](
-        configs: Map[ConfigResource, G[AlterConfigOp]],
-        validateOnly: Boolean
-      ): F[Unit] =
-        alterConfigsWith[F, G](client, configs, validateOnly)
+    /**
+      * Incrementally update the configuration for the specified resources
+      */
+    override def alterConfigs[G[_]: Foldable](
+      configs: Map[ConfigResource, G[AlterConfigOp]],
+      validateOnly: Boolean
+    ): F[Unit] =
+      alterConfigsWith[F, G](client, configs, validateOnly)
 
-      /**
-        * Change the log directory for the specified replicas.
-        */
-      override def alterReplicaLogDirs(
-        replicaAssignment: Map[TopicPartitionReplica, String]
-      ): F[Unit] =
-        alterReplicaLogDirsWith[F](client, replicaAssignment)
+    /**
+      * Change the log directory for the specified replicas.
+      */
+    override def alterReplicaLogDirs(
+      replicaAssignment: Map[TopicPartitionReplica, String]
+    ): F[Unit] =
+      alterReplicaLogDirsWith[F](client, replicaAssignment)
 
-      /**
-        * Query the information of all log directories on the given set of brokers.
-        */
-      override def describeLogDirs[G[_]: Foldable: Functor](
-        brokers: G[Int]
-      ): F[Map[Int, Map[String, LogDirDescription]]] =
-        describeLogDirsWith[F, G](client, brokers)
+    /**
+      * Query the information of all log directories on the given set of brokers.
+      */
+    override def describeLogDirs[G[_]: Foldable: Functor](
+      brokers: G[Int]
+    ): F[Map[Int, Map[String, LogDirDescription]]] =
+      describeLogDirsWith[F, G](client, brokers)
 
-      /**
-        * Query the replica log directory information for the specified replicas.
-        */
-      override def describeReplicaLogDirs[G[_]: Foldable](
-        replicas: G[TopicPartitionReplica]
-      ): F[Map[TopicPartitionReplica, ReplicaLogDirInfo]] =
-        describeReplicaLogDirsWith[F, G](client, replicas)
+    /**
+      * Query the replica log directory information for the specified replicas.
+      */
+    override def describeReplicaLogDirs[G[_]: Foldable](
+      replicas: G[TopicPartitionReplica]
+    ): F[Map[TopicPartitionReplica, ReplicaLogDirInfo]] =
+      describeReplicaLogDirsWith[F, G](client, replicas)
 
-      /**
-        * Delete records whose offset is smaller than the given offset of the corresponding
-        * partition.
-        */
-      override def deleteRecords(recordsToDelete: Map[TopicPartition, RecordsToDelete]): F[Unit] =
-        deleteRecordsWith[F](client, recordsToDelete)
+    /**
+      * Delete records whose offset is smaller than the given offset of the corresponding partition.
+      */
+    override def deleteRecords(recordsToDelete: Map[TopicPartition, RecordsToDelete]): F[Unit] =
+      deleteRecordsWith[F](client, recordsToDelete)
 
-      /**
-        * Expire a Delegation Token.
-        */
-      override def expireDelegationToken(
-        hmac: Array[Byte],
-        expiryTimePeriodMs: Option[Long]
-      ): F[Long] = expireDelegationTokenWith(client, hmac, expiryTimePeriodMs)
+    /**
+      * Expire a Delegation Token.
+      */
+    override def expireDelegationToken(
+      hmac: Array[Byte],
+      expiryTimePeriodMs: Option[Long]
+    ): F[Long] = expireDelegationTokenWith(client, hmac, expiryTimePeriodMs)
 
-      /**
-        * Renew a Delegation Token. Returns the expiryTimestamp.
-        */
-      override def renewDelegationToken(
-        hmac: Array[Byte],
-        renewTimePeriodMs: Option[Long]
-      ): F[Long] = renewDelegationTokenWith(client, hmac, renewTimePeriodMs)
+    /**
+      * Renew a Delegation Token. Returns the expiryTimestamp.
+      */
+    override def renewDelegationToken(
+      hmac: Array[Byte],
+      renewTimePeriodMs: Option[Long]
+    ): F[Long] = renewDelegationTokenWith(client, hmac, renewTimePeriodMs)
 
-      /**
-        * Describe the Delegation Tokens.
-        */
-      override def describeDelegationToken[G[_]: Foldable](
-        owners: Option[List[KafkaPrincipal]]
-      ): F[List[DelegationToken]] = describeDelegationTokenWith[F, G](client, owners)
+    /**
+      * Describe the Delegation Tokens.
+      */
+    override def describeDelegationToken[G[_]: Foldable](
+      owners: Option[G[KafkaPrincipal]]
+    ): F[List[DelegationToken]] = describeDelegationTokenWith[F, G](client, owners)
 
-      /**
-        * Elect a replica as leader for topic partitions.
-        */
-      override def electLeaders(
-        electionType: ElectionType,
-        partitions: Set[TopicPartition]
-      ): F[Unit] = electLeadersWith[F](client, electionType, partitions)
+    /**
+      * Elect a replica as leader for topic partitions.
+      */
+    override def electLeaders(
+      electionType: ElectionType,
+      partitions: Set[TopicPartition]
+    ): F[Unit] = electLeadersWith[F](client, electionType, partitions)
 
-      /**
-        * Change the reassignments for one or more partitions.
-        */
-      override def alterPartitionReassignments(
-        reassignments: Map[TopicPartition, Option[NewPartitionReassignment]]
-      ): F[Unit] = alterPartitionReassignmentsWith[F](client, reassignments)
+    /**
+      * Change the reassignments for one or more partitions.
+      */
+    override def alterPartitionReassignments(
+      reassignments: Map[TopicPartition, Option[NewPartitionReassignment]]
+    ): F[Unit] = alterPartitionReassignmentsWith[F](client, reassignments)
 
-      /**
-        * List the current reassignments for the given partitions.
-        */
-      override def listPartitionReassignments(
-        partitionsFilter: Option[Set[TopicPartition]]
-      ): F[Map[TopicPartition, PartitionReassignment]] =
-        listPartitionReassignmentsWith(client, partitionsFilter)
+    /**
+      * List the current reassignments for the given partitions.
+      */
+    override def listPartitionReassignments(
+      partitionsFilter: Option[Set[TopicPartition]]
+    ): F[Map[TopicPartition, PartitionReassignment]] =
+      listPartitionReassignmentsWith(client, partitionsFilter)
 
-      /**
-        * Remove members from the consumer group by given member identities.
-        */
-      override def removeMembersFromConsumerGroup(
-        groupId: String,
-        members: NonEmptySet[MemberToRemove],
-        reason: Option[String]
-      ): F[Unit] =
-        removeMembersFromConsumerGroupWith(client, groupId, members, reason)
+    /**
+      * Remove members from the consumer group by given member identities.
+      */
+    override def removeMembersFromConsumerGroup(
+      groupId: String,
+      members: NonEmptySet[MemberToRemove],
+      reason: Option[String]
+    ): F[Unit] =
+      removeMembersFromConsumerGroupWith(client, groupId, members, reason)
 
-      /**
-        * List offset for the specified partitions and isolation level.
-        */
-      override def listOffsets(
-        topicPartitionOffsets: Map[TopicPartition, OffsetSpec],
-        isolationLevel: common.IsolationLevel
-      ): F[Map[TopicPartition, ListOffsetsResultInfo]] =
-        listOffsetsWith(client, topicPartitionOffsets, isolationLevel)
+    /**
+      * List offset for the specified partitions and isolation level.
+      */
+    override def listOffsets(
+      topicPartitionOffsets: Map[TopicPartition, OffsetSpec],
+      isolationLevel: common.IsolationLevel
+    ): F[Map[TopicPartition, ListOffsetsResultInfo]] =
+      listOffsetsWith(client, topicPartitionOffsets, isolationLevel)
 
-      /**
-        * Describes all entities matching the provided filter that have at least one client quota
-        * configuration value defined.
-        */
-      override def describeClientQuotas(
-        filter: ClientQuotaFilter
-      ): F[Map[ClientQuotaEntity, Map[String, Double]]] =
-        describeClientQuotasWith(client, filter)
+    /**
+      * Describes all entities matching the provided filter that have at least one client quota
+      * configuration value defined.
+      */
+    override def describeClientQuotas(
+      filter: ClientQuotaFilter
+    ): F[Map[ClientQuotaEntity, Map[String, Double]]] =
+      describeClientQuotasWith(client, filter)
 
-      /**
-        * Alters client quota configurations with the specified alterations.
-        */
-      override def alterClientQuotas[G[_]: Foldable](entries: G[ClientQuotaAlteration]): F[Unit] =
-        alterClientQuotasWith[F, G](client, entries)
+    /**
+      * Alters client quota configurations with the specified alterations.
+      */
+    override def alterClientQuotas[G[_]: Foldable](entries: G[ClientQuotaAlteration]): F[Unit] =
+      alterClientQuotasWith[F, G](client, entries)
 
-      /**
-        * Describe all SASL/SCRAM credentials.
-        */
-      override def describeUserScramCredentials(
-        users: Option[List[String]]
-      ): F[Map[String, UserScramCredentialsDescription]] =
-        describeUserScramCredentialsWith(client, users)
+    /**
+      * Describe all SASL/SCRAM credentials.
+      */
+    override def describeUserScramCredentials(
+      users: Option[List[String]]
+    ): F[Map[String, UserScramCredentialsDescription]] =
+      describeUserScramCredentialsWith(client, users)
 
-      /**
-        * Describes finalized as well as supported features.
-        */
-      override def describeFeatures(): F[FeatureMetadata] =
-        describeFeaturesWith(client)
+    /**
+      * Describes finalized as well as supported features.
+      */
+    override def describeFeatures(): F[FeatureMetadata] =
+      describeFeaturesWith(client)
 
-      /**
-        * Applies specified updates to finalized features.
-        */
-      override def updateFeatures(
-        features: Map[String, FeatureUpdate],
-        validateOnly: Boolean
-      ): F[Unit] = updateFeaturesWith(client, features, validateOnly)
+    /**
+      * Applies specified updates to finalized features.
+      */
+    override def updateFeatures(
+      features: Map[String, FeatureUpdate],
+      validateOnly: Boolean
+    ): F[Unit] = updateFeaturesWith(client, features, validateOnly)
 
-      /**
-        * Describes the state of the metadata quorum.
-        */
-      override def describeMetadataQuorum(): F[QuorumInfo] =
-        describeMetadataQuorumWith(client)
+    /**
+      * Describes the state of the metadata quorum.
+      */
+    override def describeMetadataQuorum(): F[QuorumInfo] =
+      describeMetadataQuorumWith(client)
 
-      /**
-        * Describe producer state on a set of topic partitions.
-        */
-      override def describeProducers[G[_]: Foldable](
-        partitions: G[TopicPartition],
-        brokerId: Option[Int]
-      ): F[Map[TopicPartition, PartitionProducerState]] =
-        describeProducersWith(client, partitions, brokerId)
+    /**
+      * Describe producer state on a set of topic partitions.
+      */
+    override def describeProducers[G[_]: Foldable](
+      partitions: G[TopicPartition],
+      brokerId: Option[Int]
+    ): F[Map[TopicPartition, PartitionProducerState]] =
+      describeProducersWith(client, partitions, brokerId)
 
-      /**
-        * Describe the state of a set of transactional IDs from the respective transaction
-        * coordinators, which are dynamically discovered.
-        */
-      override def describeTransactions[G[_]: Foldable](
-        transactionalIds: G[String]
-      ): F[Map[String, TransactionDescription]] =
-        describeTransactionsWith(client, transactionalIds)
+    /**
+      * Describe the state of a set of transactional IDs from the respective transaction
+      * coordinators, which are dynamically discovered.
+      */
+    override def describeTransactions[G[_]: Foldable](
+      transactionalIds: G[String]
+    ): F[Map[String, TransactionDescription]] =
+      describeTransactionsWith(client, transactionalIds)
 
-      /**
-        * Forcefully abort a transaction which is open on a topic partition.
-        */
-      override def abortTransaction(
-        topicPartition: TopicPartition,
-        producerId: Long,
-        producerEpoch: Short,
-        coordinationEpoch: Int
-      ): F[Unit] =
-        abortTransactionWith(client, topicPartition, producerId, producerEpoch, coordinationEpoch)
+    /**
+      * Forcefully abort a transaction which is open on a topic partition.
+      */
+    override def abortTransaction(
+      topicPartition: TopicPartition,
+      producerId: Long,
+      producerEpoch: Short,
+      coordinationEpoch: Int
+    ): F[Unit] =
+      abortTransactionWith(client, topicPartition, producerId, producerEpoch, coordinationEpoch)
 
-      /**
-        * List active transactions in the cluster.
-        */
-      override def listTransactions(
-        states: Option[Set[TransactionState]],
-        producerIds: Option[Set[Long]],
-        duration: Option[Long]
-      ): F[List[TransactionListing]] = listTransactionsWith(client, states, producerIds, duration)
+    /**
+      * List active transactions in the cluster.
+      */
+    override def listTransactions(
+      states: Option[Set[TransactionState]],
+      producerIds: Option[Set[Long]],
+      duration: Option[Long]
+    ): F[List[TransactionListing]] = listTransactionsWith(client, states, producerIds, duration)
 
-      /**
-        * Fence out all active producers that use any of the provided transactional IDs.
-        */
-      override def fenceProducers[G[_]: Foldable](transactionalIds: G[String]): F[Unit] =
-        fenceProducersWith(client, transactionalIds)
+    /**
+      * Fence out all active producers that use any of the provided transactional IDs.
+      */
+    override def fenceProducers[G[_]: Foldable](transactionalIds: G[String]): F[Unit] =
+      fenceProducersWith(client, transactionalIds)
 
-      /**
-        * List the client metrics configuration resources available in the cluster.
-        */
-      override def listClientMetricsResources(): F[List[ClientMetricsResourceListing]] =
-        listClientMetricsResourcesWith(client)
+    /**
+      * List all configuration resources available in the cluster with the default options.
+      */
+    override def listConfigResources(): F[List[ConfigResource]] = listConfigResourcesWith[F](client)
 
-      /**
-        * Add a new voter node to the KRaft metadata quorum.
-        */
-      override def addRaftVoter(
-        voterId: Int,
-        voterDirectoryId: Uuid,
-        endpoints: Set[RaftVoterEndpoint],
-        clusterId: Option[String]
-      ): F[Unit] = addRaftVoterWith(client, voterId, voterDirectoryId, endpoints, clusterId)
+    /**
+      * Add a new voter node to the KRaft metadata quorum.
+      */
+    override def addRaftVoter(
+      voterId: Int,
+      voterDirectoryId: Uuid,
+      endpoints: Set[RaftVoterEndpoint],
+      clusterId: Option[String]
+    ): F[Unit] = addRaftVoterWith(client, voterId, voterDirectoryId, endpoints, clusterId)
 
-      /**
-        * Remove a voter node from the KRaft metadata quorum.
-        */
-      override def removeRaftVoter(
-        voterId: Int,
-        voterDirectoryId: Uuid,
-        clusterId: Option[String]
-      ): F[Unit] = removeRaftVoterWith(client, voterId, voterDirectoryId, clusterId)
+    /**
+      * Remove a voter node from the KRaft metadata quorum.
+      */
+    override def removeRaftVoter(
+      voterId: Int,
+      voterDirectoryId: Uuid,
+      clusterId: Option[String]
+    ): F[Unit] = removeRaftVoterWith(client, voterId, voterDirectoryId, clusterId)
 
-      /**
-        * Get the metrics kept by the adminClient
-        */
-      override def metrics(): F[Map[MetricName, Metric]] = metricsWith(client)
-    }
+    /**
+      * Get the metrics kept by the adminClient
+      */
+    override def metrics(): F[Map[MetricName, Metric]] = metricsWith(client)
+
+  }
 
   /**
     * Creates a new [[KafkaAdminClient]] in the `Stream` context, using the specified

--- a/modules/core/src/main/scala/fs2/kafka/LowLevelKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/LowLevelKafkaProducer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2025 OVO Energy Limited
+ * Copyright 2018 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/fs2/kafka/LowLevelKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/LowLevelKafkaProducer.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018-2025 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka
+
+import scala.annotation.nowarn
+import scala.concurrent.{Promise}
+
+import cats.effect.{Async, Resource}
+import cats.effect.kernel.Resource.ExitCase
+import cats.effect.syntax.all.*
+import cats.syntax.all.*
+import fs2.{Chunk}
+import fs2.kafka.internal.*
+import fs2.kafka.internal.converters.collection.*
+import fs2.kafka.producer.MkProducer
+
+import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, OffsetAndMetadata}
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
+
+/**
+  * Represents a producer of Kafka records specialized for 'read-process-write' streams, with the
+  * ability to atomically produce `ProducerRecord`s and commit corresponding [[CommittableOffset]]s
+  * using [[produce]].<br><br>
+  *
+  * Records are wrapped in [[TransactionalProducerRecords]], which is a chunk of
+  * [[CommittableProducerRecord]] which wrap zero or more records together with a
+  * [[CommittableOffset]].
+  */
+abstract class LowLevelKafkaProducer[F[_], K, V] {
+
+  def produce(records: ProducerRecords[K, V]): F[ProducerResult[K, V]]
+
+  def sendOffsetsToTransaction(
+    offsets: Map[TopicPartition, OffsetAndMetadata],
+    groupMetadata: ConsumerGroupMetadata
+  ): F[Unit]
+
+  def transaction: Resource[F, Unit]
+
+  /**
+    * Returns producer metrics.
+    *
+    * @see
+    *   org.apache.kafka.clients.producer.KafkaProducer#metrics
+    */
+  def metrics: F[Map[MetricName, Metric]]
+
+}
+
+object LowLevelKafkaProducer {
+
+  def resource[F[_], K, V](
+    settings: TransactionalProducerSettings[F, K, V]
+  )(implicit F: Async[F], mk: MkProducer[F]): Resource[F, LowLevelKafkaProducer[F, K, V]] = for {
+    keySerializer   <- settings.producerSettings.keySerializer
+    valueSerializer <- settings.producerSettings.valueSerializer
+    withProducer    <- WithTransactionalProducer(mk, settings)
+    _               <- withProducer.blocking(withProducer.producer.initTransactions()).toResource
+  } yield new LowLevelKafkaProducer[F, K, V] {
+
+    override def transaction: Resource[F, Unit] = {
+      val acquireTx = withProducer.blocking(withProducer.producer.beginTransaction())
+      val commitTx  = withProducer.blocking(withProducer.producer.commitTransaction())
+      val abortTx   = withProducer.blocking(withProducer.producer.abortTransaction())
+      for {
+        _ <- withProducer.exclusiveAccess
+        _ <- Resource.makeCase(acquireTx) {
+               case (_, ExitCase.Succeeded)                      => commitTx
+               case (_, ExitCase.Canceled | ExitCase.Errored(_)) => abortTx
+             }
+      } yield ()
+    }
+
+    override def sendOffsetsToTransaction(
+      offsets: Map[TopicPartition, OffsetAndMetadata],
+      groupMetadata: ConsumerGroupMetadata
+    ): F[Unit] =
+      withProducer.blocking(
+        withProducer.producer.sendOffsetsToTransaction(offsets.asJava, groupMetadata)
+      )
+
+    private def sendRecords(
+      produceRecordError: Option[Promise[Throwable]],
+      records: Chunk[ProducerRecord[K, V]]
+    ): F[Chunk[(ProducerRecord[K, V], RecordMetadata)]] = {
+      records
+        .traverse(
+          KafkaProducer.produceRecord(
+            keySerializer,
+            valueSerializer,
+            withProducer.producer,
+            withProducer.blocking,
+            produceRecordError
+          )
+        )
+        .flatMap(_.sequence)
+    }
+
+    override def produce(records: ProducerRecords[K, V]): F[ProducerResult[K, V]] = {
+      if (settings.producerSettings.failFastProduce)
+        for {
+          produceRecordError <- Async[F].delay(Promise[Throwable]())
+          waitErrorF          = Async[F].fromFutureCancelable(
+                         Async[F].delay((produceRecordError.future, Async[F].unit))
+                       )
+          recordsToProduce = sendRecords(produceRecordError.some, records)
+          result          <- waitErrorF.race(recordsToProduce).rethrow
+        } yield result
+      else sendRecords(None, records)
+    }
+
+    /**
+      * Returns producer metrics.
+      *
+      * @see
+      *   org.apache.kafka.clients.producer.KafkaProducer#metrics
+      */
+    override def metrics: F[Map[MetricName, Metric]] = withProducer
+      .blocking(withProducer.producer.metrics())
+      .map(_.asScala.toMap)
+  }
+
+  /*
+   * Prevents the default `MkProducer` instance from being implicitly available
+   * to code defined in this object, ensuring factory methods require an instance
+   * to be provided at the call site.
+   */
+  @nowarn("msg=never used")
+  implicit private def mkAmbig1[F[_]]: MkProducer[F] =
+    throw new AssertionError("should not be used")
+
+  @nowarn("msg=never used")
+  implicit private def mkAmbig2[F[_]]: MkProducer[F] =
+    throw new AssertionError("should not be used")
+
+}

--- a/modules/core/src/main/scala/fs2/kafka/LowLevelKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/LowLevelKafkaProducer.scala
@@ -7,16 +7,16 @@
 package fs2.kafka
 
 import scala.annotation.nowarn
-import scala.concurrent.{Promise}
+import scala.concurrent.Promise
 
 import cats.effect.{Async, Resource}
 import cats.effect.kernel.Resource.ExitCase
 import cats.effect.syntax.all.*
 import cats.syntax.all.*
-import fs2.{Chunk}
 import fs2.kafka.internal.*
 import fs2.kafka.internal.converters.collection.*
 import fs2.kafka.producer.MkProducer
+import fs2.Chunk
 
 import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, OffsetAndMetadata}
 import org.apache.kafka.clients.producer.RecordMetadata
@@ -70,8 +70,9 @@ object LowLevelKafkaProducer {
       for {
         _ <- withProducer.exclusiveAccess
         _ <- Resource.makeCase(acquireTx) {
-               case (_, ExitCase.Succeeded)                      => commitTx
-               case (_, ExitCase.Canceled | ExitCase.Errored(_)) => abortTx
+               case (_, ExitCase.Succeeded)  => commitTx
+               case (_, ExitCase.Canceled)   => abortTx
+               case (_, ExitCase.Errored(e)) => abortTx *> e.raiseError[F, Unit]
              }
       } yield ()
     }

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -92,10 +92,9 @@ object TransactionalKafkaProducer {
               offsets.parFlatTraverse { case (committer, offsets) =>
                 for {
                   metadata       <- committer.metadata
-                  _              <- producer.sendOffsetsToTransaction(offsets, metadata)
-                  producerRecords =
-                    records.filter(_.offset.committer == committer).flatMap(_.records)
+                  producerRecords = records.filter(_.offset.committer == committer).flatMap(_.records)
                   result <- producer.produce(producerRecords)
+                  _              <- producer.sendOffsetsToTransaction(offsets, metadata)
                 } yield result
               }
             }

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -7,13 +7,15 @@
 package fs2.kafka
 
 import scala.annotation.nowarn
+
 import cats.effect.Async
-import cats.syntax.all.*
 import cats.effect.Resource
+import cats.syntax.all.*
 import cats.Parallel
 import fs2.kafka.producer.MkProducer
 import fs2.Chunk
 import fs2.Stream
+
 import org.apache.kafka.common.Metric
 import org.apache.kafka.common.MetricName
 
@@ -92,9 +94,10 @@ object TransactionalKafkaProducer {
               offsets.parFlatTraverse { case (committer, offsets) =>
                 for {
                   metadata       <- committer.metadata
-                  producerRecords = records.filter(_.offset.committer == committer).flatMap(_.records)
+                  producerRecords =
+                    records.filter(_.offset.committer == committer).flatMap(_.records)
                   result <- producer.produce(producerRecords)
-                  _              <- producer.sendOffsetsToTransaction(offsets, metadata)
+                  _      <- producer.sendOffsetsToTransaction(offsets, metadata)
                 } yield result
               }
             }

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -7,21 +7,13 @@
 package fs2.kafka
 
 import scala.annotation.nowarn
-import scala.concurrent.Promise
-
-import cats.effect.syntax.all.*
 import cats.effect.Async
-import cats.effect.Outcome
-import cats.effect.Resource
 import cats.syntax.all.*
+import cats.effect.Resource
 import cats.Parallel
-import fs2.kafka.internal.*
-import fs2.kafka.internal.converters.collection.*
 import fs2.kafka.producer.MkProducer
 import fs2.Chunk
 import fs2.Stream
-
-import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.Metric
 import org.apache.kafka.common.MetricName
 
@@ -83,106 +75,49 @@ object TransactionalKafkaProducer {
     F: Async[F],
     mk: MkProducer[F],
     p: Parallel[F]
-  ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
-    (
-      settings.producerSettings.keySerializer,
-      settings.producerSettings.valueSerializer,
-      WithTransactionalProducer(mk, settings)
-    ).mapN { (keySerializer, valueSerializer, withProducer) =>
-      new TransactionalKafkaProducer[F, K, V] {
+  ): Resource[F, TransactionalKafkaProducer[F, K, V]] = {
+    for {
+      producer <- LowLevelKafkaProducer.resource[F, K, V](settings)(F, mk)
+    } yield new TransactionalKafkaProducer[F, K, V] {
 
-        override def produce(
-          records: TransactionalProducerRecords[F, K, V]
-        ): F[ProducerResult[K, V]] =
-          produceTransactionWithOffsets(records)
-
-        private[this] def produceTransactionWithOffsets(
-          records: Chunk[CommittableProducerRecords[F, K, V]]
-        ): F[Chunk[(ProducerRecord[K, V], RecordMetadata)]] =
-          if (records.isEmpty) F.pure(Chunk.empty)
-          else {
-            val batch   = CommittableOffsetBatch.fromFoldableMap(records)(_.offset)
-            val offsets = Chunk.from(batch.offsets.toVector)
-
-            offsets.parFlatTraverse { case (committer, offsets) =>
-              committer
-                .metadata
-                .flatMap { consumerGroupMetadata =>
-                  val sendOffsets: (KafkaByteProducer, Blocking[F]) => F[Unit] =
-                    (producer, blocking) =>
-                      blocking {
-                        producer.sendOffsetsToTransaction(
-                          offsets.asJava,
-                          consumerGroupMetadata
-                        )
-                      }
-
-                  val producerRecords: Chunk[ProducerRecord[K, V]] =
+      override def produce(r: TransactionalProducerRecords[F, K, V]): F[ProducerResult[K, V]] = {
+        val records: Chunk[CommittableProducerRecords[F, K, V]] = r
+        if (records.isEmpty) F.pure(Chunk.empty)
+        else {
+          val batch   = CommittableOffsetBatch.fromFoldableMap(records)(_.offset)
+          val offsets = Chunk.from(batch.offsets.toVector)
+          producer
+            .transaction
+            .use { _ =>
+              offsets.parFlatTraverse { case (committer, offsets) =>
+                for {
+                  metadata       <- committer.metadata
+                  _              <- producer.sendOffsetsToTransaction(offsets, metadata)
+                  producerRecords =
                     records.filter(_.offset.committer == committer).flatMap(_.records)
-
-                  produceTransaction(producerRecords, Some(sendOffsets))
-                }
+                  result <- producer.produce(producerRecords)
+                } yield result
+              }
             }
-          }
-
-        override def produceWithoutOffsets(
-          records: ProducerRecords[K, V]
-        ): F[ProducerResult[K, V]] =
-          produceTransaction(records, None)
-
-        private[this] def produceTransaction(
-          records: Chunk[ProducerRecord[K, V]],
-          sendOffsets: Option[(KafkaByteProducer, Blocking[F]) => F[Unit]]
-        ): F[Chunk[(ProducerRecord[K, V], RecordMetadata)]] =
-          withProducer.exclusiveAccess { (producer, blocking) =>
-            blocking(producer.beginTransaction()).bracketCase { _ =>
-              def produceRecords(produceRecordError: Option[Promise[Throwable]]) =
-                records
-                  .traverse(
-                    KafkaProducer.produceRecord(
-                      keySerializer,
-                      valueSerializer,
-                      producer,
-                      blocking,
-                      produceRecordError
-                    )
-                  )
-                  .flatMap(_.sequence)
-
-              val produce =
-                if (settings.producerSettings.failFastProduce)
-                  Async[F]
-                    .delay(Promise[Throwable]())
-                    .flatMap { produceRecordError =>
-                      Async[F]
-                        .race(
-                          Async[F].fromFutureCancelable(
-                            Async[F].delay((produceRecordError.future, Async[F].unit))
-                          ),
-                          produceRecords(produceRecordError.some)
-                        )
-                        .rethrow
-                    }
-                else
-                  produceRecords(None)
-
-              sendOffsets.fold(produce)(f => produce.flatTap(_ => f(producer, blocking)))
-            } {
-              case (_, Outcome.Succeeded(_)) =>
-                blocking(producer.commitTransaction())
-              case (_, Outcome.Canceled() | Outcome.Errored(_)) =>
-                blocking(producer.abortTransaction())
-            }
-          }
-
-        override def metrics: F[Map[MetricName, Metric]] =
-          withProducer.blocking(_.metrics().asScala.toMap)
-
-        override def toString: String =
-          "TransactionalKafkaProducer$" + System.identityHashCode(this)
-
+        }
       }
+
+      override def produceWithoutOffsets(
+        records: ProducerRecords[K, V]
+      ): F[ProducerResult[K, V]] =
+        producer
+          .transaction
+          .use { _ =>
+            producer.produce(records)
+          }
+
+      override def metrics: F[Map[MetricName, Metric]] = producer.metrics
+
+      override def toString: String =
+        "TransactionalKafkaProducer$" + System.identityHashCode(this)
+
     }
+  }
 
   /**
     * Creates a new [[TransactionalKafkaProducer]] in the `Stream` context, using the specified

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
@@ -8,22 +8,16 @@ package fs2.kafka.internal
 
 import cats.effect.{Async, MonadCancelThrow, Resource}
 import cats.effect.std.Semaphore
-import cats.implicits.*
+import cats.effect.syntax.all.*
 import fs2.kafka.{KafkaByteProducer, TransactionalProducerSettings}
 import fs2.kafka.internal.syntax.*
 import fs2.kafka.producer.MkProducer
 
 sealed abstract private[kafka] class WithTransactionalProducer[F[_]] {
 
-  def apply[A](f: (KafkaByteProducer, Blocking[F], ExclusiveAccess[F, A]) => F[A]): F[A]
-
-  def exclusiveAccess[A](f: (KafkaByteProducer, Blocking[F]) => F[A]): F[A] = apply {
-    case (producer, blocking, exclusive) => exclusive(f(producer, blocking))
-  }
-
-  def blocking[A](f: KafkaByteProducer => A): F[A] = apply { case (producer, blocking, _) =>
-    blocking(f(producer))
-  }
+  def blocking: Blocking[F]
+  def exclusiveAccess: Resource[F, Unit]
+  def producer: KafkaByteProducer
 
 }
 
@@ -34,50 +28,44 @@ private[kafka] object WithTransactionalProducer {
     settings: TransactionalProducerSettings[F, K, V]
   )(implicit
     F: Async[F]
-  ): Resource[F, WithTransactionalProducer[F]] =
-    Resource[F, WithTransactionalProducer[F]] {
-      (mk(settings.producerSettings), Semaphore(1))
-        .tupled
-        .flatMap { case (producer, semaphore) =>
-          val blocking = settings
-            .producerSettings
-            .customBlockingContext
-            .fold(Blocking.fromSync[F])(Blocking.fromExecutionContext)
-
-          val withProducer = create(producer, blocking, semaphore)
-
-          val initTransactions = withProducer.blocking(_.initTransactions())
-
-          /*
-          Deliberately does not use the exclusive access functionality to close the producer. The close method on
-          the underlying client waits until the buffer has been flushed to the broker or the timeout is exceeded.
-          Because the transactional producer _always_ waits until the buffer is flushed and the transaction
-          committed on the broker before proceeding, upon gaining exclusive access to the producer the buffer will
-          always be empty. Therefore if we used exclusive access to close the underlying producer, the buffer
-          would already be empty and the close timeout setting would be redundant.
-
-          TLDR: not using exclusive access here preserves the behaviour of the underlying close method and timeout
-          setting
-           */
-          val close = withProducer.blocking {
-            _.close(settings.producerSettings.closeTimeout.toJava)
-          }
-
-          initTransactions.as((withProducer, close))
-        }
-    }
+  ): Resource[F, WithTransactionalProducer[F]] = {
+    /*
+     * Deliberately does not use the exclusive access functionality to close the producer. The close method on
+     * the underlying client waits until the buffer has been flushed to the broker or the timeout is exceeded.
+     * Because the transactional producer _always_ waits until the buffer is flushed and the transaction
+     * committed on the broker before proceeding, upon gaining exclusive access to the producer the buffer will
+     * always be empty. Therefore if we used exclusive access to close the underlying producer, the buffer
+     * would already be empty and the close timeout setting would be redundant.
+     *
+     * TLDR: not using exclusive access here preserves the behaviour of the underlying close method and timeout
+     * setting
+     */
+    for {
+      producer  <- mk(settings.producerSettings).toResource
+      semaphore <- Semaphore(1).toResource
+      blocking   = settings
+                   .producerSettings
+                   .customBlockingContext
+                   .fold(Blocking.fromSync[F])(Blocking.fromExecutionContext)
+      _           <- blocking(producer.initTransactions()).toResource
+      withProducer = create(producer, blocking, semaphore)
+      close        = blocking(producer.close(settings.producerSettings.closeTimeout.toJava))
+      _           <- Resource.onFinalize(close)
+    } yield withProducer
+  }
 
   private def create[F[_]: MonadCancelThrow](
-    producer: KafkaByteProducer,
+    _producer: KafkaByteProducer,
     _blocking: Blocking[F],
     transactionSemaphore: Semaphore[F]
   ): WithTransactionalProducer[F] = new WithTransactionalProducer[F] {
 
-    override def apply[A](
-      f: (KafkaByteProducer, Blocking[F], ExclusiveAccess[F, A]) => F[A]
-    ): F[A] =
-      f(producer, _blocking, transactionSemaphore.permit.surround)
 
+    override def blocking: Blocking[F] = _blocking
+
+    override def exclusiveAccess: Resource[F, Unit] = Resource.make(transactionSemaphore.acquire)(_ => transactionSemaphore.release)
+
+    override def producer: KafkaByteProducer = _producer
   }
 
 }

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
@@ -59,10 +59,10 @@ private[kafka] object WithTransactionalProducer {
     transactionSemaphore: Semaphore[F]
   ): WithTransactionalProducer[F] = new WithTransactionalProducer[F] {
 
-
     override def blocking: Blocking[F] = _blocking
 
-    override def exclusiveAccess: Resource[F, Unit] = Resource.make(transactionSemaphore.acquire)(_ => transactionSemaphore.release)
+    override def exclusiveAccess: Resource[F, Unit] =
+      Resource.make(transactionSemaphore.acquire)(_ => transactionSemaphore.release)
 
     override def producer: KafkaByteProducer = _producer
   }

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithTransactionalProducer.scala
@@ -47,7 +47,6 @@ private[kafka] object WithTransactionalProducer {
                    .producerSettings
                    .customBlockingContext
                    .fold(Blocking.fromSync[F])(Blocking.fromExecutionContext)
-      _           <- blocking(producer.initTransactions()).toResource
       withProducer = create(producer, blocking, semaphore)
       close        = blocking(producer.close(settings.producerSettings.closeTimeout.toJava))
       _           <- Resource.onFinalize(close)

--- a/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -6,21 +6,53 @@
 
 package fs2.kafka
 
+import java.time
+
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+
 import cats.effect.{IO, SyncIO}
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
+import fs2.{Chunk, Stream}
 
-import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry, NewPartitions, NewTopic}
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.clients.admin.{
+  AlterConfigOp,
+  ConfigEntry,
+  FeatureUpdate,
+  MemberToRemove,
+  NewPartitionReassignment,
+  NewPartitions,
+  NewTopic,
+  OffsetSpec,
+  RecordsToDelete
+}
+import org.apache.kafka.clients.consumer.{ConsumerConfig, OffsetAndMetadata}
 import org.apache.kafka.common.acl.*
 import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.errors.{
+  ElectionNotNeededException,
+  LogDirNotFoundException,
+  ProducerFencedException,
+  UnsupportedByAuthenticationException
+}
+import org.apache.kafka.common.quota.{
+  ClientQuotaAlteration,
+  ClientQuotaEntity,
+  ClientQuotaFilter,
+  ClientQuotaFilterComponent
+}
 import org.apache.kafka.common.resource.{
   PatternType,
   ResourcePattern,
   ResourcePatternFilter,
   ResourceType
 }
+import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.apache.kafka.common.ElectionType
+import org.apache.kafka.common.IsolationLevel
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.TopicPartitionReplica
 
 final class KafkaAdminClientSpec extends BaseKafkaSpec {
 
@@ -156,28 +188,26 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
     it("should support config-related functionalities") {
       withTopic { topic =>
         commonSetup(topic)
-
         KafkaAdminClient
           .resource[IO](adminClientSettings)
           .use { adminClient =>
             for {
-              cr             <- IO.pure(new ConfigResource(ConfigResource.Type.TOPIC, topic))
-              ce              = new ConfigEntry("cleanup.policy", "delete")
-              alteredConfigs <- adminClient
-                                  .alterConfigs {
-                                    Map(cr -> List(new AlterConfigOp(ce, AlterConfigOp.OpType.SET)))
-                                  }
-                                  .attempt
-              _                <- IO(assert(alteredConfigs.isRight))
-              describedConfigs <- adminClient.describeConfigs(List(cr))
-              _                <- IO(
-                     assert(
-                       describedConfigs(cr).exists(actual =>
-                         actual.name == ce.name && actual.value == ce.value
-                       )
-                     )
-                   )
-            } yield ()
+              cr                    <- IO.pure(new ConfigResource(ConfigResource.Type.TOPIC, topic))
+              delete                 = new ConfigEntry("cleanup.policy", "delete")
+              compact                = new ConfigEntry("cleanup.policy", "compact")
+              invalid                = new ConfigEntry("cleanup.policy", "foo")
+              setDelete              = Map(cr -> List(new AlterConfigOp(delete, AlterConfigOp.OpType.SET)))
+              setCompact             = Map(cr -> List(new AlterConfigOp(compact, AlterConfigOp.OpType.SET)))
+              _                     <- adminClient.alterConfigs[List](setDelete)
+              describeAfterSet      <- adminClient.describeConfigs(List(cr))
+              _                     <- adminClient.alterConfigs[List](setCompact, validateOnly = true)
+              describeAfterValidate <- adminClient.describeConfigs(List(cr))
+            } yield {
+              describeAfterSet(cr).exists(actual =>
+                actual.name == delete.name && actual.value == delete.value
+              )
+              assert(describeAfterSet.get(cr) == describeAfterValidate.get(cr))
+            }
           }
           .unsafeRunSync()
       }
@@ -296,6 +326,356 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
       }
     }
 
+    it("should support log directory-related functionality") {
+      withTopic { topic =>
+        commonSetup(topic)
+
+        KafkaAdminClient
+          .resource[IO](adminClientSettings)
+          .use { adminClient =>
+            for {
+              nodes       <- adminClient.describeCluster.nodes
+              brokerId    <- IO(nodes.head.id)
+              logDirs     <- adminClient.describeLogDirs(List(brokerId))
+              _           <- IO(assert(logDirs.nonEmpty))
+              _           <- IO(assert(logDirs.get(brokerId).exists(_.nonEmpty)))
+              replica      = new TopicPartitionReplica(topic, 0, brokerId)
+              replicaDirs <- adminClient.describeReplicaLogDirs(List(replica))
+              _           <- IO(assert(replicaDirs.contains(replica)))
+              alterDirs   <-
+                adminClient.alterReplicaLogDirs(Map(replica -> "/nonexistent-log-dir")).attempt
+            } yield {
+              alterDirs match {
+                case Left(_: LogDirNotFoundException) => succeed
+                case other                            =>
+                  fail(s"expected alterReplicaLogDirs to fail for invalid log directory but got: $other")
+              }
+            }
+          }
+          .unsafeRunSync()
+      }
+    }
+
+    it("should support listOffsets and deleteRecords") {
+      withKafkaConsumer(defaultConsumerProperties) { consumer =>
+        withTopic { topic =>
+          commonSetup(topic)
+          KafkaAdminClient
+            .resource[IO](adminClientSettings)
+            .use { adminClient =>
+              val tp = new TopicPartition(topic, 0)
+              for {
+                offsets <- adminClient.listOffsets(
+                             Map(tp -> OffsetSpec.latest()),
+                             IsolationLevel.READ_COMMITTED
+                           )
+                _            <- IO(assert(offsets(tp).offset() > 0L))
+                _             = println(offsets(tp).offset())
+                beforeDelete <-
+                  IO.blocking(consumer.beginningOffsets(List(tp).asJava)).map(_.asScala)
+                _ <- adminClient.deleteRecords(
+                       Map(tp -> RecordsToDelete.beforeOffset(offsets(tp).offset()))
+                     )
+                afterDelete <-
+                  IO.blocking(consumer.beginningOffsets(List(tp).asJava)).map(_.asScala)
+              } yield assert(beforeDelete(tp) < afterDelete(tp))
+            }
+            .unsafeRunSync()
+        }
+      }
+
+    }
+
+    it("should support partition reassignment-related functionality") {
+      withTopic { topic =>
+        commonSetup(topic)
+        KafkaAdminClient
+          .resource[IO](adminClientSettings)
+          .use { adminClient =>
+            val tp = new TopicPartition(topic, 0)
+            for {
+              nodes         <- adminClient.describeCluster.nodes
+              brokerId      <- IO(nodes.head.id)
+              all           <- adminClient.listPartitionReassignments(None)
+              filtered      <- adminClient.listPartitionReassignments(Some(Set(tp)))
+              _             <- IO(assert(all == Map.empty))
+              _             <- IO(assert(filtered == Map.empty))
+              targetReplicas = new NewPartitionReassignment(List(Integer.valueOf(brokerId)).asJava)
+              _             <- adminClient.alterPartitionReassignments(Map(tp -> Some(targetReplicas)))
+            } yield ()
+          }
+          .unsafeRunSync()
+      }
+    }
+
+    it("should support quotas, features, SCRAM, metadata quorum, and config resource listing") {
+      withTopic { topic =>
+        commonSetup(topic)
+        KafkaAdminClient
+          .resource[IO](adminClientSettings)
+          .use { adminClient =>
+            val qClientId = s"fs2-kafka-quota-$topic"
+            val byteRate  = 1048576.0
+            // User + client-id matches PLAINTEXT / StandardAuthorizer.
+            val quotaMap = Map(
+              ClientQuotaEntity.USER      -> "User:ANONYMOUS",
+              ClientQuotaEntity.CLIENT_ID -> qClientId
+            ).asJava
+            val metaFeature     = "metadata.version"
+            val quotaEntity     = new ClientQuotaEntity(quotaMap)
+            val quotaOp         = new ClientQuotaAlteration.Op("producer_byte_rate", byteRate)
+            val quotaAlteration = new ClientQuotaAlteration(quotaEntity, List(quotaOp).asJava)
+            val quotaFilter     =
+              ClientQuotaFilterComponent.ofEntity(ClientQuotaEntity.CLIENT_ID, qClientId)
+            val describeFilter = ClientQuotaFilter.contains(List(quotaFilter).asJava)
+            for {
+              _ <- adminClient.alterClientQuotas(List(quotaAlteration))
+              _ <- Stream
+                     .awakeEvery[IO](500.millis)
+                     .evalMap(_ => adminClient.describeClientQuotas(describeFilter))
+                     .map(_.get(quotaEntity).flatMap(_.get("producer_byte_rate")))
+                     .collect { case Some(quota) => quota }
+                     .filter(_ == byteRate)
+                     .take(1)
+                     .interruptAfter(30.seconds)
+                     .compile
+                     .drain
+              _       <- adminClient.describeUserScramCredentials(None) // no assertion other than we can make the call
+              feature <-
+                adminClient.describeFeatures().map(_.supportedFeatures().asScala(metaFeature))
+              update     = new FeatureUpdate(feature.maxVersion(), FeatureUpdate.UpgradeType.UPGRADE)
+              _         <- adminClient.updateFeatures(Map(metaFeature -> update), true)
+              quorum    <- adminClient.describeMetadataQuorum()
+              _         <- IO(assert(quorum.leaderId() >= 0))
+              resources <- adminClient.listConfigResources()
+              _         <- IO(assert(resources.nonEmpty))
+            } yield ()
+          }
+          .unsafeRunSync()
+      }
+    }
+
+    it("should support delegation token-related functionality") {
+      withTopic { topic =>
+        commonSetup(topic)
+
+        val renewers  = List(KafkaPrincipal.ANONYMOUS)
+        val maxLifeMs = Some(1.hour)
+        val badHmac   = Array[Byte](0)
+        KafkaAdminClient
+          .resource[IO](adminClientSettings)
+          .use { adminClient =>
+            // token renewal mechanics require SSL to be created and managed.
+            // To avoid the need for SSL, we will assert that the call fails with an UnsupportedByAuthenticationException meaning it was done
+            for {
+              createResult <-
+                adminClient.createDelegationToken(renewers, owner = None, maxLifeMs).attempt
+              renewResult  <- adminClient.renewDelegationToken(badHmac, None).attempt
+              expireResult <- adminClient.expireDelegationToken(badHmac, None).attempt
+            } yield {
+              createResult match {
+                case Left(e: UnsupportedByAuthenticationException) => succeed
+                case other                                         => fail(s"expected createDelegationToken to fail but got: $other")
+              }
+              renewResult match {
+                case Left(e: UnsupportedByAuthenticationException) => succeed
+                case other                                         => fail(s"expected createDelegationToken to fail but got: $other")
+              }
+              expireResult match {
+                case Left(e: UnsupportedByAuthenticationException) => succeed
+                case other                                         => fail(s"expected createDelegationToken to fail but got: $other")
+              }
+            }
+          }
+          .unsafeRunSync()
+      }
+    }
+
+    it("should support removeMembersFromConsumerGroup") {
+      val groupID    = defaultConsumerProperties(ConsumerConfig.GROUP_ID_CONFIG)
+      val instanceID = "my-instance-id"
+      withKafkaConsumer(
+        defaultConsumerProperties + (ConsumerConfig.GROUP_INSTANCE_ID_CONFIG -> instanceID)
+      ) { consumer =>
+        withTopic { topic =>
+          commonSetup(topic)
+          KafkaAdminClient
+            .resource[IO](adminClientSettings)
+            .use { adminClient =>
+              for {
+                _            <- IO.blocking(consumer.subscribe(topic.pure[List].asJava))
+                _            <- IO.blocking(consumer.poll(time.Duration.ofMillis(100)))
+                groupMembers <-
+                  adminClient.describeConsumerGroups(List(groupID)).map(_(groupID)).map(_.members())
+                toRemove = groupMembers.asScala.map(member => new MemberToRemove(instanceID)).toList
+                _       <-
+                  adminClient.removeMembersFromConsumerGroup[List](groupID, toRemove, reason = None)
+              } yield ()
+            }
+            .unsafeRunSync()
+        }
+      }
+    }
+
+    it("should support transaction and producer state-related functionality") {
+      val transactionID = "some-random-tx-id"
+      withTopic { topic =>
+        commonSetup(topic)
+        val tp = new TopicPartition(topic, 0)
+        (for {
+          producer <- LowLevelKafkaProducer.resource[IO, Unit, Unit](
+                        TransactionalProducerSettings(
+                          transactionID,
+                          ProducerSettings[IO, Unit, Unit].withProperties(defaultConsumerProperties)
+                        )
+                      )
+          adminClient <- KafkaAdminClient.resource[IO](adminClientSettings)
+          _           <- producer.transaction // start transaction so that it can be managed
+          _           <- producer             // we are forced to produce in order for the transaction to become visble
+                 .produce(
+                   Chunk.singleton(ProducerRecord(tp.topic(), (), ()).withPartition(tp.partition()))
+                 )
+                 .toResource
+        } yield (producer, adminClient))
+          .use { case (producer, adminClient) =>
+            for {
+              listed       <- adminClient.listTransactions(None, None, None)
+              _            <- IO(assert(listed.exists(_.transactionalId() == transactionID)))
+              myTx          = listed.find(_.transactionalId() == transactionID).get
+              filteredList <- adminClient.listTransactions(
+                                Set(myTx.state()).some,
+                                Set(myTx.producerId()).some,
+                                0L.some
+                              )
+              _         <- IO(assert(filteredList.exists(_.transactionalId() == transactionID)))
+              described <- adminClient.describeTransactions[List](transactionID.pure[List])
+              _         <- IO(assert(described.contains(transactionID)))
+              producers <- adminClient.describeProducers(tp.some, none)
+              _         <- IO(assert(producers.size == 1))
+              _         <- adminClient.fenceProducers[List](myTx.transactionalId().pure[List])
+            } yield ()
+          }
+          .attempt
+          .flatMap {
+            // the resource will be deallocated.
+            // When it does it attempts to commit the transaction but since the producer was fenced it should fail
+            // We assert that the failure does happen.
+            case Left(_: ProducerFencedException) => succeed.pure[IO]
+            case _                                => IO(fail("expected ProducerFencedException when deallocating transaction"))
+          }
+          .unsafeRunSync()
+      }
+    }
+
+    it("should support aborting an ongoing transaction") {
+      // Transaction cancelation through the admin client is non trivial to test.
+      // An initial attempt was done using the list transactions followed by an assertion on the state change but
+      // as far as I was able to investigate, the state won't really reflect the aborted state. (it moves to CompleteCommit)
+
+      // A new approach was therefore needed. This test asserts that when the admin client aborts a transaction, the
+      // sent records are indeed not committed.
+
+      // We assert that by subsequntly producing records and asserting that the aborted ones are not visible while the ones
+      // produced afterwards are.
+      val transactionID = "some-random-tx-id"
+      withKafkaConsumer(
+        defaultConsumerProperties + (ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+      ) { consumer =>
+        withTopic { topic =>
+          commonSetup(topic)
+          val tp = new TopicPartition(topic, 0)
+          (for {
+            producer <-
+              LowLevelKafkaProducer.resource[IO, String, String](
+                TransactionalProducerSettings(
+                  transactionID,
+                  ProducerSettings[IO, String, String].withProperties(defaultConsumerProperties)
+                )
+              )
+            adminClient <- KafkaAdminClient.resource[IO](adminClientSettings)
+          } yield (producer, adminClient))
+            .use { case (producer, adminClient) =>
+              for {
+                _ <- producer
+                       .transaction
+                       .use { _ =>
+                         for {
+                           _ <- producer.produce(
+                                  Chunk.singleton(
+                                    ProducerRecord(
+                                      tp.topic(),
+                                      "records01-aborted-tx",
+                                      "records01-aborted-tx"
+                                    ).withPartition(tp.partition())
+                                  )
+                                )
+                           producers <- adminClient.describeProducers(tp.some, none)
+                           myProducer = producers.headOption.get._2.activeProducers().asScala.head
+                           _         <- adminClient.abortTransaction(
+                                  tp,
+                                  myProducer.producerId(),
+                                  myProducer.producerEpoch().toShort,
+                                  myProducer.coordinatorEpoch().orElse(-1)
+                                )
+                         } yield ()
+                       }
+                _ <-
+                  producer
+                    .transaction
+                    .use { _ =>
+                      producer.produce(
+                        Chunk.singleton(
+                          ProducerRecord(tp.topic(), "records02-success-tx", "records02-success-tx")
+                            .withPartition(
+                              tp.partition()
+                            )
+                        )
+                      )
+                    }
+                _        <- IO.blocking(consumer.assign(List(tp).asJava))
+                elements <-
+                  Stream
+                    .repeatEval(IO.blocking(consumer.poll(java.time.Duration.ofMillis(2000))))
+                    .map(_.asScala.toList.map(_.key()).map(new String(_)))
+                    .evalTap(IO.println)
+                    .takeWhile(x => !x.exists(_ == "records02-success-tx"), true)
+                    .flatMap(Stream.emits)
+                    .compile
+                    .toList
+              } yield assert(!elements.exists(_ == "records01-aborted-tx"))
+            }
+            .unsafeRunSync()
+        }
+      }
+    }
+
+    it("should support electLeaders") {
+      withTopic { topic =>
+        commonSetup(topic)
+
+        KafkaAdminClient
+          .resource[IO](adminClientSettings)
+          .use { adminClient =>
+            val tp = new TopicPartition(topic, 0)
+            for {
+              elected <- adminClient.electLeaders(ElectionType.PREFERRED, Set(tp)).attempt
+              _       <- IO {
+                     elected match {
+                       case Left(e: ElectionNotNeededException) =>
+                         assert(
+                           Option(e.getMessage).exists(msg =>
+                             msg.contains("not needed") || msg.contains("election")
+                           )
+                         )
+                       case other => fail(s"expected specific failure but got: $other")
+                     }
+                   }
+            } yield ()
+          }
+          .unsafeRunSync()
+      }
+    }
+
     it("should support misc defined functionality") {
       withTopic { topic =>
         commonSetup(topic)
@@ -311,6 +691,21 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
           }
           .unsafeRunSync()
       }
+    }
+  }
+
+  it("should support metrics") {
+    withTopic { topic =>
+      commonSetup(topic)
+      KafkaAdminClient
+        .resource[IO](adminClientSettings)
+        .use { adminClient =>
+          for {
+            metrics <- adminClient.metrics()
+            _       <- IO(assert(metrics.nonEmpty))
+          } yield println(metrics)
+        }
+        .unsafeRunSync()
     }
   }
 

--- a/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -505,9 +505,16 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
                 _            <- IO.blocking(consumer.poll(time.Duration.ofMillis(100)))
                 groupMembers <-
                   adminClient.describeConsumerGroups(List(groupID)).map(_(groupID)).map(_.members())
-                toRemove = groupMembers.asScala.map(_ => new MemberToRemove(instanceID)).toList
-                _       <-
+                toRemove = groupMembers
+                             .asScala
+                             .map(member => new MemberToRemove(member.groupInstanceId().get))
+                             .toList
+                _ <- IO.delay(assert(groupMembers.size == 1))
+                _ <-
                   adminClient.removeMembersFromConsumerGroup[List](groupID, toRemove, reason = None)
+                groupMembersAfter <-
+                  adminClient.describeConsumerGroups(List(groupID)).map(_(groupID)).map(_.members())
+                _ <- IO.delay(assert(groupMembersAfter.isEmpty))
               } yield ()
             }
             .unsafeRunSync()

--- a/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -9,12 +9,12 @@ package fs2.kafka
 import java.time
 
 import scala.concurrent.duration.*
-import scala.jdk.CollectionConverters.*
 
 import cats.effect.{IO, SyncIO}
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import fs2.{Chunk, Stream}
+import fs2.kafka.internal.converters.collection.*
 
 import org.apache.kafka.clients.admin.{
   AlterConfigOp,
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.admin.{
   RecordsToDelete
 }
 import org.apache.kafka.clients.consumer.{ConsumerConfig, OffsetAndMetadata}
+import org.apache.kafka.common.{IsolationLevel => KafkaIsolationLevel}
 import org.apache.kafka.common.acl.*
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors.{
@@ -50,7 +51,6 @@ import org.apache.kafka.common.resource.{
 }
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.ElectionType
-import org.apache.kafka.common.IsolationLevel
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.TopicPartitionReplica
 
@@ -195,7 +195,6 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
               cr                    <- IO.pure(new ConfigResource(ConfigResource.Type.TOPIC, topic))
               delete                 = new ConfigEntry("cleanup.policy", "delete")
               compact                = new ConfigEntry("cleanup.policy", "compact")
-              invalid                = new ConfigEntry("cleanup.policy", "foo")
               setDelete              = Map(cr -> List(new AlterConfigOp(delete, AlterConfigOp.OpType.SET)))
               setCompact             = Map(cr -> List(new AlterConfigOp(compact, AlterConfigOp.OpType.SET)))
               _                     <- adminClient.alterConfigs[List](setDelete)
@@ -367,10 +366,9 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
               for {
                 offsets <- adminClient.listOffsets(
                              Map(tp -> OffsetSpec.latest()),
-                             IsolationLevel.READ_COMMITTED
+                             KafkaIsolationLevel.READ_COMMITTED
                            )
                 _            <- IO(assert(offsets(tp).offset() > 0L))
-                _             = println(offsets(tp).offset())
                 beforeDelete <-
                   IO.blocking(consumer.beginningOffsets(List(tp).asJava)).map(_.asScala)
                 _ <- adminClient.deleteRecords(
@@ -474,15 +472,15 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
               expireResult <- adminClient.expireDelegationToken(badHmac, None).attempt
             } yield {
               createResult match {
-                case Left(e: UnsupportedByAuthenticationException) => succeed
+                case Left(_: UnsupportedByAuthenticationException) => succeed
                 case other                                         => fail(s"expected createDelegationToken to fail but got: $other")
               }
               renewResult match {
-                case Left(e: UnsupportedByAuthenticationException) => succeed
+                case Left(_: UnsupportedByAuthenticationException) => succeed
                 case other                                         => fail(s"expected createDelegationToken to fail but got: $other")
               }
               expireResult match {
-                case Left(e: UnsupportedByAuthenticationException) => succeed
+                case Left(_: UnsupportedByAuthenticationException) => succeed
                 case other                                         => fail(s"expected createDelegationToken to fail but got: $other")
               }
             }
@@ -507,7 +505,7 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
                 _            <- IO.blocking(consumer.poll(time.Duration.ofMillis(100)))
                 groupMembers <-
                   adminClient.describeConsumerGroups(List(groupID)).map(_(groupID)).map(_.members())
-                toRemove = groupMembers.asScala.map(member => new MemberToRemove(instanceID)).toList
+                toRemove = groupMembers.asScala.map(_ => new MemberToRemove(instanceID)).toList
                 _       <-
                   adminClient.removeMembersFromConsumerGroup[List](groupID, toRemove, reason = None)
               } yield ()
@@ -537,7 +535,7 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
                  )
                  .toResource
         } yield (producer, adminClient))
-          .use { case (producer, adminClient) =>
+          .use { case (_, adminClient) =>
             for {
               listed       <- adminClient.listTransactions(None, None, None)
               _            <- IO(assert(listed.exists(_.transactionalId() == transactionID)))
@@ -637,9 +635,8 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
                   Stream
                     .repeatEval(IO.blocking(consumer.poll(java.time.Duration.ofMillis(2000))))
                     .map(_.asScala.toList.map(_.key()).map(new String(_)))
-                    .evalTap(IO.println)
                     .takeWhile(x => !x.exists(_ == "records02-success-tx"), true)
-                    .flatMap(Stream.emits)
+                    .flatMap(Stream.emits(_))
                     .compile
                     .toList
               } yield assert(!elements.exists(_ == "records01-aborted-tx"))
@@ -703,7 +700,7 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
           for {
             metrics <- adminClient.metrics()
             _       <- IO(assert(metrics.nonEmpty))
-          } yield println(metrics)
+          } yield ()
         }
         .unsafeRunSync()
     }


### PR DESCRIPTION
Changes: 

- **Admin client:** Added new methods on KafkaAdminClient that mirror the Java AdminClient 
- **Low-level producer:** Introduced LowLevelKafkaProducer to allow fine grain control over transaction open/closing
- **Transactional producer:** Refactored TransactionalKafkaProducer to delegate to LowLevelKafkaProducer, in order to avoid code duplication.

