### PR TITLE
Add `KafkaConsumer#settings` and `KafkaProducer#settings`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -265,7 +265,8 @@ lazy val publishSettings =
 ThisBuild / mimaBinaryIssueFilters ++= {
   import com.typesafe.tools.mima.core.*
   Seq(
-    ProblemFilters.exclude[Problem]("fs2.kafka.internal.*")
+    ProblemFilters.exclude[Problem]("fs2.kafka.internal.*"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.settings")
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val scala212 = "2.12.21"
 val scala213 = "2.13.18"
 val scala3   = "3.3.7"
 
-ThisBuild / tlBaseVersion := "4.0"
+ThisBuild / tlBaseVersion := "4.1"
 
 lazy val root = project
   .in(file("."))

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -65,7 +65,7 @@ import org.apache.kafka.common.{Metric, MetricName, PartitionInfo, TopicPartitio
   * per [[KafkaConsumer]], and if you want to start a new stream if the first one finishes, let the
   * [[KafkaConsumer]] shutdown and create a new one.
   */
-sealed abstract class KafkaConsumer[F[_], K, V]
+abstract class KafkaConsumer[F[_], K, V]
     extends KafkaConsume[F, K, V]
     with KafkaConsumeChunk[F, K, V]
     with KafkaAssignment[F]

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -74,7 +74,13 @@ sealed abstract class KafkaConsumer[F[_], K, V]
     with KafkaTopics[F]
     with KafkaCommit[F]
     with KafkaMetrics[F]
-    with KafkaConsumerLifecycle[F]
+    with KafkaConsumerLifecycle[F] {
+
+  /**
+    * Returns the settings used to create the consumer instance.
+    */
+  def settings: ConsumerSettings[F, K, V]
+}
 
 object KafkaConsumer {
 
@@ -136,7 +142,8 @@ object KafkaConsumer {
     id: Int,
     withConsumer: WithConsumer[F],
     stopConsumingDeferred: Deferred[F, Unit]
-  )(implicit F: Async[F], logging: Logging[F]): KafkaConsumer[F, K, V] =
+  )(implicit F: Async[F], logging: Logging[F]): KafkaConsumer[F, K, V] = {
+    val _settings = settings
     new KafkaConsumer[F, K, V] {
 
       override def partitionsMapStream
@@ -575,7 +582,11 @@ object KafkaConsumer {
 
       override def groupMetadata: F[ConsumerGroupMetadata] =
         withConsumer.blocking(_.groupMetadata())
+
+      override def settings: ConsumerSettings[F, K, V] =
+        _settings
     }
+  }
 
   /**
     * Creates a new [[KafkaConsumer]] in the `Resource` context, using the specified

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -145,6 +145,14 @@ abstract class KafkaProducer[F[_], K, V] {
 
 object KafkaProducer {
 
+  trait WithSettings[F[_], K, V] extends KafkaProducer[F, K, V] {
+
+    /**
+      * Returns the settings used to create the producer instance.
+      */
+    def settings: ProducerSettings[F, K, V]
+  }
+
   implicit class ProducerOps[F[_], K, V](private val producer: KafkaProducer[F, K, V])
       extends AnyVal {
 
@@ -193,7 +201,11 @@ object KafkaProducer {
     */
   def stream[F[_], K, V](
     settings: ProducerSettings[F, K, V]
-  )(implicit F: Async[F], mk: MkProducer[F], P: Parallel[F]): Stream[F, KafkaProducer[F, K, V]] =
+  )(implicit
+    F: Async[F],
+    mk: MkProducer[F],
+    P: Parallel[F]
+  ): Stream[F, KafkaProducer.WithSettings[F, K, V]] =
     Stream.resource(KafkaProducer.resource(settings)(F, mk, P))
 
   /**
@@ -209,7 +221,7 @@ object KafkaProducer {
     F: Async[F],
     mk: MkProducer[F],
     P: Parallel[F]
-  ): Resource[F, KafkaProducer[F, K, V]] = {
+  ): Resource[F, KafkaProducer.WithSettings[F, K, V]] = {
     for {
       producer <- KafkaProducer.resource(settings)(F, mk, P)
       _        <- producer.initTransactions.toResource
@@ -229,7 +241,7 @@ object KafkaProducer {
     F: Async[F],
     mk: MkProducer[F],
     P: Parallel[F]
-  ): Stream[F, KafkaProducer[F, K, V]] =
+  ): Stream[F, KafkaProducer.WithSettings[F, K, V]] =
     Stream.resource(transactional(settings)(F, mk, P))
 
   /**
@@ -267,7 +279,7 @@ object KafkaProducer {
     F: Async[F],
     mk: MkProducer[F],
     P: Parallel[F]
-  ): Resource[F, KafkaProducer[F, K, V]] = {
+  ): Resource[F, KafkaProducer.WithSettings[F, K, V]] = {
     for {
       keySerializer   <- settings.keySerializer
       valueSerializer <- settings.valueSerializer
@@ -278,7 +290,7 @@ object KafkaProducer {
       close            = blocking(producer.close(java.time.Duration.ofMillis(settings.closeTimeout.toMillis)))
       _               <- Resource.onFinalize(close)
       fs2KafkaProducer = resourceInternal[F, K, V](
-                           settings.failFastProduce,
+                           settings,
                            keySerializer,
                            valueSerializer,
                            producer,
@@ -289,17 +301,17 @@ object KafkaProducer {
   }
 
   private def resourceInternal[F[_], K, V](
-    failFastProduce: Boolean,
+    settings: ProducerSettings[F, K, V],
     keySerializer: KeySerializer[F, K],
     valueSerializer: ValueSerializer[F, V],
     producer: KafkaByteProducer,
     txSemaphore: Semaphore[F],
     blocking: Blocking[F]
-  )(implicit F: Async[F], P: Parallel[F]): KafkaProducer[F, K, V] =
-    new KafkaProducer[F, K, V] {
-
+  )(implicit F: Async[F], P: Parallel[F]): KafkaProducer.WithSettings[F, K, V] = {
+    val _settings = settings
+    new KafkaProducer.WithSettings[F, K, V] {
       override def produce(records: ProducerRecords[K, V]): F[F[ProducerResult[K, V]]] = {
-        if (failFastProduce)
+        if (settings.failFastProduce)
           Async[F]
             .delay(Promise[Throwable]())
             .flatMap { produceRecordError =>
@@ -421,11 +433,22 @@ object KafkaProducer {
         k: KeySerializer[F, K2],
         v: ValueSerializer[F, V2]
       ): KafkaProducer[F, K2, V2] =
-        resourceInternal[F, K2, V2](failFastProduce, k, v, producer, txSemaphore, blocking)
+        resourceInternal[F, K2, V2](
+          settings = settings.withSerializers(Resource.pure(k), Resource.pure(v)),
+          keySerializer = k,
+          valueSerializer = v,
+          producer = producer,
+          txSemaphore = txSemaphore,
+          blocking = blocking
+        )
+
+      override def settings: ProducerSettings[F, K, V] =
+        _settings
 
       override def toString: String =
         "KafkaProducer$" + System.identityHashCode(this)
     }
+  }
 
   private[this] def serializeToBytes[F[_], K, V](
     keySerializer: KeySerializer[F, K],
@@ -476,7 +499,7 @@ object KafkaProducer {
       F: Async[F],
       mk: MkProducer[F],
       P: Parallel[F]
-    ): Resource[F, KafkaProducer[F, K, V]] =
+    ): Resource[F, KafkaProducer.WithSettings[F, K, V]] =
       KafkaProducer.resource(settings)(F, mk, P)
 
     /**
@@ -492,7 +515,7 @@ object KafkaProducer {
       F: Async[F],
       mk: MkProducer[F],
       P: Parallel[F]
-    ): Stream[F, KafkaProducer[F, K, V]] =
+    ): Stream[F, KafkaProducer.WithSettings[F, K, V]] =
       KafkaProducer.stream(settings)(F, mk, P)
 
     override def toString: String =


### PR DESCRIPTION
- Add `KafkaConsumer#settings` for the settings used to create the consumer instance.
- Add `KafkaProducer#settings` for the settings used to create the producer instance.
- Change `KafkaConsumer` to no longer be `sealed`.