### PR TITLE
Add otel4s-trace module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        scala: [2.12, 2.13, 3]
+        scala: [2.13]
         java: [temurin@21]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -57,10 +57,9 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck
 
-      - run: sbt '++ ${{ matrix.scala }}' ci
+      - run: sbt ci
 
-      - if: matrix.scala == '2.13'
-        run: sbt '++ ${{ matrix.scala }}' docs/run
+      - run: sbt docs/run
 
   publish:
     name: Publish Artifacts

--- a/build.sbt
+++ b/build.sbt
@@ -19,20 +19,35 @@ val scala3   = "3.3.7"
 
 ThisBuild / tlBaseVersion := "4.0"
 
+val allScalaVersions    = Seq(scala212, scala213, scala3)
+val otel4sScalaVersions = Seq(scala213, scala3)
+
+lazy val core213               = core.jvm(scala213)
+lazy val vulcan213             = vulcan.jvm(scala213)
+lazy val vulcanTestkitMunit213 = `vulcan-testkit-munit`.jvm(scala213)
+lazy val otel4sTrace213        = `otel4s-trace`.jvm(scala213)
+
+lazy val axesDefault = Seq(VirtualAxis.scalaABIVersion(scala213), VirtualAxis.jvm)
+
+lazy val projects =
+  core.projectRefs ++ vulcan.projectRefs ++ `vulcan-testkit-munit`.projectRefs ++
+    `otel4s-trace`.projectRefs
+
 lazy val root = project
   .in(file("."))
   .settings(
     noPublishSettings,
     scalaSettings,
     mimaPreviousArtifacts := Set.empty,
-    console               := (core / Compile / console).value,
-    Test / console        := (core / Test / console).value
+    console               := (core213 / Compile / console).value,
+    Test / console        := (core213 / Test / console).value
   )
   .enablePlugins(TypelevelMimaPlugin)
-  .aggregate(core, vulcan, `vulcan-testkit-munit`, `otel4s-trace`)
+  .aggregate(projects: _*)
 
-lazy val core = project
+lazy val core = projectMatrix
   .in(file("modules/core"))
+  .defaultAxes(axesDefault: _*)
   .settings(
     moduleName := "fs2-kafka",
     name       := moduleName.value,
@@ -48,13 +63,19 @@ lazy val core = project
         "org.typelevel"   %% "cats-kernel"        % catsVersion
       )
     ),
+    Test / scalacOptions ++= {
+      if (tlIsScala3.value) Seq("-language:implicitConversions")
+      else Seq.empty
+    },
     publishSettings,
     scalaSettings,
     testSettings
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val vulcan = project
+lazy val vulcan = projectMatrix
   .in(file("modules/vulcan"))
+  .defaultAxes(axesDefault: _*)
   .settings(
     moduleName := "fs2-kafka-vulcan",
     name       := moduleName.value,
@@ -74,10 +95,12 @@ lazy val vulcan = project
     scalaSettings,
     testSettings
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
   .dependsOn(core)
 
-lazy val `vulcan-testkit-munit` = project
+lazy val `vulcan-testkit-munit` = projectMatrix
   .in(file("modules/vulcan-testkit-munit"))
+  .defaultAxes(axesDefault: _*)
   .settings(
     moduleName := "fs2-kafka-vulcan-testkit-munit",
     name       := moduleName.value,
@@ -96,10 +119,12 @@ lazy val `vulcan-testkit-munit` = project
     testSettings,
     versionIntroduced("2.2.0")
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
   .dependsOn(vulcan)
 
-lazy val `otel4s-trace` = project
+lazy val `otel4s-trace` = projectMatrix
   .in(file("modules/otel4s-trace"))
+  .defaultAxes(axesDefault: _*)
   .settings(
     moduleName := "fs2-kafka-otel4s-trace",
     name       := moduleName.value,
@@ -116,13 +141,12 @@ lazy val `otel4s-trace` = project
     publishSettings,
     scalaSettings,
     testSettings,
-    scalaVersion       := scala213,
-    crossScalaVersions := Seq(scala213, scala3),
-    versionIntroduced("4.1.0"),
+    versionIntroduced("4.1.0", otel4sScalaVersions),
     buildInfoPackage := "fs2.kafka",
     buildInfoKeys    := Seq[BuildInfoKey](version),
     buildInfoOptions += BuildInfoOption.PackagePrivate
   )
+  .jvmPlatform(scalaVersions = otel4sScalaVersions)
   .dependsOn(core % "compile->compile;test->test")
   .enablePlugins(BuildInfoPlugin)
 
@@ -137,7 +161,7 @@ lazy val docs = project
     mdocSettings,
     buildInfoSettings
   )
-  .dependsOn(core, vulcan, `vulcan-testkit-munit`, `otel4s-trace`)
+  .dependsOn(core213, vulcan213, vulcanTestkitMunit213, otel4sTrace213)
   .enablePlugins(BuildInfoPlugin, DocusaurusPlugin, MdocPlugin, ScalaUnidocPlugin)
 
 lazy val dependencySettings = Seq(
@@ -179,7 +203,7 @@ lazy val mdocSettings = Seq(
   mdoc                                       := (Compile / run).evaluated,
   scalacOptions                             --= Seq("-Xfatal-warnings", "-Ywarn-unused"),
   crossScalaVersions                         := Seq(scala213),
-  ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(core, vulcan),
+  ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(core213, vulcan213),
   ScalaUnidoc / unidoc / target              := (LocalRootProject / baseDirectory)
     .value / "website" / "static" / "api",
   cleanFiles           += (ScalaUnidoc / unidoc / target).value,
@@ -213,31 +237,27 @@ lazy val buildInfoSettings = Seq(
     BuildInfoKey.map(ThisBuild / version) { case (_, v) =>
       "latestSnapshotVersion" -> v
     },
-    BuildInfoKey.map(core / moduleName) { case (k, v) =>
+    BuildInfoKey.map(core213 / moduleName) { case (k, v) =>
       "core" ++ k.capitalize -> v
     },
-    BuildInfoKey.map(core / crossScalaVersions) { case (k, v) =>
-      "core" ++ k.capitalize -> v
-    },
-    BuildInfoKey.map(vulcan / moduleName) { case (k, v) =>
+    BuildInfoKey("coreCrossScalaVersions" -> allScalaVersions),
+    BuildInfoKey.map(vulcan213 / moduleName) { case (k, v) =>
       "vulcan" ++ k.capitalize -> v
     },
-    BuildInfoKey.map(vulcan / crossScalaVersions) { case (k, v) =>
-      "vulcan" ++ k.capitalize -> v
-    },
-    BuildInfoKey.map(`vulcan-testkit-munit` / moduleName) { case (k, v) =>
+    BuildInfoKey("vulcanCrossScalaVersions" -> allScalaVersions),
+    BuildInfoKey.map(vulcanTestkitMunit213 / moduleName) { case (k, v) =>
       "vulcanTestkitMunit" ++ k.capitalize -> v
     },
-    BuildInfoKey.map(`otel4s-trace` / moduleName) { case (k, v) =>
+    BuildInfoKey.map(otel4sTrace213 / moduleName) { case (k, v) =>
       "otel4s" ++ k.capitalize -> v
     },
     LocalRootProject / organization,
-    core / crossScalaVersions,
-    BuildInfoKey("fs2Version"       -> fs2Version),
-    BuildInfoKey("kafkaVersion"     -> kafkaVersion),
-    BuildInfoKey("vulcanVersion"    -> vulcanVersion),
-    BuildInfoKey("confluentVersion" -> confluentVersion),
-    BuildInfoKey("otel4sVersion"    -> otel4sVersion)
+    BuildInfoKey("crossScalaVersions" -> allScalaVersions),
+    BuildInfoKey("fs2Version"         -> fs2Version),
+    BuildInfoKey("kafkaVersion"       -> kafkaVersion),
+    BuildInfoKey("vulcanVersion"      -> vulcanVersion),
+    BuildInfoKey("confluentVersion"   -> confluentVersion),
+    BuildInfoKey("otel4sVersion"      -> otel4sVersion)
   )
 )
 
@@ -246,11 +266,8 @@ lazy val metadataSettings = Seq(
 )
 
 ThisBuild / githubWorkflowBuild := Seq(
-  WorkflowStep.Sbt(List("ci")),
-  WorkflowStep.Sbt(
-    List("docs/run"),
-    cond = Some(s"matrix.scala == '2.13'")
-  )
+  WorkflowStep.Run(List("sbt ci")),
+  WorkflowStep.Run(List("sbt docs/run"))
 )
 
 ThisBuild / githubWorkflowArtifactUpload := false
@@ -311,8 +328,7 @@ lazy val noPublishSettings =
     publishArtifact := false
   )
 
-ThisBuild / scalaVersion       := scala213
-ThisBuild / crossScalaVersions := Seq(scala212, scala213, scala3)
+ThisBuild / scalaVersion := scala213
 
 lazy val scalaSettings = Seq(
   Compile / doc / scalacOptions      += "-nowarn", // workaround for https://github.com/scala/bug/issues/12007 but also suppresses genunine problems
@@ -324,14 +340,18 @@ lazy val scalaSettings = Seq(
     if (tlIsScala3.value) Seq.empty else Seq("-Xsource:3")
   },
   Test / console / scalacOptions        := (Compile / console / scalacOptions).value,
-  Compile / unmanagedSourceDirectories ++=
+  Compile / unmanagedSourceDirectories ++= {
+    val projectBase =
+      projectMatrixBaseDirectory.?.value.getOrElse(baseDirectory.value).getAbsoluteFile
+
     Seq(
-      baseDirectory.value / "src" / "main" / {
+      projectBase / "src" / "main" / {
         if (scalaVersion.value.startsWith("2.12"))
           "scala-2.12"
         else "scala-2.13+"
       }
-    ),
+    )
+  },
   Test / fork := true
 )
 
@@ -362,11 +382,11 @@ ThisBuild / updateSiteVariables := {
   val variables =
     Map[String, String](
       "organization"          -> (LocalRootProject / organization).value,
-      "coreModuleName"        -> (core / moduleName).value,
-      "otel4sTraceModuleName" -> (`otel4s-trace` / moduleName).value,
+      "coreModuleName"        -> (core213 / moduleName).value,
+      "otel4sTraceModuleName" -> (otel4sTrace213 / moduleName).value,
       "latestVersion"         -> latestVersion.value,
       "scalaPublishVersions"  -> {
-        val minorVersions = (core / crossScalaVersions).value.map(minorVersion)
+        val minorVersions = allScalaVersions.map(minorVersion)
         if (minorVersions.size <= 2) minorVersions.mkString(" and ")
         else minorVersions.init.mkString(", ") ++ " and " ++ minorVersions.last
       }
@@ -385,8 +405,8 @@ ThisBuild / updateSiteVariables := {
   IO.write(file, fileContents)
 }
 
-def versionIntroduced(v: String) = Seq(
-  tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> v).toMap
+def versionIntroduced(v: String, scalaVersions: Seq[String] = allScalaVersions) = Seq(
+  tlVersionIntroduced := scalaVersions.map(minorVersion).map(_ -> v).toMap
 )
 
 def addCommandsAlias(name: String, values: List[String]) =
@@ -395,13 +415,13 @@ def addCommandsAlias(name: String, values: List[String]) =
 addCommandsAlias(
   "validate",
   List(
-    "+clean",
-    "+test",
-    "+mimaReportBinaryIssues",
-    "+scalafmtCheck",
+    "clean",
+    "test",
+    "mimaReportBinaryIssues",
+    "scalafmtCheckAll",
     "scalafmtSbtCheck",
-    "+headerCheck",
-    "+doc",
+    "headerCheckAll",
+    "doc",
     "docs/run"
   )
 )
@@ -412,9 +432,9 @@ addCommandsAlias(
     "clean",
     "test",
     "mimaReportBinaryIssues",
-    "scalafmtCheck",
+    "scalafmtCheckAll",
     "scalafmtSbtCheck",
-    "headerCheck",
+    "headerCheckAll",
     "doc"
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ val fs2Version                 = "3.13.0"
 val kafkaVersion               = "4.2.0"
 val logbackVersion             = "1.5.32"
 val munitVersion               = "1.3.0"
+val munitCatsEffectVersion     = "2.2.0"
+val otel4sVersion              = "1.0.0-RC1"
 val slf4jVersion               = "1.7.36"
 val testcontainersScalaVersion = "0.44.1"
 val vulcanVersion              = "1.13.0"
@@ -27,7 +29,7 @@ lazy val root = project
     Test / console        := (core / Test / console).value
   )
   .enablePlugins(TypelevelMimaPlugin)
-  .aggregate(core, vulcan, `vulcan-testkit-munit`)
+  .aggregate(core, vulcan, `vulcan-testkit-munit`, `otel4s-trace`)
 
 lazy val core = project
   .in(file("modules/core"))
@@ -96,6 +98,34 @@ lazy val `vulcan-testkit-munit` = project
   )
   .dependsOn(vulcan)
 
+lazy val `otel4s-trace` = project
+  .in(file("modules/otel4s-trace"))
+  .settings(
+    moduleName := "fs2-kafka-otel4s-trace",
+    name       := moduleName.value,
+    dependencySettings ++ Seq(
+      libraryDependencies ++= Seq(
+        "org.typelevel" %% "otel4s-core-trace"           % otel4sVersion,
+        "org.typelevel" %% "otel4s-semconv"              % otel4sVersion,
+        "org.typelevel" %% "otel4s-oteljava-testkit"     % otel4sVersion          % Test,
+        "org.typelevel" %% "otel4s-semconv-experimental" % otel4sVersion          % Test,
+        "org.scalameta" %% "munit"                       % munitVersion           % Test,
+        "org.typelevel" %% "munit-cats-effect"           % munitCatsEffectVersion % Test
+      )
+    ),
+    publishSettings,
+    scalaSettings,
+    testSettings,
+    scalaVersion       := scala213,
+    crossScalaVersions := Seq(scala213, scala3),
+    versionIntroduced("4.1.0"),
+    buildInfoPackage := "fs2.kafka",
+    buildInfoKeys    := Seq[BuildInfoKey](version),
+    buildInfoOptions += BuildInfoOption.PackagePrivate
+  )
+  .dependsOn(core % "compile->compile;test->test")
+  .enablePlugins(BuildInfoPlugin)
+
 lazy val docs = project
   .in(file("docs"))
   .settings(
@@ -107,7 +137,7 @@ lazy val docs = project
     mdocSettings,
     buildInfoSettings
   )
-  .dependsOn(core, vulcan, `vulcan-testkit-munit`)
+  .dependsOn(core, vulcan, `vulcan-testkit-munit`, `otel4s-trace`)
   .enablePlugins(BuildInfoPlugin, DocusaurusPlugin, MdocPlugin, ScalaUnidocPlugin)
 
 lazy val dependencySettings = Seq(
@@ -198,12 +228,16 @@ lazy val buildInfoSettings = Seq(
     BuildInfoKey.map(`vulcan-testkit-munit` / moduleName) { case (k, v) =>
       "vulcanTestkitMunit" ++ k.capitalize -> v
     },
+    BuildInfoKey.map(`otel4s-trace` / moduleName) { case (k, v) =>
+      "otel4s" ++ k.capitalize -> v
+    },
     LocalRootProject / organization,
     core / crossScalaVersions,
     BuildInfoKey("fs2Version"       -> fs2Version),
     BuildInfoKey("kafkaVersion"     -> kafkaVersion),
     BuildInfoKey("vulcanVersion"    -> vulcanVersion),
-    BuildInfoKey("confluentVersion" -> confluentVersion)
+    BuildInfoKey("confluentVersion" -> confluentVersion),
+    BuildInfoKey("otel4sVersion"    -> otel4sVersion)
   )
 )
 
@@ -327,10 +361,11 @@ ThisBuild / updateSiteVariables := {
 
   val variables =
     Map[String, String](
-      "organization"         -> (LocalRootProject / organization).value,
-      "coreModuleName"       -> (core / moduleName).value,
-      "latestVersion"        -> latestVersion.value,
-      "scalaPublishVersions" -> {
+      "organization"          -> (LocalRootProject / organization).value,
+      "coreModuleName"        -> (core / moduleName).value,
+      "otel4sTraceModuleName" -> (`otel4s-trace` / moduleName).value,
+      "latestVersion"         -> latestVersion.value,
+      "scalaPublishVersions"  -> {
         val minorVersions = (core / crossScalaVersions).value.map(minorVersion)
         if (minorVersions.size <= 2) minorVersions.mkString(" and ")
         else minorVersions.init.mkString(", ") ++ " and " ++ minorVersions.last

--- a/build.sbt
+++ b/build.sbt
@@ -364,7 +364,8 @@ lazy val testSettings = Seq(
 def minorVersion(version: String): String = {
   val (major, minor) =
     CrossVersion.partialVersion(version).get
-  s"$major.$minor"
+  if (major == 3) "3"
+  else s"$major.$minor"
 }
 
 val latestVersion = settingKey[String]("Latest stable released version")

--- a/docs/src/main/mdoc/modules.md
+++ b/docs/src/main/mdoc/modules.md
@@ -30,7 +30,7 @@ The main entry points are:
 - `fs2.kafka.otel4s.trace.TracedKafkaConsumer`
 - `fs2.kafka.otel4s.trace.syntax._`
 
-See the dedicated [otel4s Trace](otel4s-trace.md) guide for usage, configuration, span semantics,
+See the dedicated [otel4s trace](otel4s-trace.md) guide for usage, configuration, span semantics,
 and caveats.
 
 ## Vulcan

--- a/docs/src/main/mdoc/modules.md
+++ b/docs/src/main/mdoc/modules.md
@@ -5,6 +5,34 @@ title: Modules
 
 The following sections describe the additional modules.
 
+## otel4s-trace
+
+The `@OTEL4S_TRACE_MODULE_NAME@` module adds tracing support for `fs2-kafka` using
+[otel4s](https://typelevel.org/otel4s).
+
+Add it to your project in `build.sbt`:
+
+```scala
+libraryDependencies += "org.typelevel" %% "@OTEL4S_TRACE_MODULE_NAME@" % "@LATEST_VERSION@"
+```
+
+This module is optional:
+
+- `core` does not depend on `otel4s`
+- tracing is explicit, not automatic instrumentation of `KafkaProducer` or `KafkaConsumer`
+- producer tracing models `send`
+- consumer tracing models `receive` and `process` as separate boundaries
+
+The main entry points are:
+
+- `fs2.kafka.otel4s.trace.KafkaTracer`
+- `fs2.kafka.otel4s.trace.TracedKafkaProducer`
+- `fs2.kafka.otel4s.trace.TracedKafkaConsumer`
+- `fs2.kafka.otel4s.trace.syntax._`
+
+See the dedicated [otel4s Trace](otel4s-trace.md) guide for usage, configuration, span semantics,
+and caveats.
+
 ## Vulcan
 
 The `@VULCAN_MODULE_NAME@` module provides [Avro](https://avro.apache.org) serialization support using [Vulcan](https://typelevel.org/vulcan).

--- a/docs/src/main/mdoc/otel4s-trace.md
+++ b/docs/src/main/mdoc/otel4s-trace.md
@@ -1,0 +1,257 @@
+---
+id: otel4s-trace
+title: OTel4s Trace
+---
+
+The `@OTEL4S_TRACE_MODULE_NAME@` module adds tracing support for `fs2-kafka` using
+[otel4s](https://typelevel.org/otel4s).
+
+Add it to your project in `build.sbt`:
+
+```scala
+libraryDependencies += "org.typelevel" %% "@OTEL4S_TRACE_MODULE_NAME@" % "@LATEST_VERSION@"
+```
+
+The following imports are assumed throughout this page.
+
+```scala mdoc:silent
+import cats.Parallel
+import cats.effect.{Async, Resource}
+import cats.syntax.all._
+import fs2.{Chunk, Stream}
+import fs2.kafka._
+import fs2.kafka.otel4s.trace._
+import fs2.kafka.otel4s.trace.syntax._
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.trace.TracerProvider
+```
+
+## Overview
+
+This module is explicit:
+
+- it does not auto-instrument `KafkaProducer` or `KafkaConsumer`
+- it does not trace message processing unless you mark that boundary yourself
+- producer and consumer tracing use different APIs
+
+It models three operations:
+
+- `send` for producer sends
+- `receive` for delivery of records to application code
+- `process` for handling an individual record
+
+## Basic Usage
+
+Create `KafkaTracer` from the ambient `TracerProvider`, then bind it to a producer or consumer.
+
+```scala mdoc:silent
+def bindProducer[F[_]: Async: Parallel: TracerProvider](
+  producer: KafkaProducer[F, String, String]
+): F[TracedKafkaProducer[F, String, String]] =
+  KafkaTracer.create[F](KafkaTracer.Config.default).map(_.producer(producer))
+
+def bindConsumer[F[_]: Async: Parallel: TracerProvider](
+  consumer: KafkaConsumer[F, String, String]
+): F[TracedKafkaConsumer[F, String, String]] =
+  KafkaTracer.create[F](KafkaTracer.Config.default).map(_.consumer(consumer))
+```
+
+Create the traced handle once per Kafka client and reuse it.
+
+The producer and consumer APIs are different:
+
+- `TracedKafkaProducer` is an explicit producer-side tracing handle
+- `TracedKafkaConsumer` is a consumer-bound tracing handle with explicit `receive` and `process`
+
+## Producer Usage
+
+Bind a traced producer once, then use the awaited send helpers.
+
+```scala mdoc:silent
+def tracedProducerResource[F[_]: Async: Parallel: TracerProvider](
+  settings: ProducerSettings[F, String, String]
+): Resource[F, TracedKafkaProducer[F, String, String]] =
+  for {
+    producer    <- KafkaProducer.resource(settings)
+    kafkaTracer <- Resource.eval(KafkaTracer.create[F](KafkaTracer.Config.default))
+  } yield kafkaTracer.producer(producer)
+
+def publishOne[F[_]: Async: Parallel: TracerProvider](
+  settings: ProducerSettings[F, String, String]
+): Resource[F, F[Unit]] =
+  tracedProducerResource(settings).map(
+    _.produceOneAwaited(ProducerRecord("topic", "key", "value")).void
+  )
+```
+
+The main producer operations are:
+
+- `injectHeaders` to propagate trace context without sending
+- `produceAwaited` to send a batch and await completion
+- `produceOneAwaited` to send one record and await completion
+- `produceTransactionally` and `produceAndCommitTransactionally` for transactional flows
+- `underlying` to access the original `KafkaProducer` when needed
+
+### Propagation Without Sending
+
+```scala mdoc:silent
+def prepareRecord[F[_]](
+  record: ProducerRecord[String, String]
+)(implicit tracedProducer: TracedKafkaProducer[F, String, String]): F[ProducerRecord[String, String]] =
+  tracedProducer.injectHeaders(record)
+```
+
+## Consumer Usage
+
+Consumer tracing is explicit because processing happens in application code.
+
+### `process` Only
+
+If you only want per-record spans, wrap the business logic with `process`.
+
+```scala mdoc:silent
+def consumeWithProcessOnly[F[_]: Async: Parallel: TracerProvider](
+  settings: ConsumerSettings[F, String, String]
+): Stream[F, Unit] =
+  for {
+    consumer    <- KafkaConsumer.stream(settings)
+    kafkaTracer <- Stream.eval(KafkaTracer.create[F](KafkaTracer.Config.default))
+    _           <- Stream.eval(consumer.subscribeTo("topic"))
+    tracedConsumer = kafkaTracer.consumer(consumer)
+    _ <- tracedConsumer.records.evalMap { record =>
+           tracedConsumer.process(record)(Async[F].unit)
+         }
+  } yield ()
+```
+
+### `receive` Then `process`
+
+Use `receive` when you want a delivery span separate from the processing span.
+
+```scala mdoc:silent
+def consumeWithExplicitReceive[F[_]: Async: Parallel: TracerProvider](
+  settings: ConsumerSettings[F, String, String]
+): Stream[F, Unit] =
+  for {
+    consumer    <- KafkaConsumer.stream(settings)
+    kafkaTracer <- Stream.eval(KafkaTracer.create[F](KafkaTracer.Config.default))
+    _           <- Stream.eval(consumer.subscribeTo("topic"))
+    tracedConsumer = kafkaTracer.consumer(consumer)
+    partition <- consumer.partitionedStream
+    _ <- partition.chunks.evalMap { chunk =>
+           tracedConsumer.receiveCommittable(chunk) {
+             chunk.traverse_(record => tracedConsumer.process(record)(Async[F].unit))
+           }
+         }
+  } yield ()
+```
+
+### `recordsWithProcess`
+
+For the common stream shape, use `recordsWithProcess`.
+
+```scala mdoc:silent
+def consumeWithHelper[F[_]: Async: Parallel: TracerProvider](
+  settings: ConsumerSettings[F, String, String]
+): Stream[F, Unit] =
+  for {
+    consumer    <- KafkaConsumer.stream(settings)
+    kafkaTracer <- Stream.eval(KafkaTracer.create[F](KafkaTracer.Config.default))
+    _           <- Stream.eval(consumer.subscribeTo("topic"))
+    tracedConsumer = kafkaTracer.consumer(consumer)
+    _ <- tracedConsumer.recordsWithProcess(_ => Async[F].unit)
+  } yield ()
+```
+
+`recordsWithProcess` does two things:
+
+- `receive` covers handoff of a delivered chunk to application code
+- `process` covers the per-record business logic
+- the chunk-level `receive` span ends before the per-record processing work begins
+
+If you intentionally want only per-record `process` spans, use `recordsWithProcessOnly`.
+
+## Syntax Imports
+
+`syntax._` adds convenience extensions for already-bound traced handles.
+
+```scala mdoc:silent
+def injectViaSyntax[F[_]](
+  record: ProducerRecord[String, String]
+)(implicit tracedProducer: TracedKafkaProducer[F, String, String]): F[ProducerRecord[String, String]] =
+  record.injectTracingHeaders
+
+def traceReceiveViaSyntax[F[_]](
+  records: Chunk[ConsumerRecord[String, String]]
+)(fa: F[Unit])(implicit tracedConsumer: TracedKafkaConsumer[F, String, String]): F[Unit] =
+  records.traceReceive(fa)
+
+def traceProcessViaSyntax[F[_]](
+  record: ConsumerRecord[String, String]
+)(fa: F[Unit])(implicit tracedConsumer: TracedKafkaConsumer[F, String, String]): F[Unit] =
+  record.traceProcess(fa)
+```
+
+Use these helpers when they make the call site shorter. If the direct methods are clearer, use
+those instead.
+
+## Configuration
+
+`KafkaTracer.Config` customizes the emitted spans.
+
+```scala mdoc:silent
+val kafkaTracingConfig =
+  KafkaTracer
+    .Config
+    .default
+    .withServerAddress("kafka.internal", Some(9092))
+    .addConstAttributes(
+      Attribute("module.component", "payments")
+    )
+```
+
+The main configuration hooks are:
+
+- `withConstAttributes` and `addConstAttributes` for attributes added to every emitted span
+- `withServerAddress` for logical Kafka endpoint attributes
+- `withSendSpanSetup` for producer-side `send` span naming and extra attributes
+- `withReceiveSpanSetup` for consumer-side `receive` span naming and extra attributes
+- `withProcessSpanSetup` for consumer-side `process` span naming and extra attributes
+
+Attribute precedence is:
+
+1. semantic-convention attributes derived from the traced records
+2. configured constant attributes
+3. attributes from the specific span setup
+
+Later layers override earlier ones when keys overlap.
+
+## What Spans Are Emitted
+
+The module emits:
+
+- producer `send` spans
+- per-message `create` spans for multi-record sends when needed to preserve message creation
+  context
+- consumer `receive` spans
+- consumer `process` spans
+
+Current limitations:
+
+- transactional offset commit / settlement is not modeled as a separate settlement span
+- `records` on its own is not traced; only explicit `receive` or `process` boundaries are traced
+
+## Notes
+
+- Bind traced producers and traced consumers once per Kafka client. Recreating them per record or
+  per chunk adds noise and unnecessary overhead.
+- `receive` and `process` represent different boundaries. Use `receive` for delivery and `process`
+  for actual business logic.
+- Consumer-side spans link to propagated message creation context by default. They do not adopt the
+  producer span as a normal parent-child relationship.
+- Logical broker endpoint identity is not auto-discovered from `fs2-kafka`. If you want
+  `server.address` and `server.port`, configure them explicitly.
+- `messaging.kafka.message.key` is emitted only when the key has a stable string representation.
+  Custom key types can provide `KafkaMessageKey[K]`.
+- `messaging.kafka.message.tombstone=true` is emitted when a traced record value is `null`.
+- `injectHeaders` can be used on its own when you want propagation without emitting a traced send.

--- a/docs/src/main/mdoc/otel4s-trace.md
+++ b/docs/src/main/mdoc/otel4s-trace.md
@@ -1,6 +1,6 @@
 ---
 id: otel4s-trace
-title: OTel4s Trace
+title: otel4s trace
 ---
 
 The `@OTEL4S_TRACE_MODULE_NAME@` module adds tracing support for `fs2-kafka` using

--- a/docs/src/main/mdoc/overview.md
+++ b/docs/src/main/mdoc/overview.md
@@ -40,6 +40,13 @@ In order to test vulcan codecs against a [schema registry](https://docs.confluen
 libraryDependencies += "@ORGANIZATION@" %% "@VULCAN_TESTKIT_MUNIT_MODULE_NAME@" % "@LATEST_VERSION@"
 ```
 
+For tracing support using [otel4s](otel4s-trace.md), add the following line to your `build.sbt`
+file.
+
+```scala
+libraryDependencies += "@ORGANIZATION@" %% "@OTEL4S_TRACE_MODULE_NAME@" % "@LATEST_VERSION@"
+```
+
 #### External Modules
 
 Following is an incomplete list of third-party integrations.
@@ -71,10 +78,11 @@ libraryDependencies += "@ORGANIZATION@" %% "@CORE_MODULE_NAME@" % "@LATEST_SNAPS
 
 Refer to the table below for dependencies and version support across modules.
 
-| Module                 | Dependencies                                                                                                                                                           | Scala                               |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `@CORE_MODULE_NAME@`   | [FS2 @FS2_VERSION@](https://github.com/typelevel/fs2), [Apache Kafka Client @KAFKA_VERSION@](https://github.com/apache/kafka)                                          | Scala @CORE_CROSS_SCALA_VERSIONS@   |
-| `@VULCAN_MODULE_NAME@` | [Vulcan @VULCAN_VERSION@](https://github.com/typelevel/vulcan), [Confluent Kafka Avro Serializer @CONFLUENT_VERSION@](https://github.com/confluentinc/schema-registry) | Scala @VULCAN_CROSS_SCALA_VERSIONS@ |
+| Module                       | Dependencies                                                                                                                                                           | Scala                               |
+|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
+| `@CORE_MODULE_NAME@`         | [FS2 @FS2_VERSION@](https://github.com/typelevel/fs2), [Apache Kafka Client @KAFKA_VERSION@](https://github.com/apache/kafka)                                          | Scala @CORE_CROSS_SCALA_VERSIONS@   |
+| `@OTEL4S_TRACE_MODULE_NAME@` | [otel4s @OTEL4S_VERSION@](https://github.com/typelevel/otel4s)                                                                                                         | Scala 2.13 and 3                    |
+| `@VULCAN_MODULE_NAME@`       | [Vulcan @VULCAN_VERSION@](https://github.com/typelevel/vulcan), [Confluent Kafka Avro Serializer @CONFLUENT_VERSION@](https://github.com/confluentinc/schema-registry) | Scala @VULCAN_CROSS_SCALA_VERSIONS@ |
 
 ## Adopters
 

--- a/docs/src/main/scala/fs2/kafka/docs/Main.scala
+++ b/docs/src/main/scala/fs2/kafka/docs/Main.scala
@@ -36,6 +36,7 @@ object Main {
           "ORGANIZATION"                     -> organization,
           "CORE_MODULE_NAME"                 -> coreModuleName,
           "CORE_CROSS_SCALA_VERSIONS"        -> minorVersionsString(coreCrossScalaVersions),
+          "OTEL4S_TRACE_MODULE_NAME"         -> otel4sModuleName,
           "VULCAN_MODULE_NAME"               -> vulcanModuleName,
           "VULCAN_CROSS_SCALA_VERSIONS"      -> minorVersionsString(vulcanCrossScalaVersions),
           "VULCAN_TESTKIT_MUNIT_MODULE_NAME" -> vulcanTestkitMunitModuleName,
@@ -48,6 +49,7 @@ object Main {
           "VULCAN_VERSION"                   -> vulcanVersion,
           "CONFLUENT_VERSION"                -> confluentVersion,
           "KAFKA_DOCS_VERSION"               -> kafkaDocsVersion,
+          "OTEL4S_TRACE_MODULE_NAME"         -> otel4sVersion,
           "SCALA_PUBLISH_VERSIONS"           -> minorVersionsString(crossScalaVersions),
           "API_BASE_URL"                     -> s"/fs2-kafka/api/fs2/kafka",
           "KAFKA_API_BASE_URL"               -> s"https://kafka.apache.org/$kafkaDocsVersion/javadoc"

--- a/docs/src/main/scala/fs2/kafka/docs/Main.scala
+++ b/docs/src/main/scala/fs2/kafka/docs/Main.scala
@@ -49,7 +49,7 @@ object Main {
           "VULCAN_VERSION"                   -> vulcanVersion,
           "CONFLUENT_VERSION"                -> confluentVersion,
           "KAFKA_DOCS_VERSION"               -> kafkaDocsVersion,
-          "OTEL4S_TRACE_MODULE_NAME"         -> otel4sVersion,
+          "OTEL4S_VERSION"                   -> otel4sVersion,
           "SCALA_PUBLISH_VERSIONS"           -> minorVersionsString(crossScalaVersions),
           "API_BASE_URL"                     -> s"/fs2-kafka/api/fs2/kafka",
           "KAFKA_API_BASE_URL"               -> s"https://kafka.apache.org/$kafkaDocsVersion/javadoc"

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -74,9 +74,14 @@ sealed abstract class KafkaConsumer[F[_], K, V]
     with KafkaTopics[F]
     with KafkaCommit[F]
     with KafkaMetrics[F]
-    with KafkaConsumerLifecycle[F]
+    with KafkaConsumerLifecycle[F] {
+
+  private[kafka] def metadata: ConsumerMetadata = ConsumerMetadata(None, None)
+}
 
 object KafkaConsumer {
+
+  abstract private[kafka] class Unsealed[F[_], K, V] extends KafkaConsumer[F, K, V]
 
   /**
     * Processes requests from the queue, if there are pending requests, otherwise waits for the next
@@ -138,6 +143,9 @@ object KafkaConsumer {
     stopConsumingDeferred: Deferred[F, Unit]
   )(implicit F: Async[F], logging: Logging[F]): KafkaConsumer[F, K, V] =
     new KafkaConsumer[F, K, V] {
+
+      override private[kafka] val metadata: ConsumerMetadata =
+        ConsumerMetadata.fromProperties(settings.properties)
 
       override def partitionsMapStream
         : Stream[F, Map[TopicPartition, Stream[F, CommittableConsumerRecord[F, K, V]]]] = {

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -30,6 +30,8 @@ import org.apache.kafka.common.{Metric, MetricName, PartitionInfo, TopicPartitio
   */
 abstract class KafkaProducer[F[_], K, V] {
 
+  private[kafka] def metadata: ProducerMetadata = ProducerMetadata(None)
+
   /**
     * Produces the specified [[ProducerRecords]] in two steps: the first effect puts the records in
     * the buffer of the producer, and the second effect waits for the records to send.<br><br>
@@ -278,6 +280,7 @@ object KafkaProducer {
       close            = blocking(producer.close(java.time.Duration.ofMillis(settings.closeTimeout.toMillis)))
       _               <- Resource.onFinalize(close)
       fs2KafkaProducer = resourceInternal[F, K, V](
+                           ProducerMetadata.fromProperties(settings.properties),
                            settings.failFastProduce,
                            keySerializer,
                            valueSerializer,
@@ -289,6 +292,7 @@ object KafkaProducer {
   }
 
   private def resourceInternal[F[_], K, V](
+    producerMetadata: ProducerMetadata,
     failFastProduce: Boolean,
     keySerializer: KeySerializer[F, K],
     valueSerializer: ValueSerializer[F, V],
@@ -297,6 +301,8 @@ object KafkaProducer {
     blocking: Blocking[F]
   )(implicit F: Async[F], P: Parallel[F]): KafkaProducer[F, K, V] =
     new KafkaProducer[F, K, V] {
+
+      override private[kafka] val metadata: ProducerMetadata = producerMetadata
 
       override def produce(records: ProducerRecords[K, V]): F[F[ProducerResult[K, V]]] = {
         if (failFastProduce)
@@ -421,7 +427,15 @@ object KafkaProducer {
         k: KeySerializer[F, K2],
         v: ValueSerializer[F, V2]
       ): KafkaProducer[F, K2, V2] =
-        resourceInternal[F, K2, V2](failFastProduce, k, v, producer, txSemaphore, blocking)
+        resourceInternal[F, K2, V2](
+          producerMetadata,
+          failFastProduce,
+          k,
+          v,
+          producer,
+          txSemaphore,
+          blocking
+        )
 
       override def toString: String =
         "KafkaProducer$" + System.identityHashCode(this)

--- a/modules/core/src/main/scala/fs2/kafka/internal/ConsumerMetadata.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/ConsumerMetadata.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.internal
+
+import org.apache.kafka.clients.CommonClientConfigs
+
+final private[kafka] case class ConsumerMetadata(
+  clientId: Option[String],
+  groupId: Option[String]
+)
+
+private[kafka] object ConsumerMetadata {
+
+  def fromProperties(properties: Map[String, String]): ConsumerMetadata =
+    ConsumerMetadata(
+      properties.get(CommonClientConfigs.CLIENT_ID_CONFIG),
+      properties.get(CommonClientConfigs.GROUP_ID_CONFIG)
+    )
+
+}

--- a/modules/core/src/main/scala/fs2/kafka/internal/ProducerMetadata.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/ProducerMetadata.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.internal
+
+import org.apache.kafka.clients.CommonClientConfigs
+
+final private[kafka] case class ProducerMetadata(
+  clientId: Option[String]
+)
+
+private[kafka] object ProducerMetadata {
+
+  def fromProperties(properties: Map[String, String]): ProducerMetadata =
+    ProducerMetadata(
+      properties.get(CommonClientConfigs.CLIENT_ID_CONFIG)
+    )
+
+}

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/KafkaMessageKey.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/KafkaMessageKey.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import java.util.UUID
+
+/**
+  * Typeclass describing how to derive a canonical Kafka message-key string for semantic
+  * conventions.
+  *
+  * Implementations should return `Some(...)` only when the key has an unambiguous canonical string
+  * representation suitable for `messaging.kafka.message.key`. Returning `None` omits the attribute.
+  */
+trait KafkaMessageKey[-K] {
+
+  def toMessageKey(value: K): Option[String]
+
+  def contramap[K0](f: K0 => K): KafkaMessageKey[K0] =
+    KafkaMessageKey.instance(value => toMessageKey(f(value)))
+
+}
+
+object KafkaMessageKey extends KafkaMessageKeyLowPriority {
+
+  def apply[K](implicit instance: KafkaMessageKey[K]): KafkaMessageKey[K] =
+    instance
+
+  def instance[K](f: K => Option[String]): KafkaMessageKey[K] =
+    new KafkaMessageKey[K] {
+      override def toMessageKey(value: K): Option[String] =
+        f(value)
+    }
+
+  implicit val stringKafkaMessageKey: KafkaMessageKey[String] =
+    instance(Option(_))
+
+  implicit val intKafkaMessageKey: KafkaMessageKey[Int] =
+    instance(value => Option(value).map(_.toString))
+
+  implicit val longKafkaMessageKey: KafkaMessageKey[Long] =
+    instance(value => Option(value).map(_.toString))
+
+  implicit val uuidKafkaMessageKey: KafkaMessageKey[UUID] =
+    instance(value => Option(value).map(_.toString))
+
+}
+
+trait KafkaMessageKeyLowPriority {
+
+  implicit def fallbackKafkaMessageKey[K]: KafkaMessageKey[K] =
+    KafkaMessageKey.instance(_ => None)
+
+}

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/KafkaTracer.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/KafkaTracer.scala
@@ -25,8 +25,11 @@ import org.typelevel.otel4s.trace.{SpanFinalizer, StatusCode, Tracer, TracerProv
   *
   * See the OpenTelemetry messaging and Kafka semantic conventions:
   *
-  *   - https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
-  *   - https://opentelemetry.io/docs/specs/semconv/messaging/kafka/
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/]]
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/semconv/messaging/kafka/]]
   */
 trait KafkaTracer[F[_]] {
 
@@ -58,9 +61,6 @@ object KafkaTracer {
 
   /**
     * Configuration for [[KafkaTracer]].
-    *
-    * The implementation is intentionally hidden so the public API stays focused on configuration
-    * operations rather than construction details.
     *
     * Constant attributes configured here are attached to every span emitted by the library. Kafka
     * client metadata derived from `KafkaProducer` or `KafkaConsumer` is intentionally not

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/KafkaTracer.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/KafkaTracer.scala
@@ -89,7 +89,7 @@ object KafkaTracer {
       * When these attributes use the same keys as metadata derived from the bound producer or
       * consumer, the configured values take precedence.
       */
-    def addConstAttributes(head: Attribute[_], tail: Attribute[_]*): Config
+    def addConstAttributes(head: Attribute[?], tail: Attribute[?]*): Config
 
     /**
       * Replaces the function used to derive producer-side `send` span setup from record metadata.
@@ -224,7 +224,7 @@ object KafkaTracer {
       override def withConstAttributes(attributes: Attributes): Config =
         copy(constAttributes = attributes)
 
-      override def addConstAttributes(head: Attribute[_], tail: Attribute[_]*): Config =
+      override def addConstAttributes(head: Attribute[?], tail: Attribute[?]*): Config =
         copy(constAttributes = constAttributes + head ++ tail)
 
       override def withSendSpanSetup(f: SendSpanContext => SpanSetup): Config =

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/KafkaTracer.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/KafkaTracer.scala
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import cats.effect.{Concurrent, Resource}
+import cats.syntax.functor._
+import cats.syntax.semigroup._
+import cats.Parallel
+import fs2.kafka.{BuildInfo, KafkaConsumer, KafkaProducer}
+
+import org.typelevel.otel4s.{Attribute, Attributes}
+import org.typelevel.otel4s.semconv.attributes.{ErrorAttributes, ServerAttributes}
+import org.typelevel.otel4s.trace.{SpanFinalizer, StatusCode, Tracer, TracerProvider}
+
+/**
+  * Entry point for `fs2-kafka-otel4s` tracing.
+  *
+  * A [[KafkaTracer]] is created from an otel4s [[org.typelevel.otel4s.trace.TracerProvider]] using
+  * an instrumentation scope managed entirely by this library. The tracing behavior can be
+  * customized with [[KafkaTracer.Config]] while keeping the instrumentation identity stable.
+  *
+  * See the OpenTelemetry messaging and Kafka semantic conventions:
+  *
+  *   - https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+  *   - https://opentelemetry.io/docs/specs/semconv/messaging/kafka/
+  */
+trait KafkaTracer[F[_]] {
+
+  /**
+    * Creates a producer-bound tracing handle.
+    *
+    * The handle captures static producer metadata such as `client.id` from the producer itself and
+    * offers explicit traced-produce operations plus access to the underlying producer when the
+    * lower-level API is needed.
+    */
+  def producer[K: KafkaMessageKey, V](
+    producer: KafkaProducer[F, K, V]
+  ): TracedKafkaProducer[F, K, V]
+
+  /**
+    * Creates a traced consumer handle bound to the supplied Kafka consumer instance.
+    *
+    * The traced consumer captures static consumer metadata such as `client.id` and `group.id` from
+    * the consumer itself and keeps `receive` and `process` operations associated with that specific
+    * consumer.
+    */
+  def consumer[K: KafkaMessageKey, V](
+    consumer: KafkaConsumer[F, K, V]
+  ): TracedKafkaConsumer[F, K, V]
+
+}
+
+object KafkaTracer {
+
+  /**
+    * Configuration for [[KafkaTracer]].
+    *
+    * The implementation is intentionally hidden so the public API stays focused on configuration
+    * operations rather than construction details.
+    *
+    * Constant attributes configured here are attached to every span emitted by the library. Kafka
+    * client metadata derived from `KafkaProducer` or `KafkaConsumer` is intentionally not
+    * configured here; it is captured by the traced producer and bound consumer tracer created from
+    * those clients.
+    */
+  sealed trait Config {
+
+    private[otel4s] def tracerName: String
+    private[otel4s] def constAttributes: Attributes
+    private[otel4s] def sendSpanSetup: SendSpanContext => Config.SpanSetup
+    private[otel4s] def receiveSpanSetup: ReceiveSpanContext => Config.SpanSetup
+    private[otel4s] def processSpanSetup: ProcessSpanContext => Config.SpanSetup
+
+    /**
+      * Replaces the constant attributes attached to every span emitted by this library.
+      *
+      * When these attributes use the same keys as metadata derived from the bound producer or
+      * consumer, the configured values take precedence.
+      */
+    def withConstAttributes(attributes: Attributes): Config
+
+    /**
+      * Appends constant attributes to every span emitted by this library.
+      *
+      * When these attributes use the same keys as metadata derived from the bound producer or
+      * consumer, the configured values take precedence.
+      */
+    def addConstAttributes(head: Attribute[_], tail: Attribute[_]*): Config
+
+    /**
+      * Replaces the function used to derive producer-side `send` span setup from record metadata.
+      */
+    def withSendSpanSetup(f: SendSpanContext => Config.SpanSetup): Config
+
+    /**
+      * Replaces the function used to derive consumer-side `poll` / `receive` span setup from chunk
+      * metadata.
+      */
+    def withReceiveSpanSetup(f: ReceiveSpanContext => Config.SpanSetup): Config
+
+    /**
+      * Replaces the function used to derive consumer-side `process` span setup from record
+      * metadata.
+      */
+    def withProcessSpanSetup(f: ProcessSpanContext => Config.SpanSetup): Config
+
+    /**
+      * Adds `server.address` and, when provided, `server.port` to emitted spans.
+      *
+      * Use values derived from the logical Kafka broker or service address, not connection-level
+      * peer information.
+      *
+      * @example
+      *   {{{
+      * val withPort = KafkaTracer.Config.default.withServerAddress("kafka.internal", Some(9092))
+      * val socket = KafkaTracer.Config.default.withServerAddress("/run/kafka.sock", None)
+      *   }}}
+      */
+    def withServerAddress(serverAddress: String, serverPort: Option[Int]): Config
+
+  }
+
+  object Config {
+
+    object Defaults {
+
+      val tracerName: String = "fs2.kafka"
+
+      val receiveSpanSetup: ReceiveSpanContext => SpanSetup =
+        ctx => SpanSetup("poll", Option.when(ctx.topics.size == 1)(ctx.topics.head))
+
+      val processSpanSetup: ProcessSpanContext => SpanSetup = ctx =>
+        SpanSetup("process", Some(ctx.topic))
+
+      val sendSpanSetup: SendSpanContext => SpanSetup =
+        ctx => SpanSetup("send", Option.when(ctx.topics.size == 1)(ctx.topics.head))
+
+      val spanFinalizationStrategy: SpanFinalizer.Strategy = {
+        case Resource.ExitCase.Errored(e) =>
+          val errorType = Option(e.getClass.getCanonicalName).getOrElse(e.getClass.getName)
+
+          val setStatus = Option(e.getMessage)
+            .map(message => SpanFinalizer.setStatus(StatusCode.Error, message))
+            .getOrElse(SpanFinalizer.setStatus(StatusCode.Error))
+
+          SpanFinalizer.recordException(e) |+|
+            SpanFinalizer.addAttribute(ErrorAttributes.ErrorType(errorType)) |+|
+            setStatus
+
+        case Resource.ExitCase.Canceled =>
+          SpanFinalizer.addAttribute(ErrorAttributes.ErrorType("canceled")) |+|
+            SpanFinalizer.setStatus(StatusCode.Error, "canceled")
+      }
+
+    }
+
+    sealed trait SpanSetup {
+
+      /**
+        * Final span name passed to the otel4s span builder.
+        */
+      def spanName: String
+
+      /**
+        * Extra attributes attached in addition to fs2-kafka's semantic-convention attributes and
+        * configured constant attributes.
+        *
+        * When duplicate keys exist, these attributes take precedence over both.
+        */
+      def attributes: Attributes
+
+      /**
+        * Finalization strategy applied when building the span.
+        */
+      def finalizationStrategy: SpanFinalizer.Strategy
+
+    }
+
+    object SpanSetup {
+
+      def apply(
+        spanName: String,
+        attributes: Attributes,
+        finalizationStrategy: SpanFinalizer.Strategy
+      ): SpanSetup =
+        SpanSetupImpl(spanName, attributes, finalizationStrategy)
+
+      private[KafkaTracer] def apply(operation: String, topic: Option[String]): SpanSetup =
+        SpanSetup(
+          spanName = topic.fold(operation)(value => s"$operation $value"),
+          attributes = Attributes.empty,
+          finalizationStrategy = Defaults.spanFinalizationStrategy
+        )
+
+      final private case class SpanSetupImpl(
+        spanName: String,
+        attributes: Attributes,
+        finalizationStrategy: SpanFinalizer.Strategy
+      ) extends SpanSetup
+
+    }
+
+    val default: Config =
+      ConfigImpl(
+        tracerName = Defaults.tracerName,
+        constAttributes = Attributes.empty,
+        sendSpanSetup = Defaults.sendSpanSetup,
+        receiveSpanSetup = Defaults.receiveSpanSetup,
+        processSpanSetup = Defaults.processSpanSetup
+      )
+
+    final private case class ConfigImpl(
+      tracerName: String,
+      constAttributes: Attributes,
+      sendSpanSetup: SendSpanContext => SpanSetup,
+      receiveSpanSetup: ReceiveSpanContext => SpanSetup,
+      processSpanSetup: ProcessSpanContext => SpanSetup
+    ) extends Config {
+
+      override def withConstAttributes(attributes: Attributes): Config =
+        copy(constAttributes = attributes)
+
+      override def addConstAttributes(head: Attribute[_], tail: Attribute[_]*): Config =
+        copy(constAttributes = constAttributes + head ++ tail)
+
+      override def withSendSpanSetup(f: SendSpanContext => SpanSetup): Config =
+        copy(sendSpanSetup = f)
+
+      override def withReceiveSpanSetup(f: ReceiveSpanContext => SpanSetup): Config =
+        copy(receiveSpanSetup = f)
+
+      override def withProcessSpanSetup(f: ProcessSpanContext => SpanSetup): Config =
+        copy(processSpanSetup = f)
+
+      override def withServerAddress(serverAddress: String, serverPort: Option[Int]): Config =
+        copy(
+          constAttributes = constAttributes +
+            ServerAttributes.ServerAddress(serverAddress) ++
+            ServerAttributes.ServerPort.maybe(serverPort.map(_.toLong))
+        )
+
+    }
+
+  }
+
+  def apply[F[_]](implicit ev: KafkaTracer[F]): KafkaTracer[F] = ev
+
+  /**
+    * Creates a library-managed [[KafkaTracer]] from the implicit otel4s
+    * [[org.typelevel.otel4s.trace.TracerProvider]].
+    *
+    * The returned tracer is not yet bound to a specific Kafka client. Bind it to a
+    * [[fs2.kafka.KafkaProducer]] or [[fs2.kafka.KafkaConsumer]] first so the resulting spans can
+    * include static client metadata such as `client.id` and `group.id`. If you want to attach
+    * logical broker endpoint attributes such as `server.address` and `server.port`, provide them
+    * explicitly through [[KafkaTracer.Config.withServerAddress]].
+    */
+  def create[F[_]: Concurrent: Parallel: TracerProvider](
+    config: Config
+  ): F[KafkaTracer[F]] =
+    TracerProvider[F]
+      .tracer(config.tracerName)
+      .withVersion(BuildInfo.version)
+      .get
+      .map { implicit tracer =>
+        new Impl[F](config)
+      }
+
+  final private class Impl[F[_]: Concurrent: Parallel: Tracer](config: Config)
+      extends KafkaTracer[F] {
+
+    override def producer[K: KafkaMessageKey, V](
+      producer: KafkaProducer[F, K, V]
+    ): TracedKafkaProducer[F, K, V] =
+      new TracedKafkaProducer.Impl[F, K, V](
+        producer,
+        config
+      )
+
+    override def consumer[K: KafkaMessageKey, V](
+      consumer: KafkaConsumer[F, K, V]
+    ): TracedKafkaConsumer[F, K, V] =
+      new TracedKafkaConsumer.Impl[F, K, V](
+        consumer,
+        config
+      )
+
+  }
+
+}

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/ProcessSpanContext.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/ProcessSpanContext.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+/**
+  * Consumer-side metadata used to derive a tracing `process` span.
+  *
+  * This context describes a single consumed record at the application processing boundary. It
+  * carries the record coordinates used by Kafka semantic conventions together with static consumer
+  * metadata captured from the bound Kafka consumer.
+  */
+sealed trait ProcessSpanContext {
+
+  /**
+    * Topic of the processed record.
+    */
+  def topic: String
+
+  /**
+    * Partition of the processed record.
+    */
+  def partition: Int
+
+  /**
+    * Offset of the processed record.
+    */
+  def offset: Long
+
+  /**
+    * Canonical string form of the Kafka message key when it can be represented safely.
+    */
+  def messageKey: Option[String]
+
+  /**
+    * Kafka `client.id` captured from the bound consumer, when configured.
+    */
+  def clientId: Option[String]
+
+  /**
+    * Kafka `group.id` captured from the bound consumer, when configured.
+    */
+  def groupId: Option[String]
+
+}
+
+object ProcessSpanContext {
+
+  private[otel4s] def apply(
+    topic: String,
+    partition: Int,
+    offset: Long,
+    messageKey: Option[String],
+    clientId: Option[String],
+    groupId: Option[String]
+  ): ProcessSpanContext =
+    Impl(topic, partition, offset, messageKey, clientId, groupId)
+
+  final private case class Impl(
+    topic: String,
+    partition: Int,
+    offset: Long,
+    messageKey: Option[String],
+    clientId: Option[String],
+    groupId: Option[String]
+  ) extends ProcessSpanContext
+
+}

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/ReceiveSpanContext.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/ReceiveSpanContext.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+/**
+  * Consumer-side metadata used to derive a tracing `poll` / `receive` span.
+  *
+  * This context describes a delivered chunk of consumed records. It combines dynamic chunk
+  * information such as topics, partitions, and record count with static consumer metadata captured
+  * from the bound Kafka consumer.
+  */
+sealed trait ReceiveSpanContext {
+
+  /**
+    * Topics covered by the delivered chunk.
+    */
+  def topics: Set[String]
+
+  /**
+    * Partitions covered by the delivered chunk.
+    */
+  def partitions: Set[Int]
+
+  /**
+    * Number of records in the delivered chunk.
+    */
+  def recordCount: Int
+
+  /**
+    * Canonical string form of the Kafka message key when this span describes a single record and
+    * the key can be represented safely.
+    */
+  def messageKey: Option[String]
+
+  /**
+    * Kafka record offset when this span describes exactly one record.
+    */
+  def offset: Option[Long]
+
+  /**
+    * Kafka `client.id` captured from the bound consumer, when configured.
+    */
+  def clientId: Option[String]
+
+  /**
+    * Kafka `group.id` captured from the bound consumer, when configured.
+    */
+  def groupId: Option[String]
+
+}
+
+object ReceiveSpanContext {
+
+  private[otel4s] def apply(
+    topics: Set[String],
+    partitions: Set[Int],
+    recordCount: Int,
+    messageKey: Option[String],
+    offset: Option[Long],
+    clientId: Option[String],
+    groupId: Option[String]
+  ): ReceiveSpanContext =
+    Impl(
+      topics,
+      partitions,
+      recordCount,
+      messageKey,
+      offset,
+      clientId,
+      groupId
+    )
+
+  final private case class Impl(
+    topics: Set[String],
+    partitions: Set[Int],
+    recordCount: Int,
+    messageKey: Option[String],
+    offset: Option[Long],
+    clientId: Option[String],
+    groupId: Option[String]
+  ) extends ReceiveSpanContext
+
+}

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/SendSpanContext.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/SendSpanContext.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+/**
+  * Producer-side metadata used to derive a tracing `send` span.
+  *
+  * This context describes the produced batch at the point where `fs2-kafka-otel4s` is about to
+  * create a producer span. It combines dynamic record information such as topics, partitions, and
+  * batch size with static producer metadata captured from the bound Kafka producer.
+  */
+sealed trait SendSpanContext {
+
+  /**
+    * Topics covered by the produced records.
+    */
+  def topics: Set[String]
+
+  /**
+    * Partitions covered by the produced records, when explicitly set on the records.
+    */
+  def partitions: Set[Int]
+
+  /**
+    * Number of records in the produced batch.
+    */
+  def recordCount: Int
+
+  /**
+    * Canonical string form of the Kafka message key when this span describes a single record and
+    * the key can be represented safely.
+    */
+  def messageKey: Option[String]
+
+  /**
+    * Kafka `client.id` captured from the bound producer, when configured.
+    */
+  def clientId: Option[String]
+
+}
+
+object SendSpanContext {
+
+  private[otel4s] def apply(
+    topics: Set[String],
+    partitions: Set[Int],
+    recordCount: Int,
+    messageKey: Option[String],
+    clientId: Option[String]
+  ): SendSpanContext =
+    Impl(topics, partitions, recordCount, messageKey, clientId)
+
+  final private case class Impl(
+    topics: Set[String],
+    partitions: Set[Int],
+    recordCount: Int,
+    messageKey: Option[String],
+    clientId: Option[String]
+  ) extends SendSpanContext
+
+}

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/TracedKafkaConsumer.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/TracedKafkaConsumer.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import scala.util.chaining._
+
+import cats.effect.Concurrent
+import cats.syntax.all._
+import fs2.{Chunk, Stream}
+import fs2.kafka.{CommittableConsumerRecord, ConsumerRecord, KafkaConsumer}
+import fs2.kafka.otel4s.trace.instances._
+import fs2.kafka.otel4s.trace.internal.Semconv
+
+import org.typelevel.otel4s.trace.{SpanContext, SpanKind, Tracer}
+import org.typelevel.otel4s.Attributes
+
+/**
+  * A consumer-bound tracing handle for `fs2-kafka`.
+  *
+  * Unlike producer tracing, consumer tracing cannot be a fully transparent drop-in replacement,
+  * because the important `process` boundary lives in user code. This handle keeps the association
+  * with a specific [[fs2.kafka.KafkaConsumer]] while still making `receive` and `process` explicit.
+  */
+trait TracedKafkaConsumer[F[_], K, V] {
+
+  /**
+    * The underlying Kafka consumer this tracing handle is bound to.
+    */
+  def underlying: KafkaConsumer[F, K, V]
+
+  /**
+    * Delegates to [[underlying.records]].
+    *
+    * Record emission itself is not treated as processing. Wrap the actual business logic with
+    * [[process]] or use [[recordsWithProcess]] for the common `evalMap` shape.
+    */
+  def records: Stream[F, CommittableConsumerRecord[F, K, V]]
+
+  /**
+    * Evaluates `fa` inside a `poll` / `receive` span representing delivery of a non-committable
+    * chunk of records to application code.
+    */
+  def receive[A](records: Chunk[ConsumerRecord[K, V]])(fa: F[A]): F[A]
+
+  /**
+    * Evaluates `fa` inside a `poll` / `receive` span representing delivery of a committable chunk
+    * of records to application code.
+    *
+    * The commit handle is preserved, but span attributes are derived from the wrapped
+    * [[CommittableConsumerRecord.record]] values.
+    */
+  def receiveCommittable[A](records: Chunk[CommittableConsumerRecord[F, K, V]])(fa: F[A]): F[A]
+
+  /**
+    * Evaluates `fa` inside a `process` span using trace context extracted from the record headers
+    * when available.
+    */
+  def process[A](record: ConsumerRecord[K, V])(fa: F[A]): F[A]
+
+  /**
+    * Evaluates `fa` inside a `process` span using trace context extracted from the record headers
+    * when available.
+    */
+  def process[A](record: CommittableConsumerRecord[F, K, V])(fa: F[A]): F[A]
+
+  /**
+    * Convenience stream for the common traced-consumption shape: a chunk-level `receive` span
+    * around delivery, plus a per-record `process` span for each record in that chunk.
+    *
+    * This helper intentionally derives `receive` spans from the underlying per-partition delivery
+    * chunks rather than from arbitrary chunking of a flattened `records` stream. The `receive` span
+    * ends once the chunk has been handed off; user business logic then runs only inside the
+    * per-record `process` spans.
+    */
+  def recordsWithProcess[A](
+    f: CommittableConsumerRecord[F, K, V] => F[A]
+  ): Stream[F, A]
+
+  /**
+    * Convenience stream for the narrower `records.evalMap(record => process(record)(...))` shape.
+    *
+    * This intentionally omits the chunk-level `receive` span. Prefer [[recordsWithProcess]] unless
+    * you specifically want only per-record processing spans.
+    */
+  def recordsWithProcessOnly[A](f: CommittableConsumerRecord[F, K, V] => F[A]): Stream[F, A]
+
+}
+
+object TracedKafkaConsumer {
+
+  final private[otel4s] class Impl[F[_]: Concurrent: Tracer, K: KafkaMessageKey, V](
+    override val underlying: KafkaConsumer[F, K, V],
+    config: KafkaTracer.Config
+  ) extends TracedKafkaConsumer[F, K, V] {
+
+    override def records: Stream[F, CommittableConsumerRecord[F, K, V]] =
+      underlying.records
+
+    override def receive[A](records: Chunk[ConsumerRecord[K, V]])(fa: F[A]): F[A] =
+      if (records.isEmpty) fa
+      else {
+        val spanContext = Semconv.receiveSpanContext(underlying.metadata, records)
+        val spanSetup   = config.receiveSpanSetup(spanContext)
+        creationContextLinks(records.toList).flatMap { links =>
+          Tracer[F]
+            .spanBuilder(spanSetup.spanName)
+            .withSpanKind(SpanKind.Client)
+            .withFinalizationStrategy(spanSetup.finalizationStrategy)
+            .addAttributes(
+              Semconv.receiveAttributes(spanContext, records) ++
+                config.constAttributes ++
+                spanSetup.attributes
+            )
+            .pipe { builder =>
+              links.foldLeft(builder) { case (acc, (ctx, attributes)) =>
+                acc.addLink(ctx, attributes)
+              }
+            }
+            .build
+            .surround(fa)
+        }
+      }
+
+    override def receiveCommittable[A](
+      records: Chunk[CommittableConsumerRecord[F, K, V]]
+    )(fa: F[A]): F[A] =
+      receive(records.map(_.record))(fa)
+
+    override def process[A](record: ConsumerRecord[K, V])(fa: F[A]): F[A] = {
+      val spanContext = Semconv.processSpanContext(underlying.metadata, record)
+      val spanSetup   = config.processSpanSetup(spanContext)
+      creationContextLinks(record :: Nil).flatMap { links =>
+        Tracer[F]
+          .spanBuilder(spanSetup.spanName)
+          .withSpanKind(SpanKind.Consumer)
+          .withFinalizationStrategy(spanSetup.finalizationStrategy)
+          .addAttributes(
+            Semconv.processAttributes(spanContext, record) ++
+              config.constAttributes ++
+              spanSetup.attributes
+          )
+          .pipe { builder =>
+            links.foldLeft(builder) { case (acc, (ctx, attributes)) =>
+              acc.addLink(ctx, attributes)
+            }
+          }
+          .build
+          .surround(fa)
+      }
+    }
+
+    override def process[A](record: CommittableConsumerRecord[F, K, V])(fa: F[A]): F[A] =
+      process(record.record)(fa)
+
+    override def recordsWithProcess[A](
+      f: CommittableConsumerRecord[F, K, V] => F[A]
+    ): Stream[F, A] =
+      underlying
+        .partitionedStream
+        .map(
+          _.chunks
+            .flatMap { chunk =>
+              Stream
+                .eval(receiveCommittable(chunk)(Concurrent[F].pure(chunk)))
+                .flatMap(records =>
+                  Stream.chunk(records).evalMap(record => process(record)(f(record)))
+                )
+            }
+        )
+        .parJoinUnbounded
+
+    override def recordsWithProcessOnly[A](
+      f: CommittableConsumerRecord[F, K, V] => F[A]
+    ): Stream[F, A] =
+      underlying.records.evalMap(record => process(record)(f(record)))
+
+    private def creationContextLinks(
+      records: Iterable[ConsumerRecord[K, V]]
+    ): F[List[(SpanContext, Attributes)]] =
+      records
+        .toList
+        .flatTraverse { record =>
+          for {
+            ctx <- Tracer[F].joinOrRoot(record.headers)(Tracer[F].currentSpanContext)
+          } yield ctx.tupleRight(Semconv.receiveLinkAttributes(record)).toList
+        }
+
+  }
+
+}

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/TracedKafkaProducer.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/TracedKafkaProducer.scala
@@ -6,6 +6,8 @@
 
 package fs2.kafka.otel4s.trace
 
+import scala.util.chaining._
+
 import cats.effect.kernel.{Outcome, Resource}
 import cats.effect.MonadCancelThrow
 import cats.syntax.all._
@@ -200,19 +202,23 @@ object TracedKafkaProducer {
           val spanContext = Semconv.sendSpanContext(underlying.metadata, prepared.records)
           val spanSetup   = config.sendSpanSetup(spanContext)
 
-          val span =
-            addSendLinks(
-              Tracer[F]
-                .spanBuilder(spanSetup.spanName)
-                .withSpanKind(prepared.sendKind)
-                .withFinalizationStrategy(spanSetup.finalizationStrategy)
-                .addAttributes(
-                  Semconv.sendAttributes(spanContext, prepared.records) ++
-                    config.constAttributes ++
-                    spanSetup.attributes
-                ),
-              prepared.sendLinks
-            ).build
+          val span = Tracer[F]
+            .spanBuilder(spanSetup.spanName)
+            .withSpanKind(prepared.sendKind)
+            .withFinalizationStrategy(spanSetup.finalizationStrategy)
+            .addAttributes(
+              Semconv.sendAttributes(spanContext, prepared.records) ++
+                config.constAttributes ++
+                spanSetup.attributes
+            )
+            .pipe { builder =>
+              prepared
+                .sendLinks
+                .foldLeft(builder) { case (acc, (ctx, attributes)) =>
+                  acc.addLink(ctx, attributes)
+                }
+            }
+            .build
 
           MonadCancelThrow[F].uncancelable { poll =>
             span
@@ -257,70 +263,56 @@ object TracedKafkaProducer {
         }
       }
 
-    private def extractedCreationContext(headers: Headers): F[Option[SpanContext]] =
-      Tracer[F].joinOrRoot(headers)(Tracer[F].currentSpanContext)
-
-    private def addSendLinks(
-      builder: SpanBuilder[F],
-      links: List[(SpanContext, Attributes)]
-    ): SpanBuilder[F] =
-      links.foldLeft(builder) { case (acc, (ctx, attributes)) =>
-        acc.addLink(ctx, attributes)
-      }
-
-    private def createSpanResource(
-      record: ProducerRecord[K, V]
-    ): Resource[F, SpanOps.Res[F]] =
-      Tracer[F]
-        .spanBuilder(Semconv.createSpanName(record.topic))
-        .withSpanKind(SpanKind.Producer)
-        .addAttributes(
-          Semconv.createAttributes(underlying.metadata, record) ++ config.constAttributes
-        )
-        .build
-        .resource
-
     private def prepareRecord(
       record: ProducerRecord[K, V],
       createCreationContext: Boolean
     ): F[PreparedRecord] =
-      extractedCreationContext(record.headers).flatMap {
-        case Some(ctx) =>
-          MonadCancelThrow[F].pure(
-            PreparedRecord(
-              record = record,
-              usesSendSpanAsCreationContext = false,
-              sendLink = Some(ctx -> Semconv.sendLinkAttributes(record)),
-              releaseCreateSpan = None
+      Tracer[F]
+        .joinOrRoot(record.headers)(Tracer[F].currentSpanContext)
+        .flatMap {
+          case Some(ctx) =>
+            MonadCancelThrow[F].pure(
+              PreparedRecord(
+                record = record,
+                usesSendSpanAsCreationContext = false,
+                sendLink = Some(ctx -> Semconv.sendLinkAttributes(record)),
+                releaseCreateSpan = None
+              )
             )
-          )
 
-        case None if createCreationContext =>
-          createSpanResource(record)
-            .allocatedCase
-            .flatMap { case (res, release) =>
-              res
-                .trace(injectHeaders(record))
-                .map { injected =>
-                  PreparedRecord(
-                    record = injected,
-                    usesSendSpanAsCreationContext = false,
-                    sendLink = Some(res.span.context -> Semconv.sendLinkAttributes(record)),
-                    releaseCreateSpan = Some(release)
-                  )
-                }
-            }
+          case None if createCreationContext =>
+            Tracer[F]
+              .spanBuilder(Semconv.createSpanName(record.topic))
+              .withSpanKind(SpanKind.Producer)
+              .addAttributes(
+                Semconv.createAttributes(underlying.metadata, record) ++ config.constAttributes
+              )
+              .build
+              .resource
+              .allocatedCase
+              .flatMap { case (res, release) =>
+                res
+                  .trace(injectHeaders(record))
+                  .map { injected =>
+                    PreparedRecord(
+                      record = injected,
+                      usesSendSpanAsCreationContext = false,
+                      sendLink = Some(res.span.context -> Semconv.sendLinkAttributes(record)),
+                      releaseCreateSpan = Some(release)
+                    )
+                  }
+              }
 
-        case None =>
-          MonadCancelThrow[F].pure(
-            PreparedRecord(
-              record = record,
-              usesSendSpanAsCreationContext = true,
-              sendLink = None,
-              releaseCreateSpan = None
+          case None =>
+            MonadCancelThrow[F].pure(
+              PreparedRecord(
+                record = record,
+                usesSendSpanAsCreationContext = true,
+                sendLink = None,
+                releaseCreateSpan = None
+              )
             )
-          )
-      }
+        }
 
     private def prepareBatch(records: ProducerRecords[K, V]): F[PreparedBatch] = {
       val useCreateSpans = records.size > 1

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/TracedKafkaProducer.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/TracedKafkaProducer.scala
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import cats.effect.kernel.{Outcome, Resource}
+import cats.effect.MonadCancelThrow
+import cats.syntax.all._
+import cats.Parallel
+import fs2.kafka._
+import fs2.kafka.otel4s.trace.instances._
+import fs2.kafka.otel4s.trace.internal.Semconv
+import fs2.Chunk
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+import org.typelevel.otel4s.trace._
+import org.typelevel.otel4s.Attributes
+
+/**
+  * A tracing handle bound to a specific [[fs2.kafka.KafkaProducer]].
+  *
+  * This handle keeps the traced producer API explicit instead of mirroring the full operational
+  * surface of [[fs2.kafka.KafkaProducer]]. Use [[underlying]] when you need low-level producer
+  * operations such as metrics, partition metadata, or the original two-stage `produce` contract.
+  *
+  * The traced send operations on this handle are intentionally one-shot awaited effects so the
+  * emitted `send` spans line up with Kafka send completion more closely.
+  */
+trait TracedKafkaProducer[F[_], K, V] {
+
+  /**
+    * The underlying Kafka producer this tracing handle is bound to.
+    */
+  def underlying: KafkaProducer[F, K, V]
+
+  /**
+    * Injects the current tracing context into the headers of a single record without producing it.
+    */
+  def injectHeaders(record: ProducerRecord[K, V]): F[ProducerRecord[K, V]]
+
+  /**
+    * Injects the current tracing context into the headers of all records in a batch without
+    * producing them.
+    */
+  def injectHeaders(records: ProducerRecords[K, V]): F[ProducerRecords[K, V]]
+
+  /**
+    * Produces a batch and awaits Kafka completion in one effect.
+    *
+    * This is the preferred traced producer API when you want `send` span timing to track the actual
+    * Kafka send rather than the lifetime of a deferred await handle.
+    */
+  def produceAwaited(records: ProducerRecords[K, V]): F[ProducerResult[K, V]]
+
+  /**
+    * Produces a single record and awaits Kafka completion in one effect.
+    */
+  def produceOneAwaited(record: ProducerRecord[K, V]): F[ProducerResult[K, V]]
+
+  /**
+    * Injects tracing headers into all records before delegating to the underlying transactional
+    * produce-and-commit flow.
+    */
+  def produceAndCommitTransactionally(
+    records: TransactionalProducerRecords[F, K, V]
+  ): F[ProducerResult[K, V]]
+
+  /**
+    * Injects tracing headers into all records before delegating to the underlying transactional
+    * produce flow.
+    */
+  def produceTransactionally(
+    records: ProducerRecords[K, V]
+  ): F[ProducerResult[K, V]]
+
+  /**
+    * Preserves tracing behavior when switching serializers.
+    */
+  def withSerializers[K2, V2](
+    keySerializer: KeySerializer[F, K2],
+    valueSerializer: ValueSerializer[F, V2]
+  ): TracedKafkaProducer[F, K2, V2]
+
+}
+
+object TracedKafkaProducer {
+
+  final private[otel4s] class Impl[F[_]: MonadCancelThrow: Parallel: Tracer, K: KafkaMessageKey, V](
+    override val underlying: KafkaProducer[F, K, V],
+    config: KafkaTracer.Config
+  ) extends TracedKafkaProducer[F, K, V] {
+
+    override def injectHeaders(record: ProducerRecord[K, V]): F[ProducerRecord[K, V]] =
+      Tracer[F]
+        .joinOrRoot(record.headers)(Tracer[F].currentSpanContext)
+        .flatMap {
+          // if the record headers already have propagated span details, we don't need to inject anything
+          case Some(_) =>
+            MonadCancelThrow[F].pure(record)
+
+          case None =>
+            Tracer[F].propagate(record.headers).map(record.withHeaders)
+        }
+
+    override def injectHeaders(records: ProducerRecords[K, V]): F[ProducerRecords[K, V]] =
+      records.traverse(injectHeaders)
+
+    override def produceAwaited(records: ProducerRecords[K, V]): F[ProducerResult[K, V]] =
+      produce(underlying, records).flatten
+
+    override def produceOneAwaited(record: ProducerRecord[K, V]): F[ProducerResult[K, V]] =
+      produceAwaited(ProducerRecords.one(record))
+
+    override def produceAndCommitTransactionally(
+      records: TransactionalProducerRecords[F, K, V]
+    ): F[ProducerResult[K, V]] =
+      if (records.isEmpty) MonadCancelThrow[F].pure(Chunk.empty)
+      else {
+        val grouped =
+          records.foldLeft(
+            Map.empty[
+              KafkaCommitter[F],
+              (Map[TopicPartition, OffsetAndMetadata], Chunk[ProducerRecord[K, V]])
+            ]
+          ) { case (acc, recordBatch) =>
+            val offset      = recordBatch.offset
+            val committer   = offset.committer
+            val nextOffsets = acc
+              .get(committer)
+              .map(_._1)
+              .getOrElse(Map.empty)
+              .updatedWith(offset.topicPartition) {
+                case existing @ Some(current)
+                    if current.offset >= offset.offsetAndMetadata.offset =>
+                  existing
+                case Some(_) | None =>
+                  Some(offset.offsetAndMetadata)
+              }
+            val nextRecords =
+              acc.get(committer).map(_._2).getOrElse(Chunk.empty) ++ recordBatch.records
+
+            acc.updated(committer, nextOffsets -> nextRecords)
+          }
+
+        underlying
+          .transaction
+          .surround {
+            Chunk
+              .from(grouped.toList)
+              .parFlatTraverse { case (committer, offsets) =>
+                for {
+                  metadata <- committer.metadata
+                  result   <- produce(underlying, offsets._2).flatten
+                  _        <- underlying.sendOffsetsToTransaction(offsets._1, metadata)
+                } yield result
+              }
+          }
+      }
+
+    override def produceTransactionally(
+      records: ProducerRecords[K, V]
+    ): F[ProducerResult[K, V]] =
+      if (records.isEmpty) MonadCancelThrow[F].pure(Chunk.empty)
+      else underlying.transaction.surround(produce(underlying, records).flatten)
+
+    override def withSerializers[K2, V2](
+      keySerializer: KeySerializer[F, K2],
+      valueSerializer: ValueSerializer[F, V2]
+    ): TracedKafkaProducer[F, K2, V2] =
+      new Impl[F, K2, V2](
+        underlying.withSerializers(keySerializer, valueSerializer),
+        config
+      )
+
+    private case class PreparedRecord(
+      record: ProducerRecord[K, V],
+      usesSendSpanAsCreationContext: Boolean,
+      sendLink: Option[(SpanContext, Attributes)],
+      releaseCreateSpan: Option[Resource.ExitCase => F[Unit]]
+    )
+
+    private case class PreparedBatch(
+      records: ProducerRecords[K, V],
+      sendKind: SpanKind,
+      sendLinks: List[(SpanContext, Attributes)],
+      releaseCreateSpans: Resource.ExitCase => F[Unit]
+    )
+
+    private def produce(
+      producer: KafkaProducer[F, K, V],
+      records: ProducerRecords[K, V]
+    ): F[F[ProducerResult[K, V]]] =
+      if (records.isEmpty) producer.produce(records)
+      else {
+        prepareBatch(records).flatMap { prepared =>
+          val spanContext = Semconv.sendSpanContext(underlying.metadata, prepared.records)
+          val spanSetup   = config.sendSpanSetup(spanContext)
+
+          val span =
+            addSendLinks(
+              Tracer[F]
+                .spanBuilder(spanSetup.spanName)
+                .withSpanKind(prepared.sendKind)
+                .withFinalizationStrategy(spanSetup.finalizationStrategy)
+                .addAttributes(
+                  Semconv.sendAttributes(spanContext, prepared.records) ++
+                    config.constAttributes ++
+                    spanSetup.attributes
+                ),
+              prepared.sendLinks
+            ).build
+
+          MonadCancelThrow[F].uncancelable { poll =>
+            span
+              .resource
+              .allocatedCase
+              .flatMap { case (res, release) =>
+                val outerProduce =
+                  if (prepared.sendKind == SpanKind.Producer)
+                    prepared
+                      .records
+                      .traverse(record => injectHeaders(record))
+                      .flatMap(producer.produce(_))
+                  else
+                    producer.produce(prepared.records)
+
+                MonadCancelThrow[F]
+                  .guaranteeCase(poll(res.trace(outerProduce))) {
+                    case Outcome.Succeeded(_) =>
+                      prepared.releaseCreateSpans(Resource.ExitCase.Succeeded)
+                    case Outcome.Errored(e) =>
+                      prepared.releaseCreateSpans(Resource.ExitCase.Errored(e)) *>
+                        release(Resource.ExitCase.Errored(e))
+                    case Outcome.Canceled() =>
+                      prepared.releaseCreateSpans(Resource.ExitCase.Canceled) *>
+                        release(Resource.ExitCase.Canceled)
+                  }
+                  .map { awaitResult =>
+                    MonadCancelThrow[F].guaranteeCase(
+                      res
+                        .trace(awaitResult)
+                        .flatTap { result =>
+                          res.span.addAttributes(Semconv.sendResultAttributes(result))
+                        }
+                    ) {
+                      case Outcome.Succeeded(_) => release(Resource.ExitCase.Succeeded)
+                      case Outcome.Errored(e)   => release(Resource.ExitCase.Errored(e))
+                      case Outcome.Canceled()   => release(Resource.ExitCase.Canceled)
+                    }
+                  }
+              }
+          }
+        }
+      }
+
+    private def extractedCreationContext(headers: Headers): F[Option[SpanContext]] =
+      Tracer[F].joinOrRoot(headers)(Tracer[F].currentSpanContext)
+
+    private def addSendLinks(
+      builder: SpanBuilder[F],
+      links: List[(SpanContext, Attributes)]
+    ): SpanBuilder[F] =
+      links.foldLeft(builder) { case (acc, (ctx, attributes)) =>
+        acc.addLink(ctx, attributes)
+      }
+
+    private def createSpanResource(
+      record: ProducerRecord[K, V]
+    ): Resource[F, SpanOps.Res[F]] =
+      Tracer[F]
+        .spanBuilder(Semconv.createSpanName(record.topic))
+        .withSpanKind(SpanKind.Producer)
+        .addAttributes(
+          Semconv.createAttributes(underlying.metadata, record) ++ config.constAttributes
+        )
+        .build
+        .resource
+
+    private def prepareRecord(
+      record: ProducerRecord[K, V],
+      createCreationContext: Boolean
+    ): F[PreparedRecord] =
+      extractedCreationContext(record.headers).flatMap {
+        case Some(ctx) =>
+          MonadCancelThrow[F].pure(
+            PreparedRecord(
+              record = record,
+              usesSendSpanAsCreationContext = false,
+              sendLink = Some(ctx -> Semconv.sendLinkAttributes(record)),
+              releaseCreateSpan = None
+            )
+          )
+
+        case None if createCreationContext =>
+          createSpanResource(record)
+            .allocatedCase
+            .flatMap { case (res, release) =>
+              res
+                .trace(injectHeaders(record))
+                .map { injected =>
+                  PreparedRecord(
+                    record = injected,
+                    usesSendSpanAsCreationContext = false,
+                    sendLink = Some(res.span.context -> Semconv.sendLinkAttributes(record)),
+                    releaseCreateSpan = Some(release)
+                  )
+                }
+            }
+
+        case None =>
+          MonadCancelThrow[F].pure(
+            PreparedRecord(
+              record = record,
+              usesSendSpanAsCreationContext = true,
+              sendLink = None,
+              releaseCreateSpan = None
+            )
+          )
+      }
+
+    private def prepareBatch(records: ProducerRecords[K, V]): F[PreparedBatch] = {
+      val useCreateSpans = records.size > 1
+
+      records
+        .toList
+        .traverse(prepareRecord(_, useCreateSpans))
+        .map { prepared =>
+          val sendUsesOwnContext = prepared.forall(_.usesSendSpanAsCreationContext)
+          val releaseCreateSpans = (exitCase: Resource.ExitCase) =>
+            prepared
+              .reverse
+              .traverse_(_.releaseCreateSpan.fold(MonadCancelThrow[F].unit)(_(exitCase)))
+
+          PreparedBatch(
+            records = ProducerRecords(prepared.map(_.record)),
+            sendKind = if (sendUsesOwnContext) SpanKind.Producer else SpanKind.Client,
+            sendLinks = prepared.flatMap(_.sendLink),
+            releaseCreateSpans = releaseCreateSpans
+          )
+        }
+    }
+
+  }
+
+}

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/instances.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/instances.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import fs2.kafka.{Header, Headers}
+
+import org.typelevel.otel4s.context.propagation.{TextMapGetter, TextMapUpdater}
+
+/**
+  * Typeclass instances for using [[fs2.kafka.Headers]] as an otel4s propagation carrier.
+  *
+  * Trace context is propagated via Kafka headers, following the OpenTelemetry messaging
+  * specification.
+  *
+  * @see
+  *   [[https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/]]
+  */
+trait Otel4sInstances {
+
+  implicit val headersTextMapGetter: TextMapGetter[Headers] =
+    new TextMapGetter[Headers] {
+      override def get(carrier: Headers, key: String): Option[String] =
+        carrier(key).map(_.as[String])
+
+      override def keys(carrier: Headers): Iterable[String] =
+        carrier.toChain.map(_.key).toVector
+    }
+
+  implicit val headersTextMapUpdater: TextMapUpdater[Headers] =
+    new TextMapUpdater[Headers] {
+
+      override def updated(carrier: Headers, key: String, value: String): Headers =
+        Headers.fromSeq(
+          carrier.toChain.iterator.filterNot(_.key == key).toVector :+ Header(key, value)
+        )
+
+    }
+
+}
+
+/**
+  * Default otel4s propagation instances for [[fs2.kafka.Headers]].
+  */
+object instances extends Otel4sInstances

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/internal/Semconv.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/internal/Semconv.scala
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+package internal
+
+import fs2.kafka._
+import fs2.kafka.internal.{ConsumerMetadata, ProducerMetadata}
+import fs2.Chunk
+
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.typelevel.otel4s.{Attribute, AttributeKey, Attributes}
+
+/**
+  * Messaging span semantic conventions:
+  * [[https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/]]
+  *
+  * Kafka-specific messaging conventions:
+  * [[https://opentelemetry.io/docs/specs/semconv/messaging/kafka/]]
+  */
+private[otel4s] object Semconv {
+
+  object Const {
+    val MessagingSystem = Attribute("messaging.system", "kafka")
+  }
+
+  object Keys {
+
+    val DestinationName        = AttributeKey[String]("messaging.destination.name")
+    val DestinationPartitionId = AttributeKey[String]("messaging.destination.partition.id")
+    val OperationName          = AttributeKey[String]("messaging.operation.name")
+    val OperationType          = AttributeKey[String]("messaging.operation.type")
+    val ClientId               = AttributeKey[String]("messaging.client.id")
+    val ConsumerGroupName      = AttributeKey[String]("messaging.consumer.group.name")
+    val KafkaMessageKey        = AttributeKey[String]("messaging.kafka.message.key")
+    val KafkaMessageTombstone  = AttributeKey[Boolean]("messaging.kafka.message.tombstone")
+    val KafkaOffset            = AttributeKey[Long]("messaging.kafka.offset")
+    val BatchMessageCount      = AttributeKey[Long]("messaging.batch.message_count")
+
+  }
+
+  def sendSpanContext[K: KafkaMessageKey, V](
+    metadata: ProducerMetadata,
+    records: ProducerRecords[K, V]
+  ): SendSpanContext =
+    SendSpanContext(
+      topics = records.iterator.map(_.topic).toSet,
+      partitions = records.iterator.flatMap(_.partition).toSet,
+      recordCount = records.size,
+      messageKey = producerSingleRecordMessageKey(records),
+      clientId = metadata.clientId
+    )
+
+  def receiveSpanContext[K: KafkaMessageKey, V](
+    metadata: ConsumerMetadata,
+    records: Chunk[ConsumerRecord[K, V]]
+  ): ReceiveSpanContext =
+    ReceiveSpanContext(
+      topics = records.iterator.map(_.topic).toSet,
+      partitions = records.iterator.map(_.partition).toSet,
+      recordCount = records.size,
+      messageKey = consumerSingleRecordMessageKey(records),
+      offset = consumerSingleRecordOffset(records),
+      clientId = metadata.clientId,
+      groupId = metadata.groupId
+    )
+
+  def processSpanContext[K: KafkaMessageKey, V](
+    metadata: ConsumerMetadata,
+    record: ConsumerRecord[K, V]
+  ): ProcessSpanContext =
+    ProcessSpanContext(
+      topic = record.topic,
+      partition = record.partition,
+      offset = record.offset,
+      messageKey = KafkaMessageKey[K].toMessageKey(record.key),
+      clientId = metadata.clientId,
+      groupId = metadata.groupId
+    )
+
+  def sendAttributes[K, V](ctx: SendSpanContext, records: ProducerRecords[K, V]): Attributes = {
+    val builder = baseBuilder(
+      operationName = "send",
+      operationType = "send",
+      topic = singleton(ctx.topics),
+      clientId = ctx.clientId,
+      consumerGroupName = None
+    )
+
+    // For producer send spans, span-level record attributes are only valid when the batch really
+    // describes one logical message or one logical topic-partition. We intentionally omit
+    // `messaging.destination.partition.id` for mixed-topic batches such as topic-a/0 + topic-b/0.
+    // See:
+    // - messaging spans: destination attributes belong to the operation the span actually describes
+    // - Kafka semconv: partition is a topic-partition concept, not a bare partition number
+    builder.addAll(
+      Keys.DestinationPartitionId.maybe(producerSingleLogicalPartition(records).map(_.toString))
+    )
+
+    // `messaging.kafka.message.key` and `messaging.kafka.message.tombstone` are attached at the
+    // span level only when this send span still represents exactly one produced message. For true
+    // batches, per-message detail moves to links instead of collapsing multiple values onto the span.
+    // See:
+    // https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+    builder.addAll(Keys.KafkaMessageKey.maybe(ctx.messageKey))
+    builder.addAll(Keys.KafkaMessageTombstone.maybe(producerSingleRecordTombstone(records)))
+
+    // `messaging.batch.message_count` is emitted only for actual batches, following the messaging
+    // span guidance that batch-only metadata should not be set on single-message operations.
+    builder.addAll(Keys.BatchMessageCount.maybe(Option.when(ctx.recordCount > 1)(ctx.recordCount)))
+
+    builder.result()
+  }
+
+  def createSpanName(topic: String): String =
+    s"create $topic"
+
+  def createAttributes[K: KafkaMessageKey, V](
+    metadata: ProducerMetadata,
+    record: ProducerRecord[K, V]
+  ): Attributes = {
+    val builder = baseBuilder(
+      operationName = "create",
+      operationType = "create",
+      topic = Some(record.topic),
+      clientId = metadata.clientId,
+      consumerGroupName = None
+    )
+
+    // A create span always describes exactly one message, so Kafka message attributes can be
+    // attached directly to the span. The partition is only available when the caller explicitly
+    // selected one on the producer record; otherwise Kafka chooses it later and we must not invent it.
+    // See:
+    // - messaging spans: single-message spans may carry per-message attributes directly
+    // - Kafka semconv: partition is optional until known
+    builder.addAll(Keys.DestinationPartitionId.maybe(record.partition.map(_.toString)))
+    builder.addAll(Keys.KafkaMessageKey.maybe(KafkaMessageKey[K].toMessageKey(record.key)))
+    builder.addAll(Keys.KafkaMessageTombstone.maybe(tombstoneAttribute(record.value)))
+
+    builder.result()
+  }
+
+  def receiveAttributes[K, V](
+    ctx: ReceiveSpanContext,
+    records: Chunk[ConsumerRecord[K, V]]
+  ): Attributes = {
+    val builder = baseBuilder(
+      operationName = "poll",
+      operationType = "receive",
+      topic = singleton(ctx.topics),
+      clientId = ctx.clientId,
+      consumerGroupName = ctx.groupId
+    )
+
+    // For receive spans, span-level partition attribution is only valid when the delivered chunk
+    // covers one logical topic-partition. Mixed-topic batches with the same numeric partition must
+    // not collapse to a fake singleton partition id.
+    builder.addAll(
+      Keys.DestinationPartitionId.maybe(consumerSingleLogicalPartition(records).map(_.toString))
+    )
+
+    // Message-level attributes stay on the receive span only when the delivered chunk contains one
+    // record. For larger chunks, the spec model is to keep the span generic and put per-message
+    // detail on links instead.
+    builder.addAll(Keys.KafkaMessageKey.maybe(ctx.messageKey))
+    builder.addAll(Keys.KafkaMessageTombstone.maybe(consumerSingleRecordTombstone(records)))
+    builder.addAll(Keys.KafkaOffset.maybe(ctx.offset))
+
+    // Batch count is only meaningful once the receive span represents more than one delivered
+    // message.
+    builder.addAll(Keys.BatchMessageCount.maybe(Option.when(ctx.recordCount > 1)(ctx.recordCount)))
+
+    builder.result()
+  }
+
+  def processAttributes[K, V](ctx: ProcessSpanContext, record: ConsumerRecord[K, V]): Attributes = {
+    val builder = baseBuilder(
+      operationName = "process",
+      operationType = "process",
+      topic = Some(ctx.topic),
+      clientId = ctx.clientId,
+      consumerGroupName = ctx.groupId
+    )
+
+    // A process span is always per-record, so the topic-partition and offset are known and belong
+    // directly on the span rather than on links.
+    builder.addOne(Keys.DestinationPartitionId(ctx.partition.toString))
+    builder.addAll(Keys.KafkaMessageKey.maybe(ctx.messageKey))
+    builder.addAll(Keys.KafkaMessageTombstone.maybe(tombstoneAttribute(record.value)))
+    builder.addOne(Keys.KafkaOffset(ctx.offset))
+
+    builder.result()
+  }
+
+  def receiveLinkAttributes[K: KafkaMessageKey, V](record: ConsumerRecord[K, V]): Attributes = {
+    val builder = Attributes.newBuilder
+
+    // Receive links carry the per-message Kafka detail that cannot always live on a batch receive
+    // span. That includes topic, partition, key, tombstone, and offset for the specific consumed
+    // record represented by the link.
+    builder.addOne(Keys.DestinationName(record.topic))
+    builder.addOne(Keys.DestinationPartitionId(record.partition.toString))
+    builder.addAll(Keys.KafkaMessageKey.maybe(KafkaMessageKey[K].toMessageKey(record.key)))
+    builder.addAll(Keys.KafkaMessageTombstone.maybe(tombstoneAttribute(record.value)))
+    builder.addOne(Keys.KafkaOffset(record.offset))
+
+    builder.result()
+  }
+
+  def sendLinkAttributes[K: KafkaMessageKey, V](record: ProducerRecord[K, V]): Attributes = {
+    val builder = Attributes.newBuilder
+
+    // Send links describe the message creation context or create span associated with one produced
+    // record. We keep per-record Kafka details on the link so batch send spans do not need to
+    // collapse multiple destinations or keys into one span-level value.
+    builder.addOne(Keys.DestinationName(record.topic))
+    builder.addAll(Keys.DestinationPartitionId.maybe(record.partition.map(_.toString)))
+    builder.addAll(Keys.KafkaMessageKey.maybe(KafkaMessageKey[K].toMessageKey(record.key)))
+    builder.addAll(Keys.KafkaMessageTombstone.maybe(tombstoneAttribute(record.value)))
+
+    builder.result()
+  }
+
+  def sendResultAttributes[K, V](result: ProducerResult[K, V]): Attributes =
+    Option
+      .when(result.size == 1)(result.head.get)
+      .map { case (_, metadata) => singleRecordSendResultAttributes(metadata) }
+      .getOrElse(Attributes.empty)
+
+  private def baseBuilder(
+    operationName: String,
+    operationType: String,
+    topic: Option[String],
+    clientId: Option[String],
+    consumerGroupName: Option[String]
+  ): Attributes.Builder = {
+    val builder = Attributes.newBuilder
+
+    // These are the common messaging span attributes shared by send / create / receive / process:
+    // system, operation type, operation name, destination name, producer/consumer client id, and
+    // consumer group when applicable.
+    // See:
+    // - messaging spans: operation naming and generic messaging attributes
+    // - Kafka semconv: `messaging.client.id` and `messaging.consumer.group.name`
+    builder.addOne(Const.MessagingSystem)
+    builder.addOne(Keys.OperationType(operationType))
+    builder.addOne(Keys.OperationName(operationName))
+    builder.addAll(Keys.DestinationName.maybe(topic))
+    builder.addAll(Keys.ClientId.maybe(clientId))
+    builder.addAll(Keys.ConsumerGroupName.maybe(consumerGroupName))
+
+    builder
+  }
+
+  // if there are more than 1 entry, we must return None
+  private def singleton[A](values: Set[A]): Option[A] =
+    Option.when(values.size == 1)(values.head)
+
+  private def producerSingleRecordMessageKey[K: KafkaMessageKey, V](
+    records: ProducerRecords[K, V]
+  ): Option[String] =
+    Option
+      .when(records.size == 1)(records.head.get)
+      .flatMap(record => KafkaMessageKey[K].toMessageKey(record.key))
+
+  private def consumerSingleRecordMessageKey[K: KafkaMessageKey, V](
+    records: Chunk[ConsumerRecord[K, V]]
+  ): Option[String] =
+    Option
+      .when(records.size == 1)(records.head)
+      .flatten
+      .flatMap(record => KafkaMessageKey[K].toMessageKey(record.key))
+
+  private def producerSingleRecordTombstone[K, V](
+    records: ProducerRecords[K, V]
+  ): Option[Boolean] =
+    Option
+      .when(records.size == 1)(records.head.get)
+      .flatMap(record => tombstoneAttribute(record.value))
+
+  private def consumerSingleRecordTombstone[K, V](
+    records: Chunk[ConsumerRecord[K, V]]
+  ): Option[Boolean] =
+    Option
+      .when(records.size == 1)(records.head)
+      .flatten
+      .flatMap(record => tombstoneAttribute(record.value))
+
+  private def consumerSingleRecordOffset[K, V](
+    records: Chunk[ConsumerRecord[K, V]]
+  ): Option[Long] =
+    Option.when(records.size == 1)(records.head).flatten.map(_.offset)
+
+  private def producerSingleLogicalPartition[K, V](
+    records: ProducerRecords[K, V]
+  ): Option[Int] = {
+    val topicPartitions = records
+      .iterator
+      .map(record => record.partition.map(record.topic -> _))
+      .toList
+
+    Option
+      .when(topicPartitions.nonEmpty && topicPartitions.forall(_.isDefined))(
+        topicPartitions.flatten.toSet
+      )
+      .flatMap(singleton)
+      .map(_._2)
+  }
+
+  private def consumerSingleLogicalPartition[K, V](
+    records: Chunk[ConsumerRecord[K, V]]
+  ): Option[Int] =
+    singleton(records.iterator.map(record => record.topic -> record.partition).toSet).map(_._2)
+
+  private def tombstoneAttribute(value: Any): Option[Boolean] =
+    Option.when(value == null)(true)
+
+  private def singleRecordSendResultAttributes(metadata: RecordMetadata): Attributes = {
+    val builder = Attributes.newBuilder
+
+    // Producer result metadata is only available after Kafka acknowledges a single produced record.
+    // At that point the chosen partition and broker-assigned offset become known and can be added to
+    // the send span as result attributes.
+    builder.addOne(Keys.DestinationPartitionId(metadata.partition.toString))
+    builder.addOne(Keys.KafkaOffset(metadata.offset))
+
+    builder.result()
+  }
+
+}

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/syntax.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/syntax.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import fs2.kafka._
+import fs2.Chunk
+
+/**
+  * Producer-side syntax for the `fs2-kafka-otel4s` module.
+  *
+  * This syntax operates on an implicit [[TracedKafkaProducer]].
+  *
+  * It is intended for cases where a traced producer has already been bound through
+  * [[fs2.kafka.otel4s.KafkaTracer#producer]], and you want compact syntax for header propagation or
+  * traced sends at the call site.
+  *
+  * See the OpenTelemetry messaging and Kafka semantic conventions:
+  *
+  *   - https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+  *   - https://opentelemetry.io/docs/specs/semconv/messaging/kafka/
+  */
+trait ProducerTracingSyntax {
+
+  implicit final class ProducerRecordTracingOps[K, V](
+    private val record: ProducerRecord[K, V]
+  ) {
+
+    def injectTracingHeaders[F[_]](implicit
+      tracedProducer: TracedKafkaProducer[F, K, V]
+    ): F[ProducerRecord[K, V]] =
+      tracedProducer.injectHeaders(record)
+
+  }
+
+  implicit final class ProducerRecordsTracingOps[K, V](
+    private val records: ProducerRecords[K, V]
+  ) {
+
+    def injectTracingHeaders[F[_]](implicit
+      tracedProducer: TracedKafkaProducer[F, K, V]
+    ): F[ProducerRecords[K, V]] =
+      tracedProducer.injectHeaders(records)
+
+  }
+
+  implicit final class TracedKafkaProducerTracingOps[F[_], K, V](
+    private val producer: TracedKafkaProducer[F, K, V]
+  ) {
+
+    /**
+      * Produces records with tracing and awaits Kafka completion immediately.
+      *
+      * Prefer this over the underlying producer's two-stage `produce` when you want `send` span
+      * timing to match the actual Kafka send.
+      */
+    def produceTraced(
+      records: ProducerRecords[K, V]
+    ): F[ProducerResult[K, V]] =
+      producer.produceAwaited(records)
+
+    /**
+      * Produces one record with tracing and awaits Kafka completion immediately.
+      */
+    def produceOneTraced(
+      record: ProducerRecord[K, V]
+    ): F[ProducerResult[K, V]] =
+      producer.produceOneAwaited(record)
+
+  }
+
+}
+
+/**
+  * Consumer-side syntax for the `fs2-kafka-otel4s` module.
+  *
+  * This syntax operates on an implicit [[TracedKafkaConsumer]] that should normally be derived once
+  * from [[fs2.kafka.otel4s.KafkaTracer#consumer]] and then reused at record or chunk boundaries.
+  *
+  * Prefer the methods on [[TracedKafkaConsumer]] directly when that reads more clearly at the call
+  * site. The syntax is mainly intended for stream code where `traceReceive` and `traceProcess`
+  * improve local readability.
+  *
+  * See the OpenTelemetry messaging and Kafka semantic conventions:
+  *
+  *   - https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+  *   - https://opentelemetry.io/docs/specs/semconv/messaging/kafka/
+  */
+trait ConsumerTracingSyntax {
+
+  implicit final class ConsumerRecordChunkTracingOps[K, V](
+    private val records: Chunk[ConsumerRecord[K, V]]
+  ) {
+
+    def traceReceive[F[_], A](fa: F[A])(implicit
+      tracedConsumer: TracedKafkaConsumer[F, K, V]
+    ): F[A] =
+      tracedConsumer.receive(records)(fa)
+
+  }
+
+  implicit final class ConsumerChunkTracingOps[F[_], K, V](
+    private val records: Chunk[CommittableConsumerRecord[F, K, V]]
+  ) {
+
+    def traceReceive[A](fa: F[A])(implicit tracedConsumer: TracedKafkaConsumer[F, K, V]): F[A] =
+      tracedConsumer.receiveCommittable(records)(fa)
+
+  }
+
+  implicit final class ConsumerRecordTracingOps[K, V](
+    private val record: ConsumerRecord[K, V]
+  ) {
+
+    def traceProcess[F[_], A](fa: F[A])(implicit
+      tracedConsumer: TracedKafkaConsumer[F, K, V]
+    ): F[A] =
+      tracedConsumer.process(record)(fa)
+
+  }
+
+  implicit final class CommittableConsumerRecordTracingOps[F[_], K, V](
+    private val record: CommittableConsumerRecord[F, K, V]
+  ) {
+
+    def traceProcess[A](fa: F[A])(implicit tracedConsumer: TracedKafkaConsumer[F, K, V]): F[A] =
+      tracedConsumer.process(record)(fa)
+
+  }
+
+}
+
+/**
+  * Syntax imports for traced producer helpers and consumer-bound tracing helpers.
+  */
+object syntax extends ProducerTracingSyntax with ConsumerTracingSyntax

--- a/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/syntax.scala
+++ b/modules/otel4s-trace/src/main/scala/fs2/kafka/otel4s/trace/syntax.scala
@@ -10,18 +10,11 @@ import fs2.kafka._
 import fs2.Chunk
 
 /**
-  * Producer-side syntax for the `fs2-kafka-otel4s` module.
-  *
   * This syntax operates on an implicit [[TracedKafkaProducer]].
   *
   * It is intended for cases where a traced producer has already been bound through
   * [[fs2.kafka.otel4s.KafkaTracer#producer]], and you want compact syntax for header propagation or
   * traced sends at the call site.
-  *
-  * See the OpenTelemetry messaging and Kafka semantic conventions:
-  *
-  *   - https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
-  *   - https://opentelemetry.io/docs/specs/semconv/messaging/kafka/
   */
 trait ProducerTracingSyntax {
 
@@ -75,19 +68,12 @@ trait ProducerTracingSyntax {
 }
 
 /**
-  * Consumer-side syntax for the `fs2-kafka-otel4s` module.
-  *
   * This syntax operates on an implicit [[TracedKafkaConsumer]] that should normally be derived once
   * from [[fs2.kafka.otel4s.KafkaTracer#consumer]] and then reused at record or chunk boundaries.
   *
   * Prefer the methods on [[TracedKafkaConsumer]] directly when that reads more clearly at the call
   * site. The syntax is mainly intended for stream code where `traceReceive` and `traceProcess`
   * improve local readability.
-  *
-  * See the OpenTelemetry messaging and Kafka semantic conventions:
-  *
-  *   - https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
-  *   - https://opentelemetry.io/docs/specs/semconv/messaging/kafka/
   */
 trait ConsumerTracingSyntax {
 

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/CustomTraceContextPropagator.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/CustomTraceContextPropagator.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import io.opentelemetry.api.trace.{
+  Span => OtelSpan,
+  SpanContext => OtelSpanContext,
+  TraceFlags => OtelTraceFlags,
+  TraceState
+}
+import io.opentelemetry.context.propagation.{
+  TextMapGetter => OtelTextMapGetter,
+  TextMapPropagator,
+  TextMapSetter
+}
+import io.opentelemetry.context.Context
+
+object CustomTraceContextPropagator extends TextMapPropagator {
+
+  val customPropagationHeader = "x-custom-trace"
+
+  override def fields(): java.util.Collection[String] =
+    java.util.Collections.singleton(customPropagationHeader)
+
+  override def inject[C](context: Context, carrier: C, setter: TextMapSetter[C]): Unit = {
+    val spanContext = OtelSpan.fromContext(context).getSpanContext
+
+    if (spanContext.isValid)
+      setter.set(carrier, customPropagationHeader, encodeCustomSpanContext(spanContext))
+  }
+
+  override def extract[C](
+    context: Context,
+    carrier: C,
+    getter: OtelTextMapGetter[C]
+  ): Context =
+    Option(getter.get(carrier, customPropagationHeader))
+      .flatMap(decodeCustomSpanContext)
+      .fold(context)(spanContext => context.`with`(OtelSpan.wrap(spanContext)))
+
+  private def encodeCustomSpanContext(spanContext: OtelSpanContext): String =
+    s"${spanContext.getTraceId}->${spanContext.getSpanId}"
+
+  private def decodeCustomSpanContext(value: String): Option[OtelSpanContext] =
+    value.split("->", -1).toList match {
+      case traceId :: spanId :: Nil if isHex(traceId, 32) && isHex(spanId, 16) =>
+        Some(
+          OtelSpanContext.createFromRemoteParent(
+            traceId,
+            spanId,
+            OtelTraceFlags.getSampled,
+            TraceState.getDefault
+          )
+        )
+
+      case _ =>
+        None
+    }
+
+  private def isHex(value: String, expectedLength: Int): Boolean =
+    value.length == expectedLength && value.forall(ch => Character.digit(ch, 16) >= 0)
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaConsumerTracingSuite.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaConsumerTracingSuite.scala
@@ -1,0 +1,628 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import cats.effect.IO
+import fs2.kafka._
+import fs2.Chunk
+
+import org.typelevel.otel4s.oteljava.testkit.trace._
+import org.typelevel.otel4s.oteljava.testkit.AttributesExpectation
+import org.typelevel.otel4s.semconv.attributes.ServerAttributes
+import org.typelevel.otel4s.semconv.experimental.attributes.MessagingExperimentalAttributes
+import org.typelevel.otel4s.trace.Tracer
+
+final class KafkaConsumerTracingSuite extends KafkaTracingTestSupport {
+
+  final class UnrepresentableKey(val value: String)
+  final class CustomKey(val value: String)
+
+  test("process links propagated context and emits a process span") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        import testkit.appTracer
+
+        for {
+          producerTracer <- testkit.tracedProducer[String, String](
+                              StubKafkaProducer.metadataOnly("producer-client")
+                            )
+          produced <- Tracer[IO]
+                        .rootSpan("producer-root")
+                        .surround {
+                          for {
+                            span       <- Tracer[IO].currentSpanOrThrow
+                            propagated <-
+                              producerTracer.injectHeaders(ProducerRecord("topic", "key", "value"))
+                          } yield (span.context, propagated)
+                        }
+          (producerRootContext, propagated) = produced
+          consumed                          = ConsumerRecord("topic", 0, 42L, "key", "value").withHeaders(propagated.headers)
+          consumerTracer                   <- testkit.tracedConsumer[String, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group")
+                            )
+          _     <- consumerTracer.process(consumed)(IO.unit)
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation.internal("producer-root").scopeName("fs2.kafka.otel4s.tests")
+                     ),
+                     TraceExpectation.leaf(
+                       SpanExpectation
+                         .consumer("process topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           MessagingExperimentalAttributes.MessagingSystem(
+                             MessagingExperimentalAttributes.MessagingSystemValue.Kafka
+                           ),
+                           MessagingExperimentalAttributes.MessagingDestinationName("topic"),
+                           MessagingExperimentalAttributes.MessagingDestinationPartitionId("0"),
+                           MessagingExperimentalAttributes.MessagingOperationName("process"),
+                           MessagingExperimentalAttributes.MessagingOperationType("process"),
+                           MessagingExperimentalAttributes.MessagingClientId("consumer-client"),
+                           MessagingExperimentalAttributes.MessagingConsumerGroupName(
+                             "consumer-group"
+                           ),
+                           MessagingExperimentalAttributes.MessagingKafkaMessageKey("key"),
+                           MessagingExperimentalAttributes.MessagingKafkaOffset(42L)
+                         )
+                         .noParentSpanContext
+                         .links(
+                           LinkSetExpectation.exactly(
+                             LinkExpectation
+                               .any
+                               .spanContext(
+                                 SpanContextExpectation
+                                   .any
+                                   .traceIdHex(producerRootContext.traceIdHex)
+                                   .spanIdHex(producerRootContext.spanIdHex)
+                               )
+                           )
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("receive emits a poll span and links to message creation contexts") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        import testkit.appTracer
+
+        for {
+          producerTracer <- testkit.tracedProducer[String, String](
+                              StubKafkaProducer.metadataOnly("producer-client")
+                            )
+          consumerTracer <- testkit.tracedConsumer[String, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group")
+                            )
+          produced <- Tracer[IO]
+                        .rootSpan("producer-root")
+                        .surround {
+                          for {
+                            span    <- Tracer[IO].currentSpanOrThrow
+                            record1 <-
+                              producerTracer.injectHeaders(ProducerRecord("topic", "k1", "v1"))
+                            record2 <-
+                              producerTracer.injectHeaders(ProducerRecord("topic", "k2", "v2"))
+                          } yield (span.context, record1, record2)
+                        }
+          (producerRootContext, record1, record2) = produced
+          records                                 = Chunk(
+                      ConsumerRecord("topic", 0, 1L, "k1", "v1").withHeaders(record1.headers),
+                      ConsumerRecord("topic", 0, 2L, "k2", "v2").withHeaders(record2.headers)
+                    )
+          _     <- consumerTracer.receive(records)(IO.unit)
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation.internal("producer-root").scopeName("fs2.kafka.otel4s.tests")
+                     ),
+                     root(
+                       SpanExpectation
+                         .client("poll topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           MessagingExperimentalAttributes.MessagingSystem(
+                             MessagingExperimentalAttributes.MessagingSystemValue.Kafka
+                           ),
+                           MessagingExperimentalAttributes.MessagingDestinationName("topic"),
+                           MessagingExperimentalAttributes.MessagingDestinationPartitionId("0"),
+                           MessagingExperimentalAttributes.MessagingOperationName("poll"),
+                           MessagingExperimentalAttributes.MessagingOperationType("receive"),
+                           MessagingExperimentalAttributes.MessagingClientId("consumer-client"),
+                           MessagingExperimentalAttributes.MessagingConsumerGroupName(
+                             "consumer-group"
+                           ),
+                           MessagingExperimentalAttributes.MessagingBatchMessageCount(2L)
+                         )
+                         .noParentSpanContext
+                         .links(
+                           LinkSetExpectation.exactly(
+                             LinkExpectation
+                               .any
+                               .spanContext(
+                                 SpanContextExpectation
+                                   .any
+                                   .traceIdHex(producerRootContext.traceIdHex)
+                                   .spanIdHex(producerRootContext.spanIdHex)
+                               ),
+                             LinkExpectation
+                               .any
+                               .spanContext(
+                                 SpanContextExpectation
+                                   .any
+                                   .traceIdHex(producerRootContext.traceIdHex)
+                                   .spanIdHex(producerRootContext.spanIdHex)
+                               )
+                           )
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("receive keeps heterogeneous batch detail on links when span-level values vary") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producerTracer <- testkit.tracedProducer[String, String](
+                              StubKafkaProducer.metadataOnly("producer-client")
+                            )
+          consumerTracer <- testkit.tracedConsumer[String, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group")
+                            )
+          produced <- testkit
+                        .appTracer
+                        .rootSpan("producer-root")
+                        .surround {
+                          for {
+                            record1 <- producerTracer.injectHeaders(
+                                         ProducerRecord("topic-a", "key-a", "value-a")
+                                       )
+                            record2 <-
+                              producerTracer.injectHeaders(
+                                ProducerRecord("topic-b", "key-b", null.asInstanceOf[String])
+                                  .withPartition(3)
+                              )
+                          } yield (record1, record2)
+                        }
+          (record1, record2) = produced
+          records            = Chunk(
+                      ConsumerRecord("topic-a", 0, 1L, "key-a", "value-a").withHeaders(
+                        record1.headers
+                      ),
+                      ConsumerRecord("topic-b", 3, 2L, "key-b", null.asInstanceOf[String])
+                        .withHeaders(record2.headers)
+                    )
+          _     <- consumerTracer.receive(records)(IO.unit)
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation.internal("producer-root").scopeName("fs2.kafka.otel4s.tests")
+                     ),
+                     root(
+                       SpanExpectation
+                         .client("poll")
+                         .scopeName("fs2.kafka")
+                         .attributes(
+                           AttributesExpectation.where(
+                             "must keep heterogeneous batch detail off the span attributes"
+                           )(attrs =>
+                             attrs
+                               .get(MessagingExperimentalAttributes.MessagingDestinationName)
+                               .isEmpty &&
+                               attrs
+                                 .get(
+                                   MessagingExperimentalAttributes.MessagingDestinationPartitionId
+                                 )
+                                 .isEmpty &&
+                               attrs
+                                 .get(
+                                   MessagingExperimentalAttributes.MessagingKafkaMessageTombstone
+                                 )
+                                 .isEmpty &&
+                               attrs
+                                 .get(MessagingExperimentalAttributes.MessagingBatchMessageCount)
+                                 .contains(
+                                   MessagingExperimentalAttributes.MessagingBatchMessageCount(2L)
+                                 )
+                           )
+                         )
+                         .links(
+                           LinkSetExpectation.exactly(
+                             LinkExpectation
+                               .any
+                               .attributesSubset(
+                                 MessagingExperimentalAttributes.MessagingDestinationName(
+                                   "topic-a"
+                                 ),
+                                 MessagingExperimentalAttributes.MessagingDestinationPartitionId(
+                                   "0"
+                                 ),
+                                 MessagingExperimentalAttributes.MessagingKafkaMessageKey("key-a"),
+                                 MessagingExperimentalAttributes.MessagingKafkaOffset(1L)
+                               ),
+                             LinkExpectation
+                               .any
+                               .attributesSubset(
+                                 MessagingExperimentalAttributes.MessagingDestinationName(
+                                   "topic-b"
+                                 ),
+                                 MessagingExperimentalAttributes.MessagingDestinationPartitionId(
+                                   "3"
+                                 ),
+                                 MessagingExperimentalAttributes.MessagingKafkaMessageKey("key-b"),
+                                 MessagingExperimentalAttributes.MessagingKafkaMessageTombstone(
+                                   true
+                                 ),
+                                 MessagingExperimentalAttributes.MessagingKafkaOffset(2L)
+                               )
+                           )
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("receive does not emit span-level partition id for mixed-topic same-number partitions") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        import testkit.appTracer
+
+        for {
+          producerTracer <- testkit.tracedProducer[String, String](
+                              StubKafkaProducer.metadataOnly("producer-client")
+                            )
+          consumerTracer <- testkit.tracedConsumer[String, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group")
+                            )
+          produced <- appTracer
+                        .rootSpan("producer-root")
+                        .surround {
+                          for {
+                            record1 <- producerTracer.injectHeaders(
+                                         ProducerRecord("topic-a", "key-a", "value-a")
+                                           .withPartition(0)
+                                       )
+                            record2 <- producerTracer.injectHeaders(
+                                         ProducerRecord("topic-b", "key-b", "value-b")
+                                           .withPartition(0)
+                                       )
+                          } yield (record1, record2)
+                        }
+          (record1, record2) = produced
+          records            = Chunk(
+                      ConsumerRecord("topic-a", 0, 1L, "key-a", "value-a").withHeaders(
+                        record1.headers
+                      ),
+                      ConsumerRecord("topic-b", 0, 2L, "key-b", "value-b").withHeaders(
+                        record2.headers
+                      )
+                    )
+          _     <- consumerTracer.receive(records)(IO.unit)
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation.internal("producer-root").scopeName("fs2.kafka.otel4s.tests")
+                     ),
+                     root(
+                       SpanExpectation
+                         .client("poll")
+                         .scopeName("fs2.kafka")
+                         .attributes(
+                           AttributesExpectation.where(
+                             "must omit span-level partition id for mixed-topic batches"
+                           )(
+                             _.get(MessagingExperimentalAttributes.MessagingDestinationPartitionId)
+                               .isEmpty
+                           )
+                         )
+                         .links(
+                           LinkSetExpectation
+                             .count(2)
+                             .and(
+                               LinkSetExpectation.forall(
+                                 LinkExpectation
+                                   .any
+                                   .attributesSubset(
+                                     MessagingExperimentalAttributes
+                                       .MessagingDestinationPartitionId("0")
+                                   )
+                               )
+                             )
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("receive and process do not create extracted-context links when headers are absent") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        val record = ConsumerRecord("topic", 0, 42L, "key", "value")
+
+        for {
+          consumerTracer <- testkit.tracedConsumer[String, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group")
+                            )
+          _ <- testkit
+                 .appTracer
+                 .rootSpan("ambient-span")
+                 .surround {
+                   consumerTracer.receive(Chunk.singleton(record)) {
+                     consumerTracer.process(record)(IO.unit)
+                   }
+                 }
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.ordered(
+                     root(
+                       SpanExpectation.internal("ambient-span").scopeName("fs2.kafka.otel4s.tests"),
+                       TraceExpectation.ordered(
+                         SpanExpectation
+                           .client("poll topic")
+                           .scopeName("fs2.kafka")
+                           .attributesSubset(
+                             MessagingExperimentalAttributes.MessagingSystem(
+                               MessagingExperimentalAttributes.MessagingSystemValue.Kafka
+                             ),
+                             MessagingExperimentalAttributes.MessagingDestinationName("topic"),
+                             MessagingExperimentalAttributes.MessagingDestinationPartitionId("0"),
+                             MessagingExperimentalAttributes.MessagingOperationName("poll"),
+                             MessagingExperimentalAttributes.MessagingOperationType("receive"),
+                             MessagingExperimentalAttributes.MessagingClientId("consumer-client"),
+                             MessagingExperimentalAttributes.MessagingConsumerGroupName(
+                               "consumer-group"
+                             ),
+                             MessagingExperimentalAttributes.MessagingKafkaMessageKey("key"),
+                             MessagingExperimentalAttributes.MessagingKafkaOffset(42L)
+                           )
+                           .linkCount(0),
+                         TraceExpectation.leaf(
+                           SpanExpectation
+                             .consumer("process topic")
+                             .scopeName("fs2.kafka")
+                             .attributesSubset(
+                               MessagingExperimentalAttributes.MessagingSystem(
+                                 MessagingExperimentalAttributes.MessagingSystemValue.Kafka
+                               ),
+                               MessagingExperimentalAttributes.MessagingDestinationName("topic"),
+                               MessagingExperimentalAttributes.MessagingDestinationPartitionId("0"),
+                               MessagingExperimentalAttributes.MessagingOperationName("process"),
+                               MessagingExperimentalAttributes.MessagingOperationType("process"),
+                               MessagingExperimentalAttributes.MessagingClientId("consumer-client"),
+                               MessagingExperimentalAttributes.MessagingConsumerGroupName(
+                                 "consumer-group"
+                               ),
+                               MessagingExperimentalAttributes.MessagingKafkaMessageKey("key"),
+                               MessagingExperimentalAttributes.MessagingKafkaOffset(42L)
+                             )
+                             .linkCount(0)
+                         )
+                       )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("single-message send and process use a custom KafkaMessageKey instance when provided") {
+    implicit val customKafkaMessageKey: KafkaMessageKey[CustomKey] =
+      KafkaMessageKey.instance(key => Some(s"custom:${key.value}"))
+
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producer       <- StubKafkaProducer.recorder[CustomKey, String]()
+          producerTracer <- testkit.tracedProducer[CustomKey, String](producer)
+          consumerTracer <- testkit.tracedConsumer[CustomKey, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group")
+                            )
+          _ <- producerTracer.produceAwaited(
+                 ProducerRecords.one(ProducerRecord("topic", new CustomKey("key"), "value"))
+               )
+          _ <- consumerTracer.process(
+                 ConsumerRecord("topic", 0, 42L, new CustomKey("key"), "value")
+               )(IO.unit)
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .producer("send topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           MessagingExperimentalAttributes.MessagingKafkaMessageKey("custom:key")
+                         )
+                     ),
+                     root(
+                       SpanExpectation
+                         .consumer("process topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           MessagingExperimentalAttributes.MessagingKafkaMessageKey("custom:key")
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test(
+    "single-message process omits messaging.kafka.message.key for null and unrepresentable keys"
+  ) {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          consumerTracer <- testkit.tracedConsumer[AnyRef, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group")
+                            )
+          _ <- consumerTracer.process(
+                 ConsumerRecord("topic", 0, 42L, null.asInstanceOf[AnyRef], "value")
+               )(IO.unit)
+          _ <- consumerTracer.process(
+                 ConsumerRecord("topic", 0, 43L, new UnrepresentableKey("secret"), "value")
+               )(IO.unit)
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .consumer("process topic")
+                         .scopeName("fs2.kafka")
+                         .attributes(
+                           AttributesExpectation.where("must omit message key for null keys")(
+                             _.get(MessagingExperimentalAttributes.MessagingKafkaMessageKey).isEmpty
+                           )
+                         )
+                     ),
+                     root(
+                       SpanExpectation
+                         .consumer("process topic")
+                         .scopeName("fs2.kafka")
+                         .attributes(
+                           AttributesExpectation.where(
+                             "must omit message key for unrepresentable keys"
+                           )(
+                             _.get(MessagingExperimentalAttributes.MessagingKafkaMessageKey).isEmpty
+                           )
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("single-message receive and process emit messaging.kafka.message.tombstone for null values") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          consumerTracer <- testkit.tracedConsumer[String, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group")
+                            )
+          record = ConsumerRecord("topic", 0, 42L, "key", null.asInstanceOf[String])
+          _     <- consumerTracer.receive(Chunk.singleton(record))(IO.unit)
+          _     <- consumerTracer.process(record)(IO.unit)
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .client("poll topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           MessagingExperimentalAttributes.MessagingKafkaOffset(42L),
+                           MessagingExperimentalAttributes.MessagingKafkaMessageTombstone(true)
+                         )
+                     ),
+                     root(
+                       SpanExpectation
+                         .consumer("process topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           MessagingExperimentalAttributes.MessagingKafkaMessageTombstone(true)
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("configured server address is emitted on consumer receive and process spans") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          consumerTracer <- testkit.tracedConsumer[String, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group"),
+                              KafkaTracer
+                                .Config
+                                .default
+                                .withServerAddress("kafka.internal", Some(9092))
+                            )
+          record = ConsumerRecord("topic", 0, 42L, "key", "value")
+          _     <- consumerTracer.receive(Chunk.singleton(record))(IO.unit)
+          _     <- consumerTracer.process(record)(IO.unit)
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .client("poll topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           ServerAttributes.ServerAddress("kafka.internal"),
+                           ServerAttributes.ServerPort(9092L)
+                         )
+                     ),
+                     root(
+                       SpanExpectation
+                         .consumer("process topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           ServerAttributes.ServerAddress("kafka.internal"),
+                           ServerAttributes.ServerPort(9092L)
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaMessageKeySuite.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaMessageKeySuite.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import java.util.UUID
+
+import munit.FunSuite
+
+class KafkaMessageKeySuite extends FunSuite {
+
+  final private class UnknownKey(val value: String)
+  final private class CustomKey(val value: String)
+
+  test("string instance preserves the key value and omits null") {
+    val instance = KafkaMessageKey[String]
+
+    assertEquals(instance.toMessageKey("key"), Some("key"))
+    assertEquals(instance.toMessageKey(null), None)
+  }
+
+  test("built-in scalar instances render canonical string values") {
+    assertEquals(KafkaMessageKey[Int].toMessageKey(42), Some("42"))
+    assertEquals(KafkaMessageKey[Long].toMessageKey(42L), Some("42"))
+    assertEquals(
+      KafkaMessageKey[UUID].toMessageKey(UUID.fromString("123e4567-e89b-12d3-a456-426614174000")),
+      Some("123e4567-e89b-12d3-a456-426614174000")
+    )
+  }
+
+  test("boxed numeric keys fall back to omission") {
+    assertEquals(KafkaMessageKey[java.lang.Integer].toMessageKey(42: java.lang.Integer), None)
+    assertEquals(KafkaMessageKey[java.lang.Long].toMessageKey(42L: java.lang.Long), None)
+    assertEquals(KafkaMessageKey[UUID].toMessageKey(null), None)
+  }
+
+  test("fallback instance omits unknown key types") {
+    assertEquals(
+      KafkaMessageKey[UnknownKey].toMessageKey(new UnknownKey("secret")),
+      None
+    )
+  }
+
+  test("custom instance can define key rendering") {
+    implicit val customKafkaMessageKey: KafkaMessageKey[CustomKey] =
+      KafkaMessageKey.instance(key => Some(s"custom:${key.value}"))
+
+    assertEquals(
+      KafkaMessageKey[CustomKey].toMessageKey(new CustomKey("value")),
+      Some("custom:value")
+    )
+  }
+
+  test("contramap can derive wrapper instances from an existing renderer") {
+    implicit val customKafkaMessageKey: KafkaMessageKey[CustomKey] =
+      KafkaMessageKey[String].contramap(_.value)
+
+    assertEquals(
+      KafkaMessageKey[CustomKey].toMessageKey(new CustomKey("value")),
+      Some("value")
+    )
+  }
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaProducerTracingSuite.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaProducerTracingSuite.scala
@@ -1,0 +1,423 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import cats.effect.IO
+import fs2.kafka._
+import fs2.kafka.otel4s.trace.instances._
+import fs2.Chunk
+
+import org.typelevel.otel4s.context.propagation.TextMapGetter
+import org.typelevel.otel4s.oteljava.testkit.trace.{
+  LinkExpectation,
+  LinkSetExpectation,
+  SpanExpectation,
+  TraceForestExpectation
+}
+import org.typelevel.otel4s.oteljava.testkit.AttributesExpectation
+import org.typelevel.otel4s.semconv.attributes.ServerAttributes
+import org.typelevel.otel4s.semconv.experimental.attributes.MessagingExperimentalAttributes
+
+final class KafkaProducerTracingSuite extends KafkaTracingTestSupport {
+
+  final class UnrepresentableKey(val value: String)
+
+  test("produce injects tracing headers and emits a send span") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producer       <- StubKafkaProducer.recorder[String, String]()
+          tracedProducer <- testkit.tracedProducer(producer)
+          _              <- tracedProducer.produceAwaited(
+                 ProducerRecords.one(ProducerRecord("topic", "key", "value"))
+               )
+          produced <- producer.getCaptured
+          spans    <- testkit.finishedSpans
+          _        <- IO {
+                 assertEquals(produced.size, 1)
+                 assertEquals(produced.head.get.topic, "topic")
+                 assert(produced.head.get.headers.toChain.nonEmpty)
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .producer("send topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           MessagingExperimentalAttributes.MessagingSystem(
+                             MessagingExperimentalAttributes.MessagingSystemValue.Kafka
+                           ),
+                           MessagingExperimentalAttributes.MessagingDestinationName("topic"),
+                           MessagingExperimentalAttributes.MessagingOperationName("send"),
+                           MessagingExperimentalAttributes.MessagingOperationType("send"),
+                           MessagingExperimentalAttributes.MessagingClientId("producer-client"),
+                           MessagingExperimentalAttributes.MessagingKafkaMessageKey("key")
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("awaited producer helpers complete traced sends in one effect") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producer       <- StubKafkaProducer.recorder[String, String]()
+          tracedProducer <- testkit.tracedProducer(producer)
+          _              <- tracedProducer.produceAwaited(
+                 ProducerRecords.one(ProducerRecord("topic-a", "key-a", "value-a"))
+               )
+          _ <- tracedProducer.produceOneAwaited(
+                 ProducerRecord("topic-b", "key-b", "value-b")
+               )
+          completionCount <- producer.getCompletions
+          produced        <- producer.getCaptured
+          spans           <- testkit.finishedSpans
+          _               <- IO {
+                 assertEquals(completionCount, 2)
+                 assertEquals(produced.size, 1)
+                 assertEquals(produced.head.get.topic, "topic-b")
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation.producer("send topic-a").scopeName("fs2.kafka")
+                     ),
+                     root(
+                       SpanExpectation.producer("send topic-b").scopeName("fs2.kafka")
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("single-message send adds broker partition and offset after completion") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          tracedProducer <- testkit.tracedProducer[String, String](
+                              StubKafkaProducer.metadataOnly("producer-client")
+                            )
+          _     <- tracedProducer.produceOneAwaited(ProducerRecord("topic", "key", "value"))
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .producer("send topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           MessagingExperimentalAttributes.MessagingDestinationPartitionId("0"),
+                           MessagingExperimentalAttributes.MessagingKafkaOffset(42L)
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("batch produce creates per-message creation contexts and links the batch send span") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producer       <- StubKafkaProducer.recorder[String, String]()
+          tracedProducer <- testkit.tracedProducer(producer)
+          records         = Chunk(
+                      ProducerRecord("topic-a", "key-a", "value-a"),
+                      ProducerRecord("topic-b", "key-b", null.asInstanceOf[String]).withPartition(3)
+                    )
+          _        <- tracedProducer.produceAwaited(records)
+          produced <- producer.getCaptured
+          spans    <- testkit.finishedSpans
+          _        <- IO {
+                 assertEquals(produced.size, 2)
+
+                 val traceparents = produced
+                   .toList
+                   .map { record =>
+                     TextMapGetter[Headers]
+                       .get(record.headers, "traceparent")
+                       .getOrElse(fail("missing produced traceparent"))
+                   }
+                 assert(traceparents.distinct.size == 2)
+
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation.producer("create topic-a").scopeName("fs2.kafka")
+                     ),
+                     root(
+                       SpanExpectation.producer("create topic-b").scopeName("fs2.kafka")
+                     ),
+                     root(
+                       SpanExpectation
+                         .client("send")
+                         .scopeName("fs2.kafka")
+                         .attributes(
+                           AttributesExpectation.where(
+                             "must keep tombstone detail off the batch span"
+                           )(
+                             _.get(MessagingExperimentalAttributes.MessagingKafkaMessageTombstone)
+                               .isEmpty
+                           )
+                         )
+                         .links(
+                           LinkSetExpectation.exactly(
+                             LinkExpectation
+                               .any
+                               .attributesSubset(
+                                 MessagingExperimentalAttributes.MessagingDestinationName("topic-a")
+                               ),
+                             LinkExpectation
+                               .any
+                               .attributesSubset(
+                                 MessagingExperimentalAttributes.MessagingDestinationName(
+                                   "topic-b"
+                                 ),
+                                 MessagingExperimentalAttributes.MessagingKafkaMessageTombstone(
+                                   true
+                                 )
+                               )
+                           )
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("batch send does not emit span-level partition id for mixed-topic same-number partitions") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producer       <- StubKafkaProducer.recorder[String, String]()
+          tracedProducer <- testkit.tracedProducer(producer)
+          records         = Chunk(
+                      ProducerRecord("topic-a", "key-a", "value-a").withPartition(0),
+                      ProducerRecord("topic-b", "key-b", "value-b").withPartition(0)
+                    )
+          _     <- tracedProducer.produceAwaited(records)
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation.producer("create topic-a").scopeName("fs2.kafka")
+                     ),
+                     root(
+                       SpanExpectation.producer("create topic-b").scopeName("fs2.kafka")
+                     ),
+                     root(
+                       SpanExpectation
+                         .client("send")
+                         .scopeName("fs2.kafka")
+                         .attributes(
+                           AttributesExpectation.where(
+                             "must omit span-level partition id for mixed-topic batches"
+                           )(
+                             _.get(MessagingExperimentalAttributes.MessagingDestinationPartitionId)
+                               .isEmpty
+                           )
+                         )
+                         .links(
+                           LinkSetExpectation
+                             .count(2)
+                             .and(
+                               LinkSetExpectation.forall(
+                                 LinkExpectation
+                                   .any
+                                   .attributesSubset(
+                                     MessagingExperimentalAttributes
+                                       .MessagingDestinationPartitionId("0")
+                                   )
+                               )
+                             )
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("configured server address is emitted on spans") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        val config = KafkaTracer
+          .Config
+          .default
+          .withServerAddress(
+            "kafka.internal",
+            Some(9092)
+          )
+
+        for {
+          producer       <- StubKafkaProducer.recorder[String, String]()
+          tracedProducer <- testkit.tracedProducer(producer, config)
+          _              <- tracedProducer.produceAwaited(
+                 ProducerRecords.one(ProducerRecord("topic", "key", "value"))
+               )
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .producer("send topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           ServerAttributes.ServerAddress("kafka.internal"),
+                           ServerAttributes.ServerPort(9092L)
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("producer send spans omit endpoint metadata unless configured explicitly") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producerTracer <- testkit.tracedProducer[String, String](
+                              StubKafkaProducer.metadataOnly("producer-client")
+                            )
+          _ <- producerTracer.produceAwaited(
+                 ProducerRecords.one(ProducerRecord("topic", "key", "value"))
+               )
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .producer("send topic")
+                         .scopeName("fs2.kafka")
+                         .attributes(
+                           AttributesExpectation.where(
+                             "must omit endpoint metadata unless configured explicitly"
+                           )(attrs =>
+                             attrs.get(ServerAttributes.ServerAddress).isEmpty &&
+                               attrs.get(ServerAttributes.ServerPort).isEmpty
+                           )
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("single-message send omits messaging.kafka.message.key for null and unrepresentable keys") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          nullProducer         <- StubKafkaProducer.recorder[String, String]()
+          badProducer          <- StubKafkaProducer.recorder[UnrepresentableKey, String]()
+          stringProducerTracer <- testkit.tracedProducer[String, String](nullProducer)
+          badProducerTracer    <- testkit.tracedProducer[UnrepresentableKey, String](badProducer)
+          _                    <- stringProducerTracer.produceAwaited(
+                 ProducerRecords.one(ProducerRecord("topic", null.asInstanceOf[String], "value"))
+               )
+          _ <- badProducerTracer.produceAwaited(
+                 ProducerRecords.one(
+                   ProducerRecord("topic", new UnrepresentableKey("secret"), "value")
+                 )
+               )
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .producer("send topic")
+                         .scopeName("fs2.kafka")
+                         .attributes(
+                           AttributesExpectation.where("must omit message key for null keys")(
+                             _.get(MessagingExperimentalAttributes.MessagingKafkaMessageKey).isEmpty
+                           )
+                         )
+                     ),
+                     root(
+                       SpanExpectation
+                         .producer("send topic")
+                         .scopeName("fs2.kafka")
+                         .attributes(
+                           AttributesExpectation.where(
+                             "must omit message key for unrepresentable keys"
+                           )(
+                             _.get(MessagingExperimentalAttributes.MessagingKafkaMessageKey).isEmpty
+                           )
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("single-message send emits messaging.kafka.message.tombstone for null values") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producer       <- StubKafkaProducer.recorder[String, String]()
+          producerTracer <- testkit.tracedProducer[String, String](producer)
+          _              <- producerTracer.produceAwaited(
+                 ProducerRecords.one(ProducerRecord("topic", "key", null.asInstanceOf[String]))
+               )
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .producer("send topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           MessagingExperimentalAttributes.MessagingKafkaMessageTombstone(true)
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaPropagationSuite.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaPropagationSuite.scala
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import cats.effect.IO
+import fs2.kafka._
+import fs2.kafka.otel4s.trace.instances._
+
+import org.typelevel.otel4s.context.propagation.{TextMapGetter, TextMapUpdater}
+import org.typelevel.otel4s.oteljava.testkit.trace.{SpanExpectation, TraceForestExpectation}
+
+final class KafkaPropagationSuite extends KafkaTracingTestSupport {
+
+  test("headers text map updater replaces existing values for the same key") {
+    val headers =
+      TextMapUpdater[Headers].updated(
+        TextMapUpdater[Headers].updated(
+          Headers.empty,
+          "traceparent",
+          "old"
+        ),
+        "traceparent",
+        "new"
+      )
+
+    assertEquals(
+      TextMapGetter[Headers].get(headers, "traceparent"),
+      Some("new")
+    )
+    assertEquals(headers.toChain.iterator.count(_.key == "traceparent"), 1)
+  }
+
+  test("produce preserves an existing message creation context and links the send span to it") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        import testkit.appTracer
+
+        for {
+          producer       <- StubKafkaProducer.recorder[String, String]()
+          tracedProducer <- testkit.tracedProducer(producer)
+          prepared       <- appTracer
+                        .rootSpan("upstream-create-context")
+                        .surround {
+                          tracedProducer.injectHeaders(ProducerRecord("topic", "key", "value"))
+                        }
+          originalTraceparent = TextMapGetter[Headers]
+                                  .get(prepared.headers, "traceparent")
+                                  .getOrElse(fail("missing prepared traceparent"))
+          _        <- tracedProducer.produceOneAwaited(prepared)
+          produced <- producer.getCaptured
+          spans    <- testkit.finishedSpans
+          _        <- IO {
+                 val producedRecord      = produced.head.getOrElse(fail("missing produced record"))
+                 val producedTraceparent = TextMapGetter[Headers]
+                   .get(producedRecord.headers, "traceparent")
+                   .getOrElse(fail("missing produced traceparent"))
+
+                 assertEquals(producedTraceparent, originalTraceparent)
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .internal("upstream-create-context")
+                         .scopeName("fs2.kafka.otel4s.tests")
+                     ),
+                     root(
+                       SpanExpectation.client("send topic").scopeName("fs2.kafka").linkCount(1)
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("injectHeaders preserves an existing message creation context") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        val producerTracer =
+          testkit.tracedProducer[String, String](StubKafkaProducer.metadataOnly("producer-client"))
+
+        for {
+          producerTracer <- producerTracer
+          prepared       <- testkit
+                        .appTracer
+                        .rootSpan("upstream-create-context")
+                        .surround {
+                          producerTracer.injectHeaders(ProducerRecord("topic", "key", "value"))
+                        }
+          originalTraceparent = TextMapGetter[Headers]
+                                  .get(prepared.headers, "traceparent")
+                                  .getOrElse(fail("missing prepared traceparent"))
+          reinjected <- testkit
+                          .appTracer
+                          .rootSpan("different-current-context")
+                          .surround {
+                            producerTracer.injectHeaders(prepared)
+                          }
+          _ <- IO {
+                 val reinjectedTraceparent = TextMapGetter[Headers]
+                   .get(reinjected.headers, "traceparent")
+                   .getOrElse(fail("missing reinjected traceparent"))
+
+                 assertEquals(reinjectedTraceparent, originalTraceparent)
+                 assertEquals(reinjected.headers.toChain.iterator.count(_.key == "traceparent"), 1)
+               }
+        } yield ()
+      }
+  }
+
+  test("injectHeaders preserves an existing non-W3C creation context recognized by the configured propagator") {
+    KafkaTracerTestkit
+      .create(propagators = Seq(CustomTraceContextPropagator))
+      .use { testkit =>
+        val producerTracer =
+          testkit.tracedProducer[String, String](StubKafkaProducer.metadataOnly("producer-client"))
+
+        for {
+          producerTracer <- producerTracer
+          prepared       <- testkit
+                        .appTracer
+                        .rootSpan("upstream-custom-context")
+                        .surround {
+                          producerTracer.injectHeaders(ProducerRecord("topic", "key", "value"))
+                        }
+          originalCustomHeader =
+            TextMapGetter[Headers]
+              .get(prepared.headers, CustomTraceContextPropagator.customPropagationHeader)
+              .getOrElse(fail("missing prepared custom propagation header"))
+          reinjected <- testkit
+                          .appTracer
+                          .rootSpan("different-current-context")
+                          .surround {
+                            producerTracer.injectHeaders(prepared)
+                          }
+          _ <- IO {
+                 val reinjectedCustomHeader = TextMapGetter[Headers]
+                   .get(reinjected.headers, CustomTraceContextPropagator.customPropagationHeader)
+                   .getOrElse(fail("missing reinjected custom propagation header"))
+
+                 assertEquals(reinjectedCustomHeader, originalCustomHeader)
+                 assertEquals(
+                   reinjected
+                     .headers
+                     .toChain
+                     .iterator
+                     .count(_.key == CustomTraceContextPropagator.customPropagationHeader),
+                   1
+                 )
+                 assertEquals(
+                   TextMapGetter[Headers].get(reinjected.headers, "traceparent"),
+                   None
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("injectHeaders replaces malformed propagation input with the current context") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        val producerTracer =
+          testkit.tracedProducer[String, String](StubKafkaProducer.metadataOnly("producer-client"))
+
+        val malformed = ProducerRecord("topic", "key", "value").withHeaders(
+          Headers(Header("traceparent", "00-not-a-valid-traceparent"))
+        )
+
+        for {
+          producerTracer <- producerTracer
+          propagated     <- testkit
+                          .appTracer
+                          .rootSpan("replacement-context")
+                          .surround {
+                            producerTracer.injectHeaders(malformed)
+                          }
+          _ <- IO {
+                 val traceparent = TextMapGetter[Headers]
+                   .get(propagated.headers, "traceparent")
+                   .getOrElse(fail("missing propagated traceparent"))
+
+                 assertNotEquals(traceparent, "00-not-a-valid-traceparent")
+                 assertEquals(propagated.headers.toChain.iterator.count(_.key == "traceparent"), 1)
+               }
+        } yield ()
+      }
+  }
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaSyntaxSuite.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaSyntaxSuite.scala
@@ -16,7 +16,6 @@ import fs2.Stream
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 import org.typelevel.otel4s.context.propagation.TextMapGetter
-import org.typelevel.otel4s.oteljava.testkit.trace.SpanExpectation.producer
 
 final class KafkaSyntaxSuite extends KafkaTracingTestSupport {
 

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaSyntaxSuite.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaSyntaxSuite.scala
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import cats.effect.{IO, Ref}
+import fs2.kafka._
+import fs2.kafka.otel4s.trace.instances._
+import fs2.kafka.otel4s.trace.syntax._
+import fs2.Chunk
+import fs2.Stream
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+import org.typelevel.otel4s.context.propagation.TextMapGetter
+import org.typelevel.otel4s.oteljava.testkit.trace.SpanExpectation.producer
+
+final class KafkaSyntaxSuite extends KafkaTracingTestSupport {
+
+  test("ProducerRecord.injectTracingHeaders delegates to TracedKafkaProducer.injectHeaders") {
+    for {
+      injectedRecord <- Ref[IO].of(Option.empty[ProducerRecord[String, String]])
+      injectedBatch  <- emptyRef[ProducerRecords[String, String]]
+      awaitedBatch   <- emptyRef[ProducerRecords[String, String]]
+      awaitedSingle  <- emptyRef[ProducerRecord[String, String]]
+      producer       <-
+        IO(new ProducerSyntaxProbe(injectedRecord, injectedBatch, awaitedBatch, awaitedSingle))
+      record  = ProducerRecord("topic", "key", "value")
+      result <- record.injectTracingHeaders(producer)
+      seen   <- injectedRecord.get
+    } yield {
+      assertEquals(seen, Some(record))
+      assertEquals(TextMapGetter[Headers].get(result.headers, "x-syntax"), Some("record"))
+    }
+  }
+
+  test("ProducerRecords.injectTracingHeaders delegates to the batch inject overload") {
+    for {
+      injectedRecord <- emptyRef[ProducerRecord[String, String]]
+      injectedBatch  <- Ref[IO].of(Option.empty[ProducerRecords[String, String]])
+      awaitedBatch   <- emptyRef[ProducerRecords[String, String]]
+      awaitedSingle  <- emptyRef[ProducerRecord[String, String]]
+      producer       <-
+        IO(new ProducerSyntaxProbe(injectedRecord, injectedBatch, awaitedBatch, awaitedSingle))
+      records = ProducerRecords.one(ProducerRecord("topic", "key", "value"))
+      result <- records.injectTracingHeaders(producer)
+      seen   <- injectedBatch.get
+    } yield {
+      assertEquals(seen, Some(records))
+      assertEquals(result, records)
+    }
+  }
+
+  test("TracedKafkaProducer.produceTraced delegates to produceAwaited") {
+    for {
+      injectedRecord <- emptyRef[ProducerRecord[String, String]]
+      injectedBatch  <- emptyRef[ProducerRecords[String, String]]
+      awaitedBatch   <- Ref[IO].of(Option.empty[ProducerRecords[String, String]])
+      awaitedSingle  <- emptyRef[ProducerRecord[String, String]]
+      producer       <-
+        IO(new ProducerSyntaxProbe(injectedRecord, injectedBatch, awaitedBatch, awaitedSingle))
+      records = ProducerRecords.one(ProducerRecord("topic", "key", "value"))
+      result <- producer.produceTraced(records)
+      seen   <- awaitedBatch.get
+    } yield {
+      assertEquals(seen, Some(records))
+      assertEquals(result, Chunk.empty)
+    }
+  }
+
+  test("TracedKafkaProducer.produceOneTraced delegates to produceOneAwaited") {
+    for {
+      injectedRecord <- emptyRef[ProducerRecord[String, String]]
+      injectedBatch  <- emptyRef[ProducerRecords[String, String]]
+      awaitedBatch   <- emptyRef[ProducerRecords[String, String]]
+      awaitedSingle  <- Ref[IO].of(Option.empty[ProducerRecord[String, String]])
+      producer       <-
+        IO(new ProducerSyntaxProbe(injectedRecord, injectedBatch, awaitedBatch, awaitedSingle))
+      record  = ProducerRecord("topic", "key", "value")
+      result <- producer.produceOneTraced(record)
+      seen   <- awaitedSingle.get
+    } yield {
+      assertEquals(seen, Some(record))
+      assertEquals(result, Chunk.empty)
+    }
+  }
+
+  test("Chunk[ConsumerRecord].traceReceive delegates to receive") {
+    for {
+      receiveCommittableChunk <- emptyRef[Chunk[CommittableConsumerRecord[IO, String, String]]]
+      receiveChunk            <- Ref[IO].of(Option.empty[Chunk[ConsumerRecord[String, String]]])
+      processedRecord         <- emptyRef[ConsumerRecord[String, String]]
+      processedCommittable    <- emptyRef[CommittableConsumerRecord[IO, String, String]]
+      producer                <- IO(
+                    new ConsumerSyntaxProbe(
+                      receiveChunk,
+                      receiveCommittableChunk,
+                      processedRecord,
+                      processedCommittable
+                    )
+                  )
+      record  = ConsumerRecord("topic", 0, 42L, "key", "value")
+      chunk   = Chunk.singleton(record)
+      result <- chunk.traceReceive(IO.pure("ok"))(producer)
+      seen   <- receiveChunk.get
+    } yield {
+      assertEquals(seen, Some(chunk))
+      assertEquals(result, "ok")
+    }
+  }
+
+  test("Chunk[CommittableConsumerRecord].traceReceive delegates to receiveCommittable") {
+    val record       = ConsumerRecord("topic", 0, 42L, "key", "value")
+    val committable  = committableRecord(record)
+    val committables = Chunk.singleton(committable)
+
+    for {
+      receiveCommittableChunk <-
+        Ref[IO].of(
+          Option.empty[Chunk[CommittableConsumerRecord[IO, String, String]]]
+        )
+      receiveChunk         <- emptyRef[Chunk[ConsumerRecord[String, String]]]
+      processedRecord      <- emptyRef[ConsumerRecord[String, String]]
+      processedCommittable <- emptyRef[CommittableConsumerRecord[IO, String, String]]
+      consumer             <- IO(
+                    new ConsumerSyntaxProbe(
+                      receiveChunk,
+                      receiveCommittableChunk,
+                      processedRecord,
+                      processedCommittable
+                    )
+                  )
+      result <- committables.traceReceive(IO.pure("ok"))(consumer)
+      seen   <- receiveCommittableChunk.get
+    } yield {
+      assertEquals(seen.map(_.map(_.record).toList), Some(List(record)))
+      assertEquals(result, "ok")
+    }
+  }
+
+  test("ConsumerRecord.traceProcess delegates to process") {
+    for {
+      receiveChunk            <- emptyRef[Chunk[ConsumerRecord[String, String]]]
+      receiveCommittableChunk <- emptyRef[Chunk[CommittableConsumerRecord[IO, String, String]]]
+      processedRecord         <- Ref[IO].of(Option.empty[ConsumerRecord[String, String]])
+      processedCommittable    <- emptyRef[CommittableConsumerRecord[IO, String, String]]
+      consumer                <- IO(
+                    new ConsumerSyntaxProbe(
+                      receiveChunk,
+                      receiveCommittableChunk,
+                      processedRecord,
+                      processedCommittable
+                    )
+                  )
+      record  = ConsumerRecord("topic", 0, 42L, "key", "value")
+      result <- record.traceProcess(IO.pure("ok"))(consumer)
+      seen   <- processedRecord.get
+    } yield {
+      assertEquals(seen, Some(record))
+      assertEquals(result, "ok")
+    }
+  }
+
+  test("CommittableConsumerRecord.traceProcess delegates to the committable process overload") {
+    val record      = ConsumerRecord("topic", 0, 42L, "key", "value")
+    val committable = committableRecord(record)
+
+    for {
+      receiveChunk            <- emptyRef[Chunk[ConsumerRecord[String, String]]]
+      receiveCommittableChunk <- emptyRef[Chunk[CommittableConsumerRecord[IO, String, String]]]
+      processedRecord         <- emptyRef[ConsumerRecord[String, String]]
+      processedCommittable    <- Ref[IO].of(
+                                Option.empty[CommittableConsumerRecord[IO, String, String]]
+                              )
+      consumer <- IO(
+                    new ConsumerSyntaxProbe(
+                      receiveChunk,
+                      receiveCommittableChunk,
+                      processedRecord,
+                      processedCommittable
+                    )
+                  )
+      result <- committable.traceProcess(IO.pure("ok"))(consumer)
+      seen   <- processedCommittable.get
+    } yield {
+      assertEquals(seen.map(_.record), Some(record))
+      assertEquals(result, "ok")
+    }
+  }
+
+  private def emptyRef[A]: IO[Ref[IO, Option[A]]] =
+    Ref[IO].of(Option.empty[A])
+
+  final private class ProducerSyntaxProbe(
+    onInjectedRecord: Ref[IO, Option[ProducerRecord[String, String]]],
+    onInjectedBatch: Ref[IO, Option[ProducerRecords[String, String]]],
+    onAwaitedBatch: Ref[IO, Option[ProducerRecords[String, String]]],
+    onAwaitedSingle: Ref[IO, Option[ProducerRecord[String, String]]]
+  ) extends TracedKafkaProducer[IO, String, String] {
+
+    override val underlying: KafkaProducer[IO, String, String] =
+      StubKafkaProducer.metadataOnly()
+
+    override def injectHeaders(
+      record: ProducerRecord[String, String]
+    ): IO[ProducerRecord[String, String]] =
+      onInjectedRecord
+        .set(Some(record))
+        .as(record.withHeaders(Headers(Header("x-syntax", "record"))))
+
+    override def injectHeaders(
+      records: ProducerRecords[String, String]
+    ): IO[ProducerRecords[String, String]] =
+      onInjectedBatch.set(Some(records)).as(records)
+
+    override def produceAwaited(
+      records: ProducerRecords[String, String]
+    ): IO[ProducerResult[String, String]] =
+      onAwaitedBatch.set(Some(records)).as(Chunk.empty)
+
+    override def produceOneAwaited(
+      record: ProducerRecord[String, String]
+    ): IO[ProducerResult[String, String]] =
+      onAwaitedSingle.set(Some(record)).as(Chunk.empty)
+
+    override def produceAndCommitTransactionally(
+      records: TransactionalProducerRecords[IO, String, String]
+    ): IO[ProducerResult[String, String]] =
+      IO.raiseError(new AssertionError("unexpected produceAndCommitTransactionally"))
+
+    override def produceTransactionally(
+      records: ProducerRecords[String, String]
+    ): IO[ProducerResult[String, String]] =
+      IO.raiseError(new AssertionError("unexpected produceTransactionally"))
+
+    override def withSerializers[K2, V2](
+      keySerializer: KeySerializer[IO, K2],
+      valueSerializer: ValueSerializer[IO, V2]
+    ): TracedKafkaProducer[IO, K2, V2] =
+      this.asInstanceOf[TracedKafkaProducer[IO, K2, V2]]
+
+  }
+
+  final private class ConsumerSyntaxProbe(
+    onReceive: Ref[IO, Option[Chunk[ConsumerRecord[String, String]]]],
+    onReceiveCommittable: Ref[IO, Option[Chunk[CommittableConsumerRecord[IO, String, String]]]],
+    onProcess: Ref[IO, Option[ConsumerRecord[String, String]]],
+    onProcessCommittable: Ref[IO, Option[CommittableConsumerRecord[IO, String, String]]]
+  ) extends TracedKafkaConsumer[IO, String, String] {
+
+    override val underlying: KafkaConsumer[IO, String, String] =
+      StubKafkaConsumer.metadataOnly()
+
+    override def records: Stream[IO, CommittableConsumerRecord[IO, String, String]] =
+      Stream.empty
+
+    override def receive[A](records: Chunk[ConsumerRecord[String, String]])(fa: IO[A]): IO[A] =
+      onReceive.set(Some(records)) *> fa
+
+    override def receiveCommittable[A](
+      records: Chunk[CommittableConsumerRecord[IO, String, String]]
+    )(fa: IO[A]): IO[A] =
+      onReceiveCommittable.set(Some(records)) *> fa
+
+    override def process[A](record: ConsumerRecord[String, String])(fa: IO[A]): IO[A] =
+      onProcess.set(Some(record)) *> fa
+
+    override def process[A](
+      record: CommittableConsumerRecord[IO, String, String]
+    )(fa: IO[A]): IO[A] =
+      onProcessCommittable.set(Some(record)) *> fa
+
+    override def recordsWithProcess[A](
+      f: CommittableConsumerRecord[IO, String, String] => IO[A]
+    ): Stream[IO, A] =
+      Stream.raiseError[IO](new AssertionError("unexpected recordsWithProcess"))
+
+    override def recordsWithProcessOnly[A](
+      f: CommittableConsumerRecord[IO, String, String] => IO[A]
+    ): Stream[IO, A] =
+      Stream.raiseError[IO](new AssertionError("unexpected recordsWithProcessOnly"))
+
+  }
+
+  private def committableRecord(
+    record: ConsumerRecord[String, String]
+  ): CommittableConsumerRecord[IO, String, String] =
+    CommittableConsumerRecord(
+      record,
+      CommittableOffset(
+        new TopicPartition(record.topic, record.partition),
+        new OffsetAndMetadata(record.offset),
+        KafkaCommitter[IO](
+          _ => IO.unit,
+          IO.raiseError(new AssertionError("committer metadata should not be called"))
+        )
+      )
+    )
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTracerConstAttributesSuite.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTracerConstAttributesSuite.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import cats.effect.IO
+import fs2.kafka._
+import fs2.Chunk
+
+import org.typelevel.otel4s.oteljava.testkit.trace.{
+  LinkSetExpectation,
+  SpanExpectation,
+  TraceForestExpectation
+}
+import org.typelevel.otel4s.semconv.attributes.ServerAttributes
+import org.typelevel.otel4s.semconv.experimental.attributes.MessagingExperimentalAttributes
+import org.typelevel.otel4s.Attributes
+
+class KafkaTracerConstAttributesSuite extends KafkaTracingTestSupport {
+
+  private val tracerScopeName = "fs2.kafka.otel4s.tests"
+
+  private val config =
+    KafkaTracer
+      .Config
+      .default
+      .withConstAttributes(
+        Attributes(
+          ServerAttributes.ServerAddress("kafka.internal"),
+          ServerAttributes.ServerPort(9092L)
+        )
+      )
+
+  private val endpointAttributes =
+    Attributes(
+      ServerAttributes.ServerAddress("kafka.internal"),
+      ServerAttributes.ServerPort(9092L)
+    )
+
+  test("configured constant endpoint attributes are emitted on create and send spans") {
+    KafkaTracerTestkit
+      .create(tracerScopeName)
+      .use { testkit =>
+        for {
+          producerTracer <-
+            testkit.tracedProducer[String, String](StubKafkaProducer.metadataOnly(), config)
+          _ <- producerTracer.produceAwaited(
+                 ProducerRecords(
+                   List(
+                     ProducerRecord("topic", "key-1", "value-1"),
+                     ProducerRecord("topic", "key-2", "value-2")
+                   )
+                 )
+               )
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .producer("create topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           endpointAttributes + MessagingExperimentalAttributes
+                             .MessagingKafkaMessageKey("key-1")
+                         )
+                     ),
+                     root(
+                       SpanExpectation
+                         .producer("create topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           endpointAttributes + MessagingExperimentalAttributes
+                             .MessagingKafkaMessageKey("key-2")
+                         )
+                     ),
+                     root(
+                       SpanExpectation
+                         .client("send topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(endpointAttributes)
+                         .links(LinkSetExpectation.count(2))
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("configured constant endpoint attributes are emitted on receive and process spans") {
+    KafkaTracerTestkit
+      .create(tracerScopeName)
+      .use { testkit =>
+        val record = ConsumerRecord("topic", 0, 42L, "key", "value")
+
+        for {
+          consumerTracer <- testkit.tracedConsumer[String, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group"),
+                              config
+                            )
+          _     <- consumerTracer.receive(Chunk.singleton(record))(IO.unit)
+          _     <- consumerTracer.process(record)(IO.unit)
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .client("poll topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(endpointAttributes)
+                     ),
+                     root(
+                       SpanExpectation
+                         .consumer("process topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(endpointAttributes)
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTracerTestkit.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTracerTestkit.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import cats.effect.{IO, Resource}
+import fs2.kafka.{KafkaConsumer, KafkaProducer}
+
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.propagation.TextMapPropagator
+import io.opentelemetry.sdk.trace.data.SpanData
+import org.typelevel.otel4s.oteljava.testkit.OtelJavaTestkit
+import org.typelevel.otel4s.trace.{Tracer, TracerProvider}
+
+class KafkaTracerTestkit(testkit: OtelJavaTestkit[IO])(implicit
+  val tracerProvider: TracerProvider[IO],
+  val appTracer: Tracer[IO]
+) {
+
+  def tracedProducer[K: KafkaMessageKey, V](
+    producer: KafkaProducer[IO, K, V],
+    config: KafkaTracer.Config = KafkaTracer.Config.default
+  ): IO[TracedKafkaProducer[IO, K, V]] =
+    KafkaTracer.create[IO](config).map(_.producer(producer))
+
+  def tracedConsumer[K: KafkaMessageKey, V](
+    consumer: KafkaConsumer[IO, K, V],
+    config: KafkaTracer.Config = KafkaTracer.Config.default
+  ): IO[TracedKafkaConsumer[IO, K, V]] =
+    KafkaTracer.create[IO](config).map(_.consumer(consumer))
+
+  def finishedSpans: IO[List[SpanData]] =
+    testkit.finishedSpans
+
+}
+
+object KafkaTracerTestkit {
+
+  def create(
+    appTracerName: String = "fs2.kafka.otel4s.tests",
+    propagators: Seq[TextMapPropagator] = Seq(W3CTraceContextPropagator.getInstance())
+  ): Resource[IO, KafkaTracerTestkit] = {
+    OtelJavaTestkit
+      .inMemory[IO](
+        _.addTextMapPropagators(propagators*)
+      )
+      .evalMap { testkit =>
+        for {
+          tracer <- testkit.tracerProvider.get(appTracerName)
+        } yield new KafkaTracerTestkit(testkit)(testkit.tracerProvider, tracer)
+      }
+  }
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTracingErrorSuite.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTracingErrorSuite.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import cats.effect.IO
+import fs2.kafka.{ConsumerRecord, ProducerRecord, ProducerRecords}
+import fs2.Chunk
+
+import org.typelevel.otel4s.oteljava.testkit.trace.{
+  SpanExpectation,
+  StatusExpectation,
+  TraceForestExpectation
+}
+import org.typelevel.otel4s.semconv.attributes.ErrorAttributes
+
+final class KafkaTracingErrorSuite extends KafkaTracingTestSupport {
+
+  test("failed send emits error.type and error status") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          tracedProducer <- testkit.tracedProducer(
+                              StubKafkaProducer.failingAwait[String, String](
+                                new RuntimeException("send failed")
+                              )
+                            )
+          result <- tracedProducer
+                      .produceAwaited(ProducerRecords.one(ProducerRecord("topic", "key", "value")))
+                      .attempt
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assert(result.isLeft)
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .producer("send topic")
+                         .scopeName("fs2.kafka")
+                         .status(StatusExpectation.error)
+                         .attributesSubset(
+                           ErrorAttributes.ErrorType("java.lang.RuntimeException")
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("failed receive emits error.type and error status") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          consumerTracer <- testkit.tracedConsumer[String, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group")
+                            )
+          boom    = new RuntimeException("receive failed")
+          record  = ConsumerRecord("topic", 0, 1L, "key", "value")
+          result <-
+            consumerTracer.receive(Chunk.singleton(record))(IO.raiseError[Unit](boom)).attempt
+          spans <- testkit.finishedSpans
+          _     <- IO {
+                 assert(result.isLeft)
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .client("poll topic")
+                         .scopeName("fs2.kafka")
+                         .status(StatusExpectation.error)
+                         .attributesSubset(ErrorAttributes.ErrorType("java.lang.RuntimeException"))
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("failed process emits error.type and error status") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          consumerTracer <- testkit.tracedConsumer[String, String](
+                              StubKafkaConsumer.metadataOnly("consumer-client", "consumer-group")
+                            )
+          boom    = new RuntimeException("process failed")
+          record  = ConsumerRecord("topic", 0, 42L, "key", "value")
+          result <- consumerTracer.process(record)(IO.raiseError[Unit](boom)).attempt
+          spans  <- testkit.finishedSpans
+          _      <- IO {
+                 assert(result.isLeft)
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .consumer("process topic")
+                         .scopeName("fs2.kafka")
+                         .status(StatusExpectation.error)
+                         .attributesSubset(ErrorAttributes.ErrorType("java.lang.RuntimeException"))
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTracingIntegrationSpec.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTracingIntegrationSpec.scala
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import scala.concurrent.duration._
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.IO
+import fs2.kafka._
+import fs2.kafka.otel4s.trace.instances._
+import fs2.Chunk
+
+import io.opentelemetry.sdk.trace.data.SpanData
+import org.typelevel.otel4s.context.propagation.TextMapGetter
+import org.typelevel.otel4s.oteljava.testkit.trace.{
+  SpanExpectation,
+  TraceExpectation,
+  TraceExpectations,
+  TraceForestExpectation
+}
+
+final class KafkaTracingIntegrationSpec extends BaseKafkaSpec {
+
+  describe("Kafka tracing integration") {
+    it("should propagate context through Kafka and emit send, receive, and process spans") {
+      withTopic { topic =>
+        createCustomTopic(topic, partitions = 1).get
+
+        KafkaTracerTestkit
+          .create("fs2.kafka.otel4s.integration")
+          .use { testkit =>
+            import testkit.{appTracer, tracerProvider}
+
+            for {
+              kafkaTracer <- KafkaTracer.create[IO](KafkaTracer.Config.default)
+              _           <- appTracer
+                     .rootSpan("producer-root")
+                     .surround {
+                       KafkaProducer
+                         .resource(producerSettings[IO])
+                         .use { producer =>
+                           kafkaTracer
+                             .producer(producer)
+                             .produceOneAwaited(
+                               ProducerRecord(topic, "key", "value")
+                             )
+                             .void
+                         }
+                     }
+              consumedRecord <- KafkaConsumer
+                                  .stream(consumerSettings[IO].withGroupId(s"group-$topic"))
+                                  .subscribeTo(topic)
+                                  .flatMap { consumer =>
+                                    val tracedConsumer = kafkaTracer.consumer(consumer)
+                                    consumer
+                                      .records
+                                      .take(1)
+                                      .evalMap { record =>
+                                        tracedConsumer.receiveCommittable(Chunk.singleton(record)) {
+                                          tracedConsumer.process(record)(IO.pure(record.record))
+                                        }
+                                      }
+                                  }
+                                  .interruptAfter(20.seconds)
+                                  .compile
+                                  .lastOrError
+              spans <- testkit.finishedSpans
+              _     <- IO {
+                     assert(
+                       TextMapGetter[Headers].get(consumedRecord.headers, "traceparent").nonEmpty
+                     )
+                     assertExpected(
+                       spans,
+                       TraceForestExpectation.unordered(
+                         root(
+                           SpanExpectation
+                             .internal("producer-root")
+                             .scopeName("fs2.kafka.otel4s.integration"),
+                           TraceExpectation.leaf(
+                             SpanExpectation.producer(s"send $topic").scopeName("fs2.kafka")
+                           )
+                         ),
+                         root(
+                           SpanExpectation
+                             .client(s"poll $topic")
+                             .scopeName("fs2.kafka")
+                             .linkCount(1),
+                           TraceExpectation.leaf(
+                             SpanExpectation
+                               .consumer(s"process $topic")
+                               .scopeName("fs2.kafka")
+                               .linkCount(1)
+                           )
+                         )
+                       )
+                     )
+                   }
+            } yield ()
+          }
+          .unsafeRunSync()
+      }
+    }
+
+    it("should emit a send span for transactional traced produce against Kafka") {
+      withTopic { topic =>
+        createCustomTopic(topic, partitions = 1).get
+
+        KafkaTracerTestkit
+          .create("fs2.kafka.otel4s.integration")
+          .use { testkit =>
+            import testkit.{appTracer, tracerProvider}
+
+            for {
+              kafkaTracer <- KafkaTracer.create[IO](KafkaTracer.Config.default)
+              _           <- appTracer
+                     .rootSpan("producer-root")
+                     .surround {
+                       KafkaProducer
+                         .transactional[IO, String, String](
+                           producerSettingsTransactional[IO].withTransactionalId(s"id-$topic")
+                         )
+                         .use { producer =>
+                           kafkaTracer
+                             .producer(producer)
+                             .produceTransactionally(
+                               ProducerRecords.one(
+                                 ProducerRecord(topic, "key", "value")
+                               )
+                             )
+                             .void
+                         }
+                     }
+              consumed <- IO(consumeFirstKeyedMessageFrom[String, String](topic))
+              spans    <- testkit.finishedSpans
+              _        <- IO {
+                     assert(consumed == ("key" -> "value"))
+                     assertExpected(
+                       spans,
+                       TraceForestExpectation.unordered(
+                         root(
+                           SpanExpectation
+                             .internal("producer-root")
+                             .scopeName("fs2.kafka.otel4s.integration"),
+                           TraceExpectation.leaf(
+                             SpanExpectation.producer(s"send $topic").scopeName("fs2.kafka")
+                           )
+                         )
+                       )
+                     )
+                   }
+            } yield ()
+          }
+          .unsafeRunSync()
+      }
+    }
+
+    it("should let recordsWithProcess emit separate receive and process spans") {
+      withTopic { topic =>
+        createCustomTopic(topic, partitions = 1).get
+
+        KafkaTracerTestkit
+          .create("fs2.kafka.otel4s.integration")
+          .use { testkit =>
+            import testkit.tracerProvider
+
+            for {
+              kafkaTracer <- KafkaTracer.create[IO](KafkaTracer.Config.default)
+              _           <- KafkaProducer
+                     .resource(producerSettings[IO])
+                     .use { producer =>
+                       kafkaTracer
+                         .producer(producer)
+                         .produceOneAwaited(ProducerRecord(topic, "key", "value"))
+                         .void
+                     }
+              consumedRecord <-
+                KafkaConsumer
+                  .stream(consumerSettings[IO].withGroupId(s"group-records-with-process-$topic"))
+                  .subscribeTo(topic)
+                  .flatMap { consumer =>
+                    kafkaTracer
+                      .consumer(consumer)
+                      .recordsWithProcess(record => IO.pure(record.record))
+                  }
+                  .take(1)
+                  .interruptAfter(20.seconds)
+                  .compile
+                  .lastOrError
+              spans <- testkit.finishedSpans
+              _     <- IO {
+                     assert(consumedRecord.key == "key")
+                     assertExpected(
+                       spans,
+                       TraceForestExpectation.unordered(
+                         root(
+                           SpanExpectation.producer(s"send $topic").scopeName("fs2.kafka")
+                         ),
+                         root(
+                           SpanExpectation
+                             .client(s"poll $topic")
+                             .scopeName("fs2.kafka")
+                             .linkCount(1)
+                         ),
+                         root(
+                           SpanExpectation
+                             .consumer(s"process $topic")
+                             .scopeName("fs2.kafka")
+                             .linkCount(1)
+                         )
+                       )
+                     )
+                   }
+            } yield ()
+          }
+          .unsafeRunSync()
+      }
+    }
+
+    it("should let recordsWithProcessOnly omit receive spans") {
+      withTopic { topic =>
+        createCustomTopic(topic, partitions = 1).get
+
+        KafkaTracerTestkit
+          .create("fs2.kafka.otel4s.integration")
+          .use { testkit =>
+            import testkit.tracerProvider
+
+            for {
+              kafkaTracer <- KafkaTracer.create[IO](KafkaTracer.Config.default)
+              _           <- KafkaProducer
+                     .resource(producerSettings[IO])
+                     .use { producer =>
+                       kafkaTracer
+                         .producer(producer)
+                         .produceOneAwaited(ProducerRecord(topic, "key", "value"))
+                         .void
+                     }
+              consumedRecord <-
+                KafkaConsumer
+                  .stream(
+                    consumerSettings[IO].withGroupId(s"group-records-with-process-only-$topic")
+                  )
+                  .subscribeTo(topic)
+                  .flatMap { consumer =>
+                    kafkaTracer
+                      .consumer(consumer)
+                      .recordsWithProcessOnly(record => IO.pure(record.record))
+                  }
+                  .take(1)
+                  .interruptAfter(20.seconds)
+                  .compile
+                  .lastOrError
+              spans <- testkit.finishedSpans
+              _     <- IO {
+                     assert(consumedRecord.key == "key")
+                     assertExpected(
+                       spans,
+                       TraceForestExpectation.unordered(
+                         root(
+                           SpanExpectation.producer(s"send $topic").scopeName("fs2.kafka")
+                         ),
+                         root(
+                           SpanExpectation
+                             .consumer(s"process $topic")
+                             .scopeName("fs2.kafka")
+                             .linkCount(1)
+                         )
+                       )
+                     )
+                   }
+            } yield ()
+          }
+          .unsafeRunSync()
+      }
+    }
+  }
+
+  private def root(span: SpanExpectation, children: TraceExpectation*): TraceExpectation =
+    TraceExpectation.ordered(
+      span.noParentSpanContext,
+      children*
+    )
+
+  private def assertExpected(spans: List[SpanData], expected: TraceForestExpectation): Unit =
+    TraceExpectations.check(spans, expected) match {
+      case Right(_) =>
+        ()
+      case Left(mismatches) =>
+        fail(TraceExpectations.format(mismatches))
+    }
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTracingTestSupport.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTracingTestSupport.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import io.opentelemetry.sdk.trace.data.SpanData
+import munit.{CatsEffectSuite, Location}
+import org.typelevel.otel4s.oteljava.testkit.trace.{
+  SpanExpectation,
+  TraceExpectation,
+  TraceExpectations,
+  TraceForestExpectation
+}
+
+trait KafkaTracingTestSupport extends CatsEffectSuite {
+
+  protected def root(
+    span: SpanExpectation,
+    children: TraceExpectation*
+  ): TraceExpectation =
+    TraceExpectation.ordered(
+      span.noParentSpanContext,
+      children*
+    )
+
+  protected def assertExpected(
+    spans: List[SpanData],
+    expected: TraceForestExpectation
+  )(implicit loc: Location): Unit =
+    TraceExpectations.check(spans, expected) match {
+      case Right(_) =>
+        ()
+      case Left(mismatches) =>
+        fail(TraceExpectations.format(mismatches))
+    }
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTransactionalTracingSuite.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/KafkaTransactionalTracingSuite.scala
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import scala.concurrent.duration._
+
+import cats.effect.{Deferred, IO, Ref}
+import fs2.kafka._
+import fs2.Chunk
+
+import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, OffsetAndMetadata}
+import org.apache.kafka.common.TopicPartition
+import org.typelevel.otel4s.oteljava.testkit.trace.{SpanExpectation, TraceForestExpectation}
+import org.typelevel.otel4s.semconv.experimental.attributes.MessagingExperimentalAttributes
+
+final class KafkaTransactionalTracingSuite extends KafkaTracingTestSupport {
+
+  test("the underlying producer remains available for the two-phase producer contract") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producer       <- StubKafkaProducer.recorder[String, String]()
+          tracedProducer <- testkit.tracedProducer(producer)
+          prepared       <- tracedProducer.injectHeaders(ProducerRecord("topic", "key", "value"))
+          staged         <- tracedProducer
+                      .underlying
+                      .produce(
+                        ProducerRecords.one(prepared)
+                      )
+          producedAfterOuter    <- producer.getCaptured
+          completionsAfterOuter <- producer.getCompletions
+          spansAfterOuter       <- testkit.finishedSpans
+          _                     <- staged
+          completionsAfterInner <- producer.getCompletions
+          spansAfterInner       <- testkit.finishedSpans
+          _                     <- IO {
+                 assertEquals(producedAfterOuter.size, 1)
+                 assertEquals(producedAfterOuter.head.get.topic, "topic")
+                 assertEquals(completionsAfterOuter, 0)
+                 assertEquals(completionsAfterInner, 1)
+                 assertEquals(spansAfterOuter, Nil)
+                 assertEquals(spansAfterInner, Nil)
+               }
+        } yield ()
+      }
+  }
+
+  test("produceTransactionally emits a send span and preserves transaction semantics") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producer       <- StubKafkaProducer.recorder[String, String]()
+          tracedProducer <- testkit.tracedProducer(producer)
+          _              <- tracedProducer.produceTransactionally(
+                 ProducerRecords.one(ProducerRecord("topic", "key", "value"))
+               )
+          produced        <- producer.getCaptured
+          completionCount <- producer.getCompletions
+          txCount         <- producer.getTransactionUses
+          offsetsSent     <- producer.getSentOffsets
+          spans           <- testkit.finishedSpans
+          _               <- IO {
+                 assertEquals(produced.size, 1)
+                 assert(produced.head.get.headers.toChain.nonEmpty)
+                 assertEquals(completionCount, 1)
+                 assertEquals(txCount, 1)
+                 assertEquals(offsetsSent, Vector.empty)
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .producer("send topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           MessagingExperimentalAttributes.MessagingSystem(
+                             MessagingExperimentalAttributes.MessagingSystemValue.Kafka
+                           ),
+                           MessagingExperimentalAttributes.MessagingDestinationName("topic"),
+                           MessagingExperimentalAttributes.MessagingOperationName("send"),
+                           MessagingExperimentalAttributes.MessagingOperationType("send"),
+                           MessagingExperimentalAttributes.MessagingClientId("producer-client")
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("produceAndCommitTransactionally emits a send span and forwards offsets") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producer       <- StubKafkaProducer.recorder[String, String]()
+          tracedProducer <- testkit.tracedProducer(producer)
+          groupMetadata   = consumerGroupMetadata("consumer-group")
+          topicPartition  = new TopicPartition("input", 0)
+          offsetMetadata  = new OffsetAndMetadata(43L)
+          committer       = KafkaCommitter[IO](
+                        _ => IO.unit,
+                        IO.pure(groupMetadata)
+                      )
+          offset  = CommittableOffset[IO](topicPartition, offsetMetadata, committer)
+          records =
+            Chunk(
+              CommittableProducerRecords.one(ProducerRecord("topic", "key", "value"), offset)
+            )
+          _                <- tracedProducer.produceAndCommitTransactionally(records)
+          produced         <- producer.getCaptured
+          completionCount  <- producer.getCompletions
+          txCount          <- producer.getTransactionUses
+          offsetsSentValue <- producer.getSentOffsets
+          spans            <- testkit.finishedSpans
+          _                <- IO {
+                 assertEquals(produced.size, 1)
+                 assert(produced.head.get.headers.toChain.nonEmpty)
+                 assertEquals(completionCount, 1)
+                 assertEquals(txCount, 1)
+                 assertEquals(offsetsSentValue.size, 1)
+                 assertEquals(offsetsSentValue.head._1, Map(topicPartition -> offsetMetadata))
+                 assertEquals(offsetsSentValue.head._2, groupMetadata)
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation
+                         .producer("send topic")
+                         .scopeName("fs2.kafka")
+                         .attributesSubset(
+                           MessagingExperimentalAttributes.MessagingSystem(
+                             MessagingExperimentalAttributes.MessagingSystemValue.Kafka
+                           ),
+                           MessagingExperimentalAttributes.MessagingDestinationName("topic"),
+                           MessagingExperimentalAttributes.MessagingOperationName("send"),
+                           MessagingExperimentalAttributes.MessagingOperationType("send"),
+                           MessagingExperimentalAttributes.MessagingClientId("producer-client")
+                         )
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  test("produceAndCommitTransactionally preserves multi-committer concurrency parity") {
+    KafkaTracerTestkit
+      .create()
+      .use { testkit =>
+        for {
+          producer        <- StubKafkaProducer.recorder[String, String]()
+          tracedProducer  <- testkit.tracedProducer(producer)
+          enteredMetadata <- Ref[IO].of(0)
+          bothEntered     <- Deferred[IO, Unit]
+          groupMetadata1   = consumerGroupMetadata("consumer-group-1")
+          groupMetadata2   = consumerGroupMetadata("consumer-group-2")
+          committer1       = KafkaCommitter[IO](
+                         _ => IO.unit,
+                         enteredMetadata
+                           .updateAndGet(_ + 1)
+                           .flatMap { n =>
+                             (if (n == 2) bothEntered.complete(()).void else IO.unit) *> bothEntered
+                               .get
+                               .as(groupMetadata1)
+                           }
+                       )
+          committer2 = KafkaCommitter[IO](
+                         _ => IO.unit,
+                         enteredMetadata
+                           .updateAndGet(_ + 1)
+                           .flatMap { n =>
+                             (if (n == 2) bothEntered.complete(()).void else IO.unit) *> bothEntered
+                               .get
+                               .as(groupMetadata2)
+                           }
+                       )
+          offset1 = CommittableOffset[IO](
+                      new TopicPartition("input", 0),
+                      new OffsetAndMetadata(10L),
+                      committer1
+                    )
+          offset2 = CommittableOffset[IO](
+                      new TopicPartition("input", 1),
+                      new OffsetAndMetadata(20L),
+                      committer2
+                    )
+          records = Chunk(
+                      CommittableProducerRecords.one(
+                        ProducerRecord("topic-a", "key-a", "value-a"),
+                        offset1
+                      ),
+                      CommittableProducerRecords.one(
+                        ProducerRecord("topic-b", "key-b", "value-b"),
+                        offset2
+                      )
+                    )
+          _                <- tracedProducer.produceAndCommitTransactionally(records).timeout(2.seconds)
+          entered          <- enteredMetadata.get
+          completionsCount <- producer.getCompletions
+          offsetsSentCount <- producer.getSentOffsets.map(_.size)
+          spans            <- testkit.finishedSpans
+          _                <- IO {
+                 assertEquals(entered, 2)
+                 assertEquals(completionsCount, 2)
+                 assertEquals(offsetsSentCount, 2)
+                 assertExpected(
+                   spans,
+                   TraceForestExpectation.unordered(
+                     root(
+                       SpanExpectation.producer("send topic-a").scopeName("fs2.kafka")
+                     ),
+                     root(
+                       SpanExpectation.producer("send topic-b").scopeName("fs2.kafka")
+                     )
+                   )
+                 )
+               }
+        } yield ()
+      }
+  }
+
+  @annotation.nowarn("msg=deprecated")
+  private def consumerGroupMetadata(groupId: String): ConsumerGroupMetadata =
+    new ConsumerGroupMetadata(groupId)
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/StubKafkaConsumer.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/StubKafkaConsumer.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import scala.collection.immutable.SortedSet
+import scala.concurrent.duration.FiniteDuration
+import scala.util.matching.Regex
+
+import cats.{Foldable, Reducible}
+import cats.data.NonEmptySet
+import cats.effect.IO
+import fs2.kafka.{CommittableConsumerRecord, KafkaConsumer}
+import fs2.kafka.internal.ConsumerMetadata
+import fs2.Stream
+
+import org.apache.kafka.clients.consumer.{
+  ConsumerGroupMetadata,
+  OffsetAndMetadata,
+  OffsetAndTimestamp
+}
+import org.apache.kafka.common.{Metric, MetricName, PartitionInfo, TopicPartition}
+
+class StubKafkaConsumer[K, V](
+  override private[kafka] val metadata: ConsumerMetadata
+) extends KafkaConsumer.Unsealed[IO, K, V] {
+
+  def assignment: IO[SortedSet[TopicPartition]] = unsupported
+
+  def assignmentStream: Stream[IO, SortedSet[TopicPartition]] = Stream.eval(unsupported)
+
+  def assign(partitions: NonEmptySet[TopicPartition]): IO[Unit] = unsupported
+
+  def assign(topic: String): IO[Unit] = unsupported
+
+  def commitAsync(offsets: Map[TopicPartition, OffsetAndMetadata]): IO[Unit] = unsupported
+
+  def commitSync(offsets: Map[TopicPartition, OffsetAndMetadata]): IO[Unit] = unsupported
+
+  def stream: Stream[IO, CommittableConsumerRecord[IO, K, V]] = Stream.eval(unsupported)
+
+  def partitionedStream: Stream[IO, Stream[IO, CommittableConsumerRecord[IO, K, V]]] =
+    Stream.eval(unsupported)
+
+  def partitionsMapStream
+    : Stream[IO, Map[TopicPartition, Stream[IO, CommittableConsumerRecord[IO, K, V]]]] =
+    Stream.eval(unsupported)
+
+  def stopConsuming: IO[Unit] = unsupported
+
+  def terminate: IO[Unit] = unsupported
+
+  def awaitTermination: IO[Unit] = unsupported
+
+  def metrics: IO[Map[MetricName, Metric]] = unsupported
+
+  def committed(partitions: Set[TopicPartition]): IO[Map[TopicPartition, OffsetAndMetadata]] =
+    unsupported
+
+  def committed(
+    partitions: Set[TopicPartition],
+    timeout: FiniteDuration
+  ): IO[Map[TopicPartition, OffsetAndMetadata]] = unsupported
+
+  def seek(partition: TopicPartition, offset: Long): IO[Unit] = unsupported
+
+  def seekToBeginning[G[_]: Foldable](partitions: G[TopicPartition]): IO[Unit] = unsupported
+
+  def seekToEnd[G[_]: Foldable](partitions: G[TopicPartition]): IO[Unit] = unsupported
+
+  def position(partition: TopicPartition): IO[Long] = unsupported
+
+  def position(partition: TopicPartition, timeout: FiniteDuration): IO[Long] = unsupported
+
+  def subscribe[G[_]: Reducible](topics: G[String]): IO[Unit] = unsupported
+
+  def subscribe(regex: Regex): IO[Unit] = unsupported
+
+  def unsubscribe: IO[Unit] = unsupported
+
+  def groupMetadata: IO[ConsumerGroupMetadata] = unsupported
+
+  def partitionsFor(topic: String): IO[List[PartitionInfo]] = unsupported
+
+  def partitionsFor(topic: String, timeout: FiniteDuration): IO[List[PartitionInfo]] = unsupported
+
+  def beginningOffsets(partitions: Set[TopicPartition]): IO[Map[TopicPartition, Long]] = unsupported
+
+  def beginningOffsets(
+    partitions: Set[TopicPartition],
+    timeout: FiniteDuration
+  ): IO[Map[TopicPartition, Long]] = unsupported
+
+  def endOffsets(partitions: Set[TopicPartition]): IO[Map[TopicPartition, Long]] = unsupported
+
+  def endOffsets(
+    partitions: Set[TopicPartition],
+    timeout: FiniteDuration
+  ): IO[Map[TopicPartition, Long]] = unsupported
+
+  def listTopics: IO[Map[String, List[PartitionInfo]]] = unsupported
+
+  def listTopics(timeout: FiniteDuration): IO[Map[String, List[PartitionInfo]]] = unsupported
+
+  def offsetsForTimes(
+    timestampsToSearch: Map[TopicPartition, Long]
+  ): IO[Map[TopicPartition, Option[OffsetAndTimestamp]]] = unsupported
+
+  def offsetsForTimes(
+    timestampsToSearch: Map[TopicPartition, Long],
+    timeout: FiniteDuration
+  ): IO[Map[TopicPartition, Option[OffsetAndTimestamp]]] =
+    unsupported
+
+  private def unsupported[A]: IO[A] =
+    IO.raiseError(new AssertionError("StubKafkaConsumer method should not be called"))
+
+}
+
+object StubKafkaConsumer {
+
+  def metadataOnly[K, V](
+    clientId: String = "consumer-client",
+    groupId: String = "consumer-group"
+  ): KafkaConsumer[IO, K, V] =
+    new StubKafkaConsumer[K, V](ConsumerMetadata(Some(clientId), Some(groupId)))
+
+}

--- a/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/StubKafkaProducer.scala
+++ b/modules/otel4s-trace/src/test/scala/fs2/kafka/otel4s/trace/StubKafkaProducer.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package fs2.kafka.otel4s.trace
+
+import cats.effect.{IO, Ref, Resource}
+import fs2.kafka._
+import fs2.kafka.internal.ProducerMetadata
+import fs2.Chunk
+
+import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, OffsetAndMetadata}
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.{Metric, MetricName, PartitionInfo, TopicPartition}
+
+class StubKafkaProducer[K, V](
+  override private[kafka] val metadata: ProducerMetadata
+) extends KafkaProducer[IO, K, V] {
+
+  override def produce(records: ProducerRecords[K, V]): IO[IO[ProducerResult[K, V]]] =
+    unsupported
+
+  override def initTransactions: IO[Unit] =
+    unsupported
+
+  override def transaction: Resource[IO, Unit] =
+    Resource.eval(unsupported)
+
+  override def sendOffsetsToTransaction(
+    offsets: Map[TopicPartition, OffsetAndMetadata],
+    consumerGroupMetadata: ConsumerGroupMetadata
+  ): IO[Unit] =
+    unsupported
+
+  override def produceAndCommitTransactionally(
+    records: Chunk[CommittableProducerRecords[IO, K, V]]
+  ): IO[ProducerResult[K, V]] =
+    unsupported
+
+  override def produceTransactionally(
+    records: ProducerRecords[K, V]
+  ): IO[ProducerResult[K, V]] =
+    unsupported
+
+  override def metrics: IO[Map[MetricName, Metric]] =
+    unsupported
+
+  override def partitionsFor(topic: String): IO[List[PartitionInfo]] =
+    unsupported
+
+  override def withSerializers[K2, V2](
+    keySerializer: KeySerializer[IO, K2],
+    valueSerializer: ValueSerializer[IO, V2]
+  ): KafkaProducer[IO, K2, V2] =
+    new StubKafkaProducer[K2, V2](metadata)
+
+  private def unsupported[A]: IO[A] =
+    IO.raiseError(new AssertionError("StubKafkaProducer method should not be called"))
+
+}
+
+object StubKafkaProducer {
+
+  trait Recorder[K, V] extends KafkaProducer[IO, K, V] {
+
+    def getCaptured: IO[Chunk[ProducerRecord[K, V]]]
+    def getCompletions: IO[Int]
+    def getTransactionUses: IO[Int]
+    def getSentOffsets: IO[Vector[(Map[TopicPartition, OffsetAndMetadata], ConsumerGroupMetadata)]]
+
+  }
+
+  def metadataOnly[K, V](
+    clientId: String = "producer-client"
+  ): KafkaProducer[IO, K, V] =
+    new StubKafkaProducer[K, V](ProducerMetadata(Some(clientId))) {
+      override def produce(records: ProducerRecords[K, V]): IO[IO[ProducerResult[K, V]]] =
+        IO.pure {
+          IO.pure(
+            records
+              .zipWithIndex
+              .map { case (record, index) =>
+                val partition = record.partition.getOrElse(0)
+                val metadata  =
+                  new RecordMetadata(
+                    new TopicPartition(record.topic, partition),
+                    index.toLong + 42L,
+                    0,
+                    0L,
+                    0,
+                    0
+                  )
+
+                record -> metadata
+              }
+          )
+        }
+    }
+
+  def recorder[K, V](clientId: String = "producer-client"): IO[Recorder[K, V]] =
+    for {
+      captured        <- Ref[IO].of(Chunk.empty[ProducerRecord[K, V]])
+      completions     <- Ref[IO].of(0)
+      transactionUses <- Ref[IO].of(0)
+      sentOffsets     <- Ref[IO].of(
+                       Vector.empty[
+                         (Map[TopicPartition, OffsetAndMetadata], ConsumerGroupMetadata)
+                       ]
+                     )
+    } yield new StubKafkaProducer[K, V](ProducerMetadata(Some(clientId))) with Recorder[K, V] {
+
+      override def getCaptured: IO[Chunk[ProducerRecord[K, V]]] =
+        captured.get
+
+      override def getCompletions: IO[Int] =
+        completions.get
+
+      override def getTransactionUses: IO[Int] =
+        transactionUses.get
+
+      override def getSentOffsets
+        : IO[Vector[(Map[TopicPartition, OffsetAndMetadata], ConsumerGroupMetadata)]] =
+        sentOffsets.get
+
+      override def produce(records: ProducerRecords[K, V]): IO[IO[ProducerResult[K, V]]] =
+        captured.set(records).as(completions.update(_ + 1).as(Chunk.empty))
+
+      override def transaction: Resource[IO, Unit] =
+        Resource.make(transactionUses.update(_ + 1))(_ => IO.unit)
+
+      override def sendOffsetsToTransaction(
+        offsets: Map[TopicPartition, OffsetAndMetadata],
+        consumerGroupMetadata: ConsumerGroupMetadata
+      ): IO[Unit] =
+        sentOffsets.update(_ :+ (offsets -> consumerGroupMetadata))
+
+    }
+
+  def failingAwait[K, V](
+    cause: Throwable,
+    clientId: String = "producer-client"
+  ): KafkaProducer[IO, K, V] =
+    new StubKafkaProducer[K, V](ProducerMetadata(Some(clientId))) {
+      override def produce(records: ProducerRecords[K, V]): IO[IO[ProducerResult[K, V]]] =
+        IO.pure(IO.raiseError(cause))
+
+      override def produceAndCommitTransactionally(
+        records: Chunk[CommittableProducerRecords[IO, K, V]]
+      ): IO[ProducerResult[K, V]] =
+        IO.raiseError(cause)
+
+      override def produceTransactionally(
+        records: ProducerRecords[K, V]
+      ): IO[ProducerResult[K, V]] =
+        IO.raiseError(cause)
+    }
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 val sbtTypelevelVersion = "0.8.5"
 
 addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo"      % "0.13.1")
+addSbtPlugin("com.eed3si9n"  % "sbt-projectmatrix"  % "0.11.0")
 addSbtPlugin("org.typelevel" % "sbt-typelevel"      % sbtTypelevelVersion)
 addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % sbtTypelevelVersion)


### PR DESCRIPTION
Hey everyone! I'm trying to bring [otel4s](https://github.com/typelevel/otel4s) tracing support in this PR.

> [!NOTE]
> The PR was implemented with the help of AI. However, the final version was thoroughly reviewed by a human (me).

## Key changes

### 1. Switched the build to [sbt-projectmatrix](https://github.com/sbt/sbt-projectmatrix)

otel4s is available only for Scala 2.13 and 3, while fs2-kafka supports 2.12, 2.13, and 3. 
Implications: now there is **1** CI job that runs tests for **all** targets.

### 2. The `otel4s-trace` module

The module covers tracing operations only. Perhaps we might want to implement `-metrics` too at some point.
Currently, only `send`, `create`, `receive`, and `process` operations are covered.

## Topics to discuss

### 1. Is exposing producer/consumer metadata in the core module acceptable?

The tracing module needs producer/consumer metadata like `client.id` and `group.id`. Right now, that requires two small package-private methods in the core. 

Is it fine, or should we drop this logic entirely and have users configure it via const attributes?

### 2. Should we allow configuration batch spans?

For multi-record sends, the implementation emits **per-record** `create` spans to cleanly preserve creation context. That is semantically useful, but it can be expensive in high-throughput cases. 

Should we have a config option to control the shape of said spans?
    
### 3. Should the traced API stay explicit and separate from `KafkaProducer` / `KafkaConsumer`?

The current design keeps tracing explicit: users bind a `KafkaTracer` to a producer/consumer and call traced operations directly. That avoids hidden behavior and makes receive / process boundaries clear, but it is less drop-in than mirroring the full producer/consumer API. 

`TracedKafkaProducer` can extend `KafkaProducer`, but I don't think `TracedKafkaConsumer` can extend `KafkaConsumer` and implement instrumentation logic for **all** operations.
